### PR TITLE
fix: 修復 Bee.Db 資安與效能問題

### DIFF
--- a/docs/plans/plan-bee-db-security-audit.md
+++ b/docs/plans/plan-bee-db-security-audit.md
@@ -1,0 +1,210 @@
+# Bee.Db Security & Performance Audit Plan
+
+## Audit Scope
+
+Full review of `src/Bee.Db/` project — database access patterns, SQL generation, connection management, error handling.
+
+---
+
+## Findings
+
+### Security Issues
+
+#### S1. SQL Injection in `SqlCreateTableCommandBuilder` (HIGH)
+
+**Files:**
+- `src/Bee.Db/Providers/SqlServer/SqlCreateTableCommandBuilder.cs`
+
+**Details:**
+
+Multiple methods directly interpolate table names and index names into raw SQL strings without parameterization or proper escaping:
+
+| Method | Line(s) | Problem |
+|--------|---------|---------|
+| `GetDropTableCommandText` | 97-98 | `tableName` interpolated into `N'{tableName}'` and `EXEC('DROP TABLE {tableName}')` |
+| `GetRenameTableCommandText` | 138-141 | Table/index names interpolated into `sp_rename` calls |
+| `GetInsertTableCommandText` | 120-121 | Uses `[{tableName}]` but doesn't escape `]` in names |
+| `GetCreateTableCommandText` | 162 | `[{dbTableName}]` without `]` escaping |
+| `GetPrimaryKeyCommandText` | 309, 312 | `[{field.FieldName}]` without `]` escaping |
+| `GetIndexCommandText` | 345, 349 | Same as above |
+| `GetFieldCommandText` | 212-214 | `[{field.FieldName}]` without `]` escaping |
+| `GetCommandText` | 55-57 | `this.TableName` in SQL comment — low risk but inconsistent |
+
+**Risk Assessment:** These values originate from `TableSchema` (internal configuration), not direct user input. However, schema definitions may come from form configurations that could be admin-controlled. The `EXEC('DROP TABLE ...')` pattern in `GetDropTableCommandText` is especially dangerous as it constructs dynamic SQL.
+
+**Fix:**
+- Create a `SanitizeIdentifier` helper that escapes `]` → `]]` (SQL Server).
+- Apply it consistently to all identifier interpolation points.
+- For `GetDropTableCommandText`, use `QUOTENAME()` in the SQL or parameterize the table name check.
+
+---
+
+#### S2. `QuoteIdentifier` doesn't escape delimiter characters (HIGH)
+
+**File:** `src/Bee.Db/DbFunc.cs:57`
+
+**Details:**
+
+```csharp
+{ DatabaseType.SQLServer, s => $"[{s}]" },
+{ DatabaseType.MySQL, s => $"`{s}`" },
+{ DatabaseType.SQLite, s => $"\"{s}\"" },
+{ DatabaseType.Oracle, s => $"\"{s}\"" }
+```
+
+If an identifier contains the delimiter character itself (e.g. `]` for SQL Server, `` ` `` for MySQL, `"` for SQLite/Oracle), the quoting is broken and could allow SQL injection. The correct escaping rules:
+- SQL Server: `]` → `]]`
+- MySQL: `` ` `` → ``` `` ```
+- SQLite/Oracle: `"` → `""`
+
+**Impact:** All query builders that use `DbFunc.QuoteIdentifier` (WhereBuilder, SelectBuilder, FromBuilder, TableSchemaCommandBuilder) are potentially affected if identifiers contain special characters.
+
+**Fix:** Update `QuoteIdentifiers` dictionary to include proper escaping:
+```csharp
+{ DatabaseType.SQLServer, s => $"[{s.Replace("]", "]]")}]" },
+{ DatabaseType.MySQL, s => $"`{s.Replace("`", "``")}`" },
+{ DatabaseType.SQLite, s => $"\"{s.Replace("\"", "\"\"")}\"" },
+{ DatabaseType.Oracle, s => $"\"{s.Replace("\"", "\"\"")}\"" },
+```
+
+---
+
+#### S3. DataTable RowFilter injection in `SqlTableSchemaProvider` (MEDIUM)
+
+**File:** `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs:151`
+
+**Details:**
+
+```csharp
+table.DefaultView.RowFilter = $"Name='{name}'";
+```
+
+The `name` variable comes from the same DataTable's rows (database query results), so it's not directly user-controlled. However, if an index name in the database contains a single quote (`'`), the RowFilter expression will break and could either throw an exception or produce incorrect filtering results.
+
+**Fix:** Escape single quotes by doubling them:
+```csharp
+table.DefaultView.RowFilter = $"Name='{name.Replace("'", "''")}'";
+```
+
+---
+
+#### S4. Sensitive information in error logs (MEDIUM)
+
+**File:** `src/Bee.Db/Logging/DbAccessLogger.cs:74-76`
+
+**Details:**
+
+```csharp
+sb.Append("Message=").Append(exception.Message).Append("; ");
+sb.Append("CommandText=").Append(context.CommandText);
+```
+
+Full SQL command text and exception messages are included in error logs. Database exceptions from providers (e.g. SqlException) may contain server names, connection details, or schema information. The CommandText reveals table structures and query patterns.
+
+**Fix:**
+- Truncate `CommandText` to a configurable maximum length in logs.
+- Avoid logging the full `exception.Message`; log only `exception.GetType().Name` and error codes.
+- Same issue in `WriteWarning` (line 102): `ctx.CommandText` is logged.
+
+---
+
+#### S5. Connection string stored in plain text in memory (LOW)
+
+**File:** `src/Bee.Db/Manager/DbConnectionInfo.cs:33`
+
+**Details:**
+
+`DbConnectionInfo.ConnectionString` is a plain `string` property containing the full connection string with embedded credentials. It's cached indefinitely in `DbConnectionManager._cache` (a static `ConcurrentDictionary`). This means credentials remain in process memory for the lifetime of the application.
+
+**Risk:** In a memory dump or debugger scenario, credentials could be extracted. This is standard ADO.NET behavior and is generally accepted, but worth documenting.
+
+**Recommendation:** Document this as a known trade-off. If higher security is needed, consider using `SecureString` or delegating to the connection string builder's `PersistSecurityInfo=false` option.
+
+---
+
+### Performance Issues
+
+#### P1. Unbounded `ILMapper` cache (MEDIUM)
+
+**File:** `src/Bee.Db/ILMapper.cs:17`
+
+**Details:**
+
+```csharp
+private static readonly ConcurrentDictionary<(Type, string), Delegate> _cache = ...
+```
+
+The cache is static and entries are never evicted. If the application uses many different query shapes (different column orderings or subsets), the cache grows unboundedly. Each entry holds a compiled `DynamicMethod` delegate.
+
+**Fix:**
+- Add a `ClearCache()` method for explicit cleanup.
+- Consider a bounded cache with LRU eviction for long-running applications.
+- At minimum, document the caching behavior.
+
+---
+
+#### P2. `SqlTableSchemaProvider` creates redundant `DbAccess` instances (LOW)
+
+**File:** `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs:72-73, 93-94, 183-184`
+
+**Details:**
+
+Three separate methods (`TableExists`, `GetTableIndexes`, `GetColumns`) each create a new `DbAccessObject(DatabaseId)` instance. While the underlying connection pooling mitigates the connection overhead, the repeated object creation and connection open/close cycles are unnecessary.
+
+**Fix:** Create a single `DbAccess` instance in `GetTableSchema` and pass it down, or make it a class field.
+
+---
+
+#### P3. String concatenation with `+=` in loops (LOW)
+
+**File:** `src/Bee.Db/Providers/SqlServer/SqlCreateTableCommandBuilder.cs:110-118, 303-308, 340-345`
+
+**Details:**
+
+Multiple methods build SQL fragments using `string += "..."` inside loops instead of `StringBuilder`:
+
+```csharp
+// GetInsertTableCommandText, line 116
+fields += $"[{field.FieldName}]";
+
+// GetPrimaryKeyCommandText, line 308
+fields += $"[{field.FieldName}] ...";
+```
+
+For tables with many columns, this creates O(n^2) string allocations.
+
+**Fix:** Replace with `StringBuilder` (already used in other methods of the same class).
+
+---
+
+#### P4. DataTable loads entire result set into memory (LOW — by design)
+
+**File:** `src/Bee.Db/DbAccess/DbAccess.cs:277-278, 617`
+
+**Details:**
+
+`ExecuteDataTableCore` uses `adapter.Fill(table)` which loads all rows. For large result sets, this causes memory pressure. The `Query<T>()` method provides a streaming alternative via `DbDataReader`, which is good.
+
+**Recommendation:** This is by design (DataTable is inherently in-memory). Document the recommended use of `Query<T>()` for large result sets.
+
+---
+
+## Proposed Fix Priority
+
+| Priority | Issue | Effort |
+|----------|-------|--------|
+| 1 | S2: `QuoteIdentifier` escape fix | Small |
+| 2 | S1: `SqlCreateTableCommandBuilder` SQL injection | Medium |
+| 3 | S3: RowFilter injection escape | Small |
+| 4 | S4: Sensitive info in error logs | Small |
+| 5 | P1: ILMapper cache cleanup method | Small |
+| 6 | P2: Redundant DbAccess instances | Small |
+| 7 | P3: String concatenation optimization | Small |
+| 8 | S5: Connection string in memory (document only) | Minimal |
+| 9 | P4: DataTable memory (document only) | Minimal |
+
+## Implementation Notes
+
+- S2 is the highest priority because `QuoteIdentifier` is used across ALL query builders.
+- S1 fixes should reuse the fixed `QuoteIdentifier` where possible, plus add SQL-level protections for the `EXEC()` pattern.
+- All fixes should include corresponding unit tests per the testing rules in `.claude/rules/testing.md`.

--- a/docs/plans/plan-bee-db-security-audit.md
+++ b/docs/plans/plan-bee-db-security-audit.md
@@ -1,49 +1,49 @@
-# Bee.Db Security & Performance Audit Plan
+# Bee.Db 資安與效能稽核計畫
 
-## Audit Scope
+## 稽核範圍
 
-Full review of `src/Bee.Db/` project — database access patterns, SQL generation, connection management, error handling.
+完整審查 `src/Bee.Db/` 專案 — 資料庫存取模式、SQL 產生方式、連線管理、錯誤處理。
 
 ---
 
-## Findings
+## 發現事項
 
-### Security Issues
+### 資安問題
 
-#### S1. SQL Injection in `SqlCreateTableCommandBuilder` (HIGH)
+#### S1. `SqlCreateTableCommandBuilder` 存在 SQL Injection 風險 (HIGH)
 
-**Files:**
+**檔案：**
 - `src/Bee.Db/Providers/SqlServer/SqlCreateTableCommandBuilder.cs`
 
-**Details:**
+**說明：**
 
-Multiple methods directly interpolate table names and index names into raw SQL strings without parameterization or proper escaping:
+多個方法將表名與索引名直接串接進原始 SQL 字串，未做參數化或跳脫處理：
 
-| Method | Line(s) | Problem |
-|--------|---------|---------|
-| `GetDropTableCommandText` | 97-98 | `tableName` interpolated into `N'{tableName}'` and `EXEC('DROP TABLE {tableName}')` |
-| `GetRenameTableCommandText` | 138-141 | Table/index names interpolated into `sp_rename` calls |
-| `GetInsertTableCommandText` | 120-121 | Uses `[{tableName}]` but doesn't escape `]` in names |
-| `GetCreateTableCommandText` | 162 | `[{dbTableName}]` without `]` escaping |
-| `GetPrimaryKeyCommandText` | 309, 312 | `[{field.FieldName}]` without `]` escaping |
-| `GetIndexCommandText` | 345, 349 | Same as above |
-| `GetFieldCommandText` | 212-214 | `[{field.FieldName}]` without `]` escaping |
-| `GetCommandText` | 55-57 | `this.TableName` in SQL comment — low risk but inconsistent |
+| 方法 | 行號 | 問題 |
+|------|------|------|
+| `GetDropTableCommandText` | 97-98 | `tableName` 直接串接進 `N'{tableName}'` 及 `EXEC('DROP TABLE {tableName}')` |
+| `GetRenameTableCommandText` | 138-141 | 表名/索引名直接串接進 `sp_rename` 呼叫 |
+| `GetInsertTableCommandText` | 120-121 | 使用 `[{tableName}]` 但未跳脫名稱中的 `]` |
+| `GetCreateTableCommandText` | 162 | `[{dbTableName}]` 未跳脫 `]` |
+| `GetPrimaryKeyCommandText` | 309, 312 | `[{field.FieldName}]` 未跳脫 `]` |
+| `GetIndexCommandText` | 345, 349 | 同上 |
+| `GetFieldCommandText` | 212-214 | `[{field.FieldName}]` 未跳脫 `]` |
+| `GetCommandText` | 55-57 | `this.TableName` 出現在 SQL 註解中 — 風險較低但不一致 |
 
-**Risk Assessment:** These values originate from `TableSchema` (internal configuration), not direct user input. However, schema definitions may come from form configurations that could be admin-controlled. The `EXEC('DROP TABLE ...')` pattern in `GetDropTableCommandText` is especially dangerous as it constructs dynamic SQL.
+**風險評估：** 這些值來自 `TableSchema`（內部設定），並非直接的使用者輸入。但 Schema 定義可能來自表單設定，有被管理者控制的可能。`GetDropTableCommandText` 中的 `EXEC('DROP TABLE ...')` 模式尤其危險，因為它建構了動態 SQL。
 
-**Fix:**
-- Create a `SanitizeIdentifier` helper that escapes `]` → `]]` (SQL Server).
-- Apply it consistently to all identifier interpolation points.
-- For `GetDropTableCommandText`, use `QUOTENAME()` in the SQL or parameterize the table name check.
+**修復方式：**
+- 建立 `SanitizeIdentifier` 輔助方法，跳脫 `]` → `]]`（SQL Server）。
+- 在所有識別符號串接點統一套用。
+- `GetDropTableCommandText` 應改用 SQL 的 `QUOTENAME()` 函式或將表名檢查參數化。
 
 ---
 
-#### S2. `QuoteIdentifier` doesn't escape delimiter characters (HIGH)
+#### S2. `QuoteIdentifier` 未跳脫分隔符號 (HIGH)
 
-**File:** `src/Bee.Db/DbFunc.cs:57`
+**檔案：** `src/Bee.Db/DbFunc.cs:57`
 
-**Details:**
+**說明：**
 
 ```csharp
 { DatabaseType.SQLServer, s => $"[{s}]" },
@@ -52,14 +52,14 @@ Multiple methods directly interpolate table names and index names into raw SQL s
 { DatabaseType.Oracle, s => $"\"{s}\"" }
 ```
 
-If an identifier contains the delimiter character itself (e.g. `]` for SQL Server, `` ` `` for MySQL, `"` for SQLite/Oracle), the quoting is broken and could allow SQL injection. The correct escaping rules:
-- SQL Server: `]` → `]]`
-- MySQL: `` ` `` → ``` `` ```
-- SQLite/Oracle: `"` → `""`
+若識別符號本身包含分隔符號（例如 SQL Server 的 `]`、MySQL 的 `` ` ``、SQLite/Oracle 的 `"`），quoting 會被突破，可能導致 SQL Injection。正確的跳脫規則：
+- SQL Server：`]` → `]]`
+- MySQL：`` ` `` → ``` `` ```
+- SQLite/Oracle：`"` → `""`
 
-**Impact:** All query builders that use `DbFunc.QuoteIdentifier` (WhereBuilder, SelectBuilder, FromBuilder, TableSchemaCommandBuilder) are potentially affected if identifiers contain special characters.
+**影響範圍：** 所有使用 `DbFunc.QuoteIdentifier` 的查詢建構器（WhereBuilder、SelectBuilder、FromBuilder、TableSchemaCommandBuilder）皆受影響。
 
-**Fix:** Update `QuoteIdentifiers` dictionary to include proper escaping:
+**修復方式：** 更新 `QuoteIdentifiers` 字典，加入跳脫邏輯：
 ```csharp
 { DatabaseType.SQLServer, s => $"[{s.Replace("]", "]]")}]" },
 { DatabaseType.MySQL, s => $"`{s.Replace("`", "``")}`" },
@@ -69,142 +69,142 @@ If an identifier contains the delimiter character itself (e.g. `]` for SQL Serve
 
 ---
 
-#### S3. DataTable RowFilter injection in `SqlTableSchemaProvider` (MEDIUM)
+#### S3. `SqlTableSchemaProvider` 的 RowFilter 注入 (MEDIUM)
 
-**File:** `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs:151`
+**檔案：** `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs:151`
 
-**Details:**
+**說明：**
 
 ```csharp
 table.DefaultView.RowFilter = $"Name='{name}'";
 ```
 
-The `name` variable comes from the same DataTable's rows (database query results), so it's not directly user-controlled. However, if an index name in the database contains a single quote (`'`), the RowFilter expression will break and could either throw an exception or produce incorrect filtering results.
+`name` 變數來自同一 DataTable 的資料列（資料庫查詢結果），並非直接由使用者控制。但若資料庫中的索引名稱包含單引號（`'`），RowFilter 表達式會中斷，可能拋出例外或產生錯誤的篩選結果。
 
-**Fix:** Escape single quotes by doubling them:
+**修復方式：** 將單引號加倍跳脫：
 ```csharp
 table.DefaultView.RowFilter = $"Name='{name.Replace("'", "''")}'";
 ```
 
 ---
 
-#### S4. Sensitive information in error logs (MEDIUM)
+#### S4. 錯誤日誌洩漏敏感資訊 (MEDIUM)
 
-**File:** `src/Bee.Db/Logging/DbAccessLogger.cs:74-76`
+**檔案：** `src/Bee.Db/Logging/DbAccessLogger.cs:74-76`
 
-**Details:**
+**說明：**
 
 ```csharp
 sb.Append("Message=").Append(exception.Message).Append("; ");
 sb.Append("CommandText=").Append(context.CommandText);
 ```
 
-Full SQL command text and exception messages are included in error logs. Database exceptions from providers (e.g. SqlException) may contain server names, connection details, or schema information. The CommandText reveals table structures and query patterns.
+完整的 SQL 命令文字與例外訊息被記入錯誤日誌。資料庫提供者的例外（如 SqlException）可能包含伺服器名稱、連線資訊或 Schema 細節。CommandText 會暴露資料表結構與查詢模式。
 
-**Fix:**
-- Truncate `CommandText` to a configurable maximum length in logs.
-- Avoid logging the full `exception.Message`; log only `exception.GetType().Name` and error codes.
-- Same issue in `WriteWarning` (line 102): `ctx.CommandText` is logged.
-
----
-
-#### S5. Connection string stored in plain text in memory (LOW)
-
-**File:** `src/Bee.Db/Manager/DbConnectionInfo.cs:33`
-
-**Details:**
-
-`DbConnectionInfo.ConnectionString` is a plain `string` property containing the full connection string with embedded credentials. It's cached indefinitely in `DbConnectionManager._cache` (a static `ConcurrentDictionary`). This means credentials remain in process memory for the lifetime of the application.
-
-**Risk:** In a memory dump or debugger scenario, credentials could be extracted. This is standard ADO.NET behavior and is generally accepted, but worth documenting.
-
-**Recommendation:** Document this as a known trade-off. If higher security is needed, consider using `SecureString` or delegating to the connection string builder's `PersistSecurityInfo=false` option.
+**修復方式：**
+- 將日誌中的 `CommandText` 截斷至可設定的最大長度。
+- 避免記錄完整的 `exception.Message`；僅記錄 `exception.GetType().Name` 及錯誤代碼。
+- `WriteWarning`（行 102）也有同樣的 `ctx.CommandText` 記錄問題。
 
 ---
 
-### Performance Issues
+#### S5. 連線字串以明文快取於記憶體中 (LOW)
 
-#### P1. Unbounded `ILMapper` cache (MEDIUM)
+**檔案：** `src/Bee.Db/Manager/DbConnectionInfo.cs:33`
 
-**File:** `src/Bee.Db/ILMapper.cs:17`
+**說明：**
 
-**Details:**
+`DbConnectionInfo.ConnectionString` 是一個包含完整連線字串（含嵌入憑證）的純 `string` 屬性，被永久快取在 `DbConnectionManager._cache`（靜態 `ConcurrentDictionary`）中。這代表憑證在應用程式的整個生命週期內都留存於程序記憶體中。
+
+**風險：** 在記憶體傾印或偵錯器情境下，憑證可能被擷取。這是標準 ADO.NET 行為，通常可接受，但值得記錄。
+
+**建議：** 記錄為已知取捨。若需更高安全性，可考慮使用 `SecureString` 或利用連線字串建構器的 `PersistSecurityInfo=false` 選項。
+
+---
+
+### 效能問題
+
+#### P1. `ILMapper` 快取無上限 (MEDIUM)
+
+**檔案：** `src/Bee.Db/ILMapper.cs:17`
+
+**說明：**
 
 ```csharp
 private static readonly ConcurrentDictionary<(Type, string), Delegate> _cache = ...
 ```
 
-The cache is static and entries are never evicted. If the application uses many different query shapes (different column orderings or subsets), the cache grows unboundedly. Each entry holds a compiled `DynamicMethod` delegate.
+快取為靜態且永不清除。若應用程式使用大量不同的查詢形式（不同的欄位順序或子集），快取會無限增長。每個項目持有一個已編譯的 `DynamicMethod` 委派。
 
-**Fix:**
-- Add a `ClearCache()` method for explicit cleanup.
-- Consider a bounded cache with LRU eviction for long-running applications.
-- At minimum, document the caching behavior.
-
----
-
-#### P2. `SqlTableSchemaProvider` creates redundant `DbAccess` instances (LOW)
-
-**File:** `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs:72-73, 93-94, 183-184`
-
-**Details:**
-
-Three separate methods (`TableExists`, `GetTableIndexes`, `GetColumns`) each create a new `DbAccessObject(DatabaseId)` instance. While the underlying connection pooling mitigates the connection overhead, the repeated object creation and connection open/close cycles are unnecessary.
-
-**Fix:** Create a single `DbAccess` instance in `GetTableSchema` and pass it down, or make it a class field.
+**修復方式：**
+- 新增 `ClearCache()` 方法供明確清理。
+- 對長時間執行的應用程式，考慮使用有上限的 LRU 快取。
+- 至少記錄快取行為的說明文件。
 
 ---
 
-#### P3. String concatenation with `+=` in loops (LOW)
+#### P2. `SqlTableSchemaProvider` 重複建立 `DbAccess` 實例 (LOW)
 
-**File:** `src/Bee.Db/Providers/SqlServer/SqlCreateTableCommandBuilder.cs:110-118, 303-308, 340-345`
+**檔案：** `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs:72-73, 93-94, 183-184`
 
-**Details:**
+**說明：**
 
-Multiple methods build SQL fragments using `string += "..."` inside loops instead of `StringBuilder`:
+三個方法（`TableExists`、`GetTableIndexes`、`GetColumns`）各自建立新的 `DbAccessObject(DatabaseId)` 實例。雖然底層連線池機制緩解了連線開銷，但重複的物件建立與連線開啟/關閉循環並無必要。
+
+**修復方式：** 在 `GetTableSchema` 中建立單一 `DbAccess` 實例並向下傳遞，或設為類別欄位。
+
+---
+
+#### P3. 迴圈中使用 `+=` 串接字串 (LOW)
+
+**檔案：** `src/Bee.Db/Providers/SqlServer/SqlCreateTableCommandBuilder.cs:110-118, 303-308, 340-345`
+
+**說明：**
+
+多個方法在迴圈中使用 `string += "..."` 而非 `StringBuilder` 來組建 SQL 片段：
 
 ```csharp
-// GetInsertTableCommandText, line 116
+// GetInsertTableCommandText, 行 116
 fields += $"[{field.FieldName}]";
 
-// GetPrimaryKeyCommandText, line 308
+// GetPrimaryKeyCommandText, 行 308
 fields += $"[{field.FieldName}] ...";
 ```
 
-For tables with many columns, this creates O(n^2) string allocations.
+對多欄位的資料表，會產生 O(n^2) 的字串配置。
 
-**Fix:** Replace with `StringBuilder` (already used in other methods of the same class).
-
----
-
-#### P4. DataTable loads entire result set into memory (LOW — by design)
-
-**File:** `src/Bee.Db/DbAccess/DbAccess.cs:277-278, 617`
-
-**Details:**
-
-`ExecuteDataTableCore` uses `adapter.Fill(table)` which loads all rows. For large result sets, this causes memory pressure. The `Query<T>()` method provides a streaming alternative via `DbDataReader`, which is good.
-
-**Recommendation:** This is by design (DataTable is inherently in-memory). Document the recommended use of `Query<T>()` for large result sets.
+**修復方式：** 改用 `StringBuilder`（同一類別的其他方法已使用此模式）。
 
 ---
 
-## Proposed Fix Priority
+#### P4. DataTable 將整個結果集載入記憶體 (LOW — 設計使然)
 
-| Priority | Issue | Effort |
-|----------|-------|--------|
-| 1 | S2: `QuoteIdentifier` escape fix | Small |
-| 2 | S1: `SqlCreateTableCommandBuilder` SQL injection | Medium |
-| 3 | S3: RowFilter injection escape | Small |
-| 4 | S4: Sensitive info in error logs | Small |
-| 5 | P1: ILMapper cache cleanup method | Small |
-| 6 | P2: Redundant DbAccess instances | Small |
-| 7 | P3: String concatenation optimization | Small |
-| 8 | S5: Connection string in memory (document only) | Minimal |
-| 9 | P4: DataTable memory (document only) | Minimal |
+**檔案：** `src/Bee.Db/DbAccess/DbAccess.cs:277-278, 617`
 
-## Implementation Notes
+**說明：**
 
-- S2 is the highest priority because `QuoteIdentifier` is used across ALL query builders.
-- S1 fixes should reuse the fixed `QuoteIdentifier` where possible, plus add SQL-level protections for the `EXEC()` pattern.
-- All fixes should include corresponding unit tests per the testing rules in `.claude/rules/testing.md`.
+`ExecuteDataTableCore` 使用 `adapter.Fill(table)` 載入所有資料列。對大型結果集會造成記憶體壓力。`Query<T>()` 方法透過 `DbDataReader` 提供了串流替代方案，設計良好。
+
+**建議：** 此為設計使然（DataTable 本質為記憶體內操作）。記錄建議對大型結果集使用 `Query<T>()` 即可。
+
+---
+
+## 修復優先順序
+
+| 優先序 | 問題 | 工作量 |
+|--------|------|--------|
+| 1 | S2：`QuoteIdentifier` 跳脫修復 | 小 |
+| 2 | S1：`SqlCreateTableCommandBuilder` SQL Injection | 中 |
+| 3 | S3：RowFilter 注入跳脫 | 小 |
+| 4 | S4：錯誤日誌敏感資訊 | 小 |
+| 5 | P1：ILMapper 快取清理方法 | 小 |
+| 6 | P2：重複 DbAccess 實例 | 小 |
+| 7 | P3：字串串接優化 | 小 |
+| 8 | S5：記憶體中的連線字串（僅記錄） | 極小 |
+| 9 | P4：DataTable 記憶體（僅記錄） | 極小 |
+
+## 實作備註
+
+- S2 為最高優先，因為 `QuoteIdentifier` 被所有查詢建構器使用。
+- S1 的修復應盡量複用修復後的 `QuoteIdentifier`，並針對 `EXEC()` 模式加入 SQL 層級的防護。
+- 所有修復應依照 `.claude/rules/testing.md` 的規範撰寫對應的單元測試。

--- a/src/Bee.Db/DbFunc.cs
+++ b/src/Bee.Db/DbFunc.cs
@@ -54,10 +54,10 @@ namespace Bee.Db
         /// </summary>
         private static readonly Dictionary<DatabaseType, Func<string, string>> QuoteIdentifiers = new Dictionary<DatabaseType, Func<string, string>>
         {
-            { DatabaseType.SQLServer, s => $"[{s}]" },
-            { DatabaseType.MySQL, s => $"`{s}`" },
-            { DatabaseType.SQLite, s => $"\"{s}\"" },
-            { DatabaseType.Oracle, s => $"\"{s}\"" }
+            { DatabaseType.SQLServer, s => $"[{s.Replace("]", "]]")}]" },
+            { DatabaseType.MySQL, s => $"`{s.Replace("`", "``")}`" },
+            { DatabaseType.SQLite, s => $"\"{s.Replace("\"", "\"\"")}\"" },
+            { DatabaseType.Oracle, s => $"\"{s.Replace("\"", "\"\"")}\"" }
         };
 
         /// <summary>

--- a/src/Bee.Db/ILMapper.cs
+++ b/src/Bee.Db/ILMapper.cs
@@ -18,6 +18,20 @@ namespace Bee.Db
             new ConcurrentDictionary<(Type, string), Delegate>();
 
         /// <summary>
+        /// Clears the cached mapping delegates for type <typeparamref name="T"/>.
+        /// Call this method to release memory in long-running applications or when query shapes are no longer needed.
+        /// </summary>
+        public static void ClearCache()
+        {
+            _cache.Clear();
+        }
+
+        /// <summary>
+        /// Gets the number of cached mapping delegates for type <typeparamref name="T"/>.
+        /// </summary>
+        public static int CacheCount => _cache.Count;
+
+        /// <summary>
         /// Creates a mapping function that converts a <see cref="DbDataReader"/> row to type <typeparamref name="T"/>.
         /// </summary>
         /// <param name="reader">The DbDataReader containing the query results.</param>

--- a/src/Bee.Db/Logging/DbAccessLogger.cs
+++ b/src/Bee.Db/Logging/DbAccessLogger.cs
@@ -16,6 +16,10 @@ namespace Bee.Db.Logging
     public static class DbAccessLogger
     {
         /// <summary>
+        /// Maximum length of CommandText included in log output. Longer values are truncated.
+        /// </summary>
+        private const int MaxCommandTextLogLength = 500;
+        /// <summary>
         /// Starts logging a database command execution.
         /// </summary>
         /// <param name="command">The database command specification.</param>
@@ -72,8 +76,7 @@ namespace Bee.Db.Logging
             if (errCode.HasValue) sb.Append("ErrorCode=").Append(errCode.Value).Append("; ");
             if (errNumber.HasValue) sb.Append("Number=").Append(errNumber.Value).Append("; ");
             sb.Append("Exception=").Append(exception.GetType().FullName).Append("; ");
-            sb.Append("Message=").Append(exception.Message).Append("; ");
-            sb.Append("CommandText=").Append(context.CommandText);
+            sb.Append("CommandText=").Append(TruncateCommandText(context.CommandText));
 
             // Write error log
             // SysInfo.LogWriter?.WriteError(sb.ToString());
@@ -99,10 +102,21 @@ namespace Bee.Db.Logging
             if (!string.IsNullOrEmpty(ctx.DatabaseId)) sb.Append("DbId=").Append(ctx.DatabaseId).Append("; ");
             sb.Append("Elapsed=").Append(elapsedSeconds.ToString("0.###", CultureInfo.InvariantCulture)).Append(" s; ");
             if (affectedRows >= 0) sb.Append("Rows=").Append(affectedRows).Append("; ");
-            sb.Append("CommandText=").Append(ctx.CommandText);
+            sb.Append("CommandText=").Append(TruncateCommandText(ctx.CommandText));
 
             // TODO: Write warning log
             // SysInfo.LogWriter?.WriteError(sb.ToString());
+        }
+
+        /// <summary>
+        /// Truncates command text to <see cref="MaxCommandTextLogLength"/> to avoid exposing excessive SQL details in logs.
+        /// </summary>
+        /// <param name="commandText">The original command text.</param>
+        private static string TruncateCommandText(string commandText)
+        {
+            if (string.IsNullOrEmpty(commandText) || commandText.Length <= MaxCommandTextLogLength)
+                return commandText;
+            return commandText.Substring(0, MaxCommandTextLogLength) + "...(truncated)";
         }
 
         /// <summary>

--- a/src/Bee.Db/Providers/SqlServer/SqlCreateTableCommandBuilder.cs
+++ b/src/Bee.Db/Providers/SqlServer/SqlCreateTableCommandBuilder.cs
@@ -44,6 +44,24 @@ namespace Bee.Db.Providers.SqlServer
         }
 
         /// <summary>
+        /// Quotes a SQL Server identifier by escaping <c>]</c> as <c>]]</c> and wrapping in square brackets.
+        /// </summary>
+        /// <param name="identifier">The identifier to quote.</param>
+        private static string QuoteName(string identifier)
+        {
+            return $"[{identifier.Replace("]", "]]")}]";
+        }
+
+        /// <summary>
+        /// Escapes a string value for use inside an N'...' literal by doubling single quotes.
+        /// </summary>
+        /// <param name="value">The string value to escape.</param>
+        private static string EscapeSqlString(string value)
+        {
+            return value.Replace("'", "''");
+        }
+
+        /// <summary>
         /// Gets the SQL statement for creating or upgrading a table.
         /// </summary>
         /// <param name="dbTable">The table schema definition.</param>
@@ -94,8 +112,10 @@ namespace Bee.Db.Providers.SqlServer
         /// <param name="tableName">The table name.</param>
         private string GetDropTableCommandText(string tableName)
         {
-            return $"IF (SELECT COUNT(*) From sys.tables WHERE name=N'{tableName}')>0\n" +
-                        $"  EXEC('DROP TABLE {tableName}');";
+            string escaped = EscapeSqlString(tableName);
+            string quoted = QuoteName(tableName);
+            return $"IF (SELECT COUNT(*) From sys.tables WHERE name=N'{escaped}')>0\n" +
+                        $"  DROP TABLE {quoted};";
         }
 
         /// <summary>
@@ -106,19 +126,20 @@ namespace Bee.Db.Providers.SqlServer
         private string GetInsertTableCommandText(string tableName, string newTableName)
         {
            // Build the list of fields to migrate
-            string fields = string.Empty;
+            var fieldBuilder = new StringBuilder();
             foreach (DbField field in this.TableSchema.Fields)
             {
                 if (field.UpgradeAction != DbUpgradeAction.New && field.DbType != FieldDbType.AutoIncrement)
                 {
-                    if (StrFunc.IsNotEmpty(fields))
-                        fields += ", ";
-                    fields += $"[{field.FieldName}]";
+                    if (fieldBuilder.Length > 0)
+                        fieldBuilder.Append(", ");
+                    fieldBuilder.Append(QuoteName(field.FieldName));
                 }
             }
+            string fields = fieldBuilder.ToString();
             // Build the INSERT INTO ... SELECT statement
-            string  sql = $"INSERT INTO [{newTableName}] ({fields}) \n" +
-                                  $"SELECT {fields} FROM [{tableName}];";
+            string sql = $"INSERT INTO {QuoteName(newTableName)} ({fields}) \n" +
+                                  $"SELECT {fields} FROM {QuoteName(tableName)};";
             return sql;
         }
 
@@ -135,10 +156,10 @@ namespace Bee.Db.Providers.SqlServer
             {
                 string oldName = StrFunc.Format(index.Name, tableName);  // Old index name
                 string newName = StrFunc.Format(index.Name, newTableName);  // New index name
-                sb.Append($"EXEC sp_rename N'dbo.{tableName}.{oldName}', N'{newName}', N'INDEX';\n");
+                sb.Append($"EXEC sp_rename N'{EscapeSqlString($"dbo.{tableName}.{oldName}")}', N'{EscapeSqlString(newName)}', N'INDEX';\n");
             }
             // Rename the table
-            sb.Append($"EXEC sp_rename N'{tableName}', N'{newTableName}';\n");
+            sb.Append($"EXEC sp_rename N'{EscapeSqlString(tableName)}', N'{EscapeSqlString(newTableName)}';\n");
             return sb.ToString();
         }
 
@@ -159,7 +180,7 @@ namespace Bee.Db.Providers.SqlServer
 
             var sb = new StringBuilder();
             // Assemble the CREATE TABLE statement
-            sb.Append($"CREATE TABLE [{dbTableName}] (\r\n{fields}");
+            sb.Append($"CREATE TABLE {QuoteName(dbTableName)} (\r\n{fields}");
             if (StrFunc.IsNotEmpty(primaryKey))
                 sb.Append($",\r\n  {primaryKey}");
             sb.Append("\r\n);");
@@ -209,9 +230,9 @@ namespace Bee.Db.Providers.SqlServer
                 defaultText = string.Empty;
 
             if (StrFunc.IsEmpty(defaultText))
-                return $"[{field.FieldName}] {dbType} {allowNull}";
+                return $"{QuoteName(field.FieldName)} {dbType} {allowNull}";
             else
-                return $"[{field.FieldName}] {dbType} {allowNull} {defaultText}";
+                return $"{QuoteName(field.FieldName)} {dbType} {allowNull} {defaultText}";
         }
 
         /// <summary>
@@ -300,16 +321,16 @@ namespace Bee.Db.Providers.SqlServer
             if (index == null) { return string.Empty; }
 
             // Build the index field list
-            string fields = string.Empty;
+            var fieldBuilder = new StringBuilder();
             foreach (IndexField field in index.IndexFields)
             {
-                if (StrFunc.IsNotEmpty(fields))
-                    fields += ", ";
-                fields += $"[{field.FieldName}] {field.SortDirection.ToString().ToUpper()}";
+                if (fieldBuilder.Length > 0)
+                    fieldBuilder.Append(", ");
+                fieldBuilder.Append($"{QuoteName(field.FieldName)} {field.SortDirection.ToString().ToUpper()}");
             }
 
             string name = StrFunc.Format(index.Name, tableName);
-            return $"CONSTRAINT [{name}] PRIMARY KEY ({fields})";
+            return $"CONSTRAINT {QuoteName(name)} PRIMARY KEY ({fieldBuilder})";
         }
 
         /// <summary>
@@ -337,18 +358,18 @@ namespace Bee.Db.Providers.SqlServer
             // Index name
             string name = StrFunc.Format(index.Name, tableName);
             // Index fields
-            string fields = string.Empty;
+            var fieldBuilder = new StringBuilder();
             foreach (IndexField field in index.IndexFields)
             {
-                if (StrFunc.IsNotEmpty(fields))
-                    fields += ", ";
-                fields += $"[{field.FieldName}] {field.SortDirection.ToString().ToUpper()}";
+                if (fieldBuilder.Length > 0)
+                    fieldBuilder.Append(", ");
+                fieldBuilder.Append($"{QuoteName(field.FieldName)} {field.SortDirection.ToString().ToUpper()}");
             }
             // Generate the CREATE INDEX statement
             if (index.Unique)
-                return $"CREATE UNIQUE INDEX [{name}] ON [{tableName}] ({fields});";
+                return $"CREATE UNIQUE INDEX {QuoteName(name)} ON {QuoteName(tableName)} ({fieldBuilder});";
             else
-                return $"CREATE INDEX [{name}] ON [{tableName}] ({fields});";
+                return $"CREATE INDEX {QuoteName(name)} ON {QuoteName(tableName)} ({fieldBuilder});";
         }
     }
 }

--- a/src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs
+++ b/src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs
@@ -14,6 +14,8 @@ namespace Bee.Db.Providers.SqlServer
     /// </summary>
     public class SqlTableSchemaProvider
     {
+        private readonly DbAccessObject _dbAccess;
+
         #region 建構函式
 
         /// <summary>
@@ -23,6 +25,7 @@ namespace Bee.Db.Providers.SqlServer
         public SqlTableSchemaProvider(string databaseId)
         {
             DatabaseId = databaseId;
+            _dbAccess = new DbAccessObject(databaseId);
         }
 
         #endregion
@@ -70,8 +73,7 @@ namespace Bee.Db.Providers.SqlServer
         {
             string sql = "Select Count(*) From sys.tables A Where A.name={0}";
             var command = new DbCommandSpec(DbCommandKind.Scalar, sql, tableName);
-            var dbAccess = new DbAccessObject(DatabaseId);
-            var result = dbAccess.Execute(command);
+            var result = _dbAccess.Execute(command);
             int count = BaseFunc.CInt(result.Scalar);
             return count > 0;
         }
@@ -91,8 +93,7 @@ namespace Bee.Db.Providers.SqlServer
                           "WHERE B.name={0} \n" +
                           "Order By D.is_primary_key,C.key_ordinal";
             var command = new DbCommandSpec(DbCommandKind.DataTable, sql, tableName);
-            var dbAccess = new DbAccessObject(DatabaseId);
-            var result = dbAccess.Execute(command);
+            var result = _dbAccess.Execute(command);
             var table = result.Table;
             table.TableName = "TableIndex";
             return table;
@@ -148,7 +149,8 @@ namespace Bee.Db.Providers.SqlServer
                 tableIndex.Unique = isUnique;
                 dbTable.Indexes.Add(tableIndex);
 
-                table.DefaultView.RowFilter = $"Name='{name}'";
+                table.DefaultView.RowFilter = $"Name='{name.Replace("'", "''")}'";
+
                 table.DefaultView.Sort = "Name,KeyOrdinal";
                 foreach (DataRowView rowView in table.DefaultView)
                 {
@@ -181,8 +183,7 @@ namespace Bee.Db.Providers.SqlServer
                           "WHERE B.name={0} \n" +
                           "ORDER BY A.column_id";
             var command = new DbCommandSpec(DbCommandKind.DataTable, sql, tableName);
-            var dbAccess = new DbAccessObject(DatabaseId);
-            var result = dbAccess.Execute(command);
+            var result = _dbAccess.Execute(command);
             var table = result.Table;
             table.TableName = "Columns";
             return table;

--- a/tests/Bee.Db.UnitTests/DbAccessLoggerTests.cs
+++ b/tests/Bee.Db.UnitTests/DbAccessLoggerTests.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using Bee.Db.Logging;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbAccessLoggerTests
+    {
+        [Fact]
+        [DisplayName("LogError 不應擲出例外")]
+        public void LogError_ValidContext_DoesNotThrow()
+        {
+            var command = new Bee.Db.DbAccess.DbCommandSpec(
+                Bee.Db.DbAccess.DbCommandKind.NonQuery,
+                "UPDATE test SET col={0}", "value");
+            var context = DbAccessLogger.LogStart(command, "testDb");
+
+            var ex = new InvalidOperationException("Test error");
+            var exception = Record.Exception(() => DbAccessLogger.LogError(context, ex));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("LogError context 為 null 應擲出 ArgumentNullException")]
+        public void LogError_NullContext_ThrowsArgumentNull()
+        {
+            var ex = new InvalidOperationException("Test");
+            Assert.Throws<ArgumentNullException>(() => DbAccessLogger.LogError(null!, ex));
+        }
+
+        [Fact]
+        [DisplayName("LogError exception 為 null 應擲出 ArgumentNullException")]
+        public void LogError_NullException_ThrowsArgumentNull()
+        {
+            var command = new Bee.Db.DbAccess.DbCommandSpec(
+                Bee.Db.DbAccess.DbCommandKind.NonQuery, "SELECT 1");
+            var context = DbAccessLogger.LogStart(command);
+            Assert.Throws<ArgumentNullException>(() => DbAccessLogger.LogError(context, null!));
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbFuncTests.cs
+++ b/tests/Bee.Db.UnitTests/DbFuncTests.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using Bee.Definition;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbFuncTests
+    {
+        #region QuoteIdentifier 跳脫測試
+
+        [Theory]
+        [InlineData(DatabaseType.SQLServer, "Name", "[Name]")]
+        [InlineData(DatabaseType.SQLServer, "Col]umn", "[Col]]umn]")]
+        [InlineData(DatabaseType.SQLServer, "A]]B", "[A]]]]B]")]
+        [DisplayName("QuoteIdentifier SQL Server 應正確跳脫 ] 字元")]
+        public void QuoteIdentifier_SqlServer_EscapesBracket(DatabaseType dbType, string identifier, string expected)
+        {
+            var result = DbFunc.QuoteIdentifier(dbType, identifier);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(DatabaseType.MySQL, "Name", "`Name`")]
+        [InlineData(DatabaseType.MySQL, "Col`umn", "`Col``umn`")]
+        [DisplayName("QuoteIdentifier MySQL 應正確跳脫 ` 字元")]
+        public void QuoteIdentifier_MySql_EscapesBacktick(DatabaseType dbType, string identifier, string expected)
+        {
+            var result = DbFunc.QuoteIdentifier(dbType, identifier);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(DatabaseType.SQLite, "Name", "\"Name\"")]
+        [InlineData(DatabaseType.SQLite, "Col\"umn", "\"Col\"\"umn\"")]
+        [InlineData(DatabaseType.Oracle, "Name", "\"Name\"")]
+        [InlineData(DatabaseType.Oracle, "Col\"umn", "\"Col\"\"umn\"")]
+        [DisplayName("QuoteIdentifier SQLite/Oracle 應正確跳脫雙引號")]
+        public void QuoteIdentifier_SqliteOracle_EscapesDoubleQuote(DatabaseType dbType, string identifier, string expected)
+        {
+            var result = DbFunc.QuoteIdentifier(dbType, identifier);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("QuoteIdentifier 不支援的資料庫類型應擲出 NotSupportedException")]
+        public void QuoteIdentifier_UnsupportedType_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                DbFunc.QuoteIdentifier((DatabaseType)999, "Test"));
+        }
+
+        #endregion
+
+        #region GetParameterPrefix 測試
+
+        [Theory]
+        [InlineData(DatabaseType.SQLServer, "@")]
+        [InlineData(DatabaseType.MySQL, "@")]
+        [InlineData(DatabaseType.SQLite, "@")]
+        [InlineData(DatabaseType.Oracle, ":")]
+        [DisplayName("GetParameterPrefix 應回傳對應資料庫的參數前綴")]
+        public void GetParameterPrefix_ReturnsCorrectPrefix(DatabaseType dbType, string expected)
+        {
+            var result = DbFunc.GetParameterPrefix(dbType);
+            Assert.Equal(expected, result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary

- **S2**: `QuoteIdentifier` 加入分隔符號跳脫，防止識別符號注入（SQL Server `]`、MySQL `` ` ``、SQLite/Oracle `"`）
- **S1**: `SqlCreateTableCommandBuilder` 移除 `EXEC` 動態 SQL，改用 `QuoteName`/`EscapeSqlString` 防止 SQL Injection
- **S3**: `SqlTableSchemaProvider` RowFilter 加入單引號跳脫
- **S4**: `DbAccessLogger` 移除 `exception.Message` 記錄，截斷 `CommandText` 至 500 字元
- **P1**: `ILMapper` 新增 `ClearCache()`/`CacheCount` 供長時間執行應用清理快取
- **P2**: `SqlTableSchemaProvider` 共用單一 `DbAccess` 實例，減少重複建立
- **P3**: `SqlCreateTableCommandBuilder` 迴圈內 `+=` 改用 `StringBuilder`

## Test plan

- [ ] CI build 通過
- [ ] `DbFuncTests` — QuoteIdentifier 跳脫驗證（SQL Server/MySQL/SQLite/Oracle）
- [ ] `DbAccessLoggerTests` — LogError 基本行為驗證

https://claude.ai/code/session_017vjzrHtmvpMqaFtbrjyY8Q