### PR TITLE
fix: enforce pre-instantiation type validation in MessagePack deserialization

### DIFF
--- a/docs/plans/plan-review-serialization-security.md
+++ b/docs/plans/plan-review-serialization-security.md
@@ -1,0 +1,131 @@
+# Plan: 序列化安全性審查與修復
+
+## 背景
+
+API 傳輸支援兩種序列化格式（JSON / MessagePack），皆採用命名空間白名單策略限制可反序列化的型別。審查後發現以下問題：
+
+| 嚴重度 | 問題 | 影響範圍 |
+|--------|------|---------|
+| **嚴重** | `SafeTypelessFormatter` 在物件實例化**之後**才驗證型別 | MessagePack 反序列化 |
+| **中等** | `DataTable` / `DataRow` 列入無條件允許的原始型別白名單 | `SafeTypelessFormatter` |
+| **中等** | `AllowedTypeNamespaces` 為 public mutable List | `SysInfo` |
+| **低** | `BuildAllowedTypeNamespaces` 與 `IsTypeNameAllowed` 大小寫比較不一致 | `SysInfo` |
+
+---
+
+## 修復項目
+
+### 1. [嚴重] SafeTypelessFormatter — 改為預先驗證型別名稱
+
+**問題**：目前 `SafeTypelessFormatter.Deserialize()` 先呼叫 `TypelessFormatter.Instance.Deserialize()` 完成物件建構，再以 `ValidateType()` 檢查型別。惡意型別的建構函式/屬性 setter 在驗證前已執行。
+
+**修復方案**：在呼叫 `TypelessFormatter` 之前，先從 MessagePack payload 讀取型別名稱字串並驗證。
+
+MessagePack `TypelessFormatter` 的序列化格式為 2-element array：`[typeName, serializedData]`。可利用 `MessagePackReader`（struct，可複製）先窺探型別名稱，驗證通過後再用原始 reader 交給 `TypelessFormatter` 處理。
+
+**修改檔案**：`src/Bee.Definition/Serialization/SafeTypelessFormatter.cs`
+
+```csharp
+public object Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+{
+    if (reader.TryReadNil())
+        return null;
+
+    // 複製 reader 以窺探型別名稱（MessagePackReader 是 struct，複製不影響原始 reader）
+    var peekReader = reader.CreatePeekReader();
+
+    // TypelessFormatter 使用 2-element array: [typeName, data]
+    var arrayLength = peekReader.ReadArrayHeader();
+    if (arrayLength >= 1)
+    {
+        // 讀取型別名稱（第一個元素）
+        var typeName = peekReader.ReadString();
+        if (typeName != null)
+        {
+            ValidateTypeName(typeName);
+        }
+    }
+
+    // 驗證通過，使用原始 reader 進行完整反序列化
+    return TypelessFormatter.Instance.Deserialize(ref reader, options);
+}
+```
+
+新增 `ValidateTypeName(string typeName)` 方法，在取得 `Type` 物件之前就以字串比對白名單。原有的 `ValidateType(Type type)` 保留作為第二道防線（belt-and-suspenders）。
+
+**測試**：
+- 新增測試：序列化一個不在白名單的型別，驗證反序列化時拋出 `InvalidOperationException`，且物件**未被建構**
+- 新增測試：白名單內的型別可正常往返序列化/反序列化
+- 新增測試：原始型別（System.Int32, System.String 等）可正常反序列化
+
+---
+
+### 2. [中等] 將 DataTable / DataRow 從原始型別白名單移除
+
+**問題**：`DataTable` 是已知高風險反序列化型別（可攜帶 Expression 欄位觸發程式碼執行），不應列入「無條件允許」清單。
+
+**修復方案**：從 `AllowedPrimitiveTypes` 移除 `System.Data.DataTable` 和 `System.Data.DataRow`。這兩個型別在 MessagePack 管道中已有專屬的 `DataTableFormatter` / `DataSetFormatter` 處理，不需要經由 `SafeTypelessFormatter` 的原始型別白名單通行。
+
+**修改檔案**：`src/Bee.Definition/Serialization/SafeTypelessFormatter.cs`
+
+**測試**：
+- 確認 DataTable 仍可透過 `DataTableFormatter` 正常序列化/反序列化
+- 確認透過 `SafeTypelessFormatter` 路徑的 DataTable 型別名稱會被攔截
+
+---
+
+### 3. [中等] AllowedTypeNamespaces 改為唯讀集合
+
+**問題**：`SysInfo.AllowedTypeNamespaces` 是 `public static List<string>` 且有 `set`，任何程式碼都能在執行期替換或清空白名單。
+
+**修復方案**：
+- 將屬性型別改為 `IReadOnlyList<string>`
+- 移除 public setter，改為僅透過 `Initialize()` 方法設定
+- 內部儲存為 `List<string>`，對外公開為 `IReadOnlyList<string>`
+
+**修改檔案**：`src/Bee.Base/SysInfo.cs`
+
+```csharp
+private static List<string> _allowedTypeNamespaces = new List<string> { "Bee.Base", "Bee.Definition", "Bee.Contracts" };
+
+/// <summary>
+/// Gets the list of type namespaces allowed for JSON-RPC data transfer (read-only).
+/// Use <see cref="Initialize"/> to configure.
+/// </summary>
+public static IReadOnlyList<string> AllowedTypeNamespaces => _allowedTypeNamespaces;
+```
+
+**注意**：此變更會影響外部直接指定 `AllowedTypeNamespaces = ...` 的程式碼，需檢查所有參考點。
+
+**修改檔案**：`src/Bee.Base/SysInfo.cs` 及所有直接存取 `AllowedTypeNamespaces` setter 的位置
+
+**測試**：
+- 確認 `Initialize()` 能正確設定命名空間
+- 確認 `AllowedTypeNamespaces` 不可被外部直接替換
+
+---
+
+### 4. [低] 統一大小寫比較策略
+
+**問題**：`BuildAllowedTypeNamespaces` 用 `StringComparer.OrdinalIgnoreCase` 去重，但 `IsTypeNameAllowed` 的 `StartsWith` 預設為 Ordinal（區分大小寫）。
+
+**修復方案**：將 `BuildAllowedTypeNamespaces` 改為 `StringComparer.Ordinal`，與 `IsTypeNameAllowed` 的行為一致。.NET 型別名稱本身區分大小寫，兩端應統一。
+
+**修改檔案**：`src/Bee.Base/SysInfo.cs`
+
+---
+
+## 執行順序
+
+1. 修復項目 1（SafeTypelessFormatter 預先驗證）— 最高優先
+2. 修復項目 2（移除 DataTable/DataRow）
+3. 修復項目 3（AllowedTypeNamespaces 唯讀化）
+4. 修復項目 4（大小寫一致性）
+5. 執行全部相關測試，確認無回歸
+
+## 影響範圍
+
+- `Bee.Definition`：SafeTypelessFormatter
+- `Bee.Base`：SysInfo
+- `Bee.Api.Core`：MessagePackHelper（間接，無需修改）
+- 測試專案：`Bee.Definition.UnitTests`、`Bee.Base.UnitTests`

--- a/src/Bee.Api.Core/MessagePack/MessagePackHelper.cs
+++ b/src/Bee.Api.Core/MessagePack/MessagePackHelper.cs
@@ -40,8 +40,10 @@ namespace Bee.Api.Core.MessagePack
                     StandardResolver.Instance              // Standard resolver
                 });
 
-            // Configure the MessagePack serialization options
-            Options = MessagePackSerializerOptions.Standard.WithResolver(resolver);
+            // Configure the MessagePack serialization options with whitelist-based type validation.
+            // SafeMessagePackSerializerOptions overrides ThrowIfDeserializingTypeIsDisallowed
+            // to block disallowed types BEFORE object instantiation inside TypelessFormatter.
+            Options = new SafeMessagePackSerializerOptions(resolver);
         }
 
         /// <summary>

--- a/src/Bee.Api.Core/MessagePack/SafeMessagePackSerializerOptions.cs
+++ b/src/Bee.Api.Core/MessagePack/SafeMessagePackSerializerOptions.cs
@@ -1,0 +1,65 @@
+using System;
+using Bee.Definition.Serialization;
+using MessagePack;
+
+namespace Bee.Api.Core.MessagePack
+{
+    /// <summary>
+    /// Custom <see cref="MessagePackSerializerOptions"/> that enforces the allowed type whitelist
+    /// during <see cref="MessagePack.Formatters.TypelessFormatter"/> deserialization.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="MessagePack.Formatters.TypelessFormatter"/> calls
+    /// <see cref="MessagePackSerializerOptions.ThrowIfDeserializingTypeIsDisallowed"/>
+    /// <b>before</b> instantiating the deserialized object. This override applies
+    /// <see cref="SafeTypelessFormatter.IsTypeAllowed"/> at that point, preventing
+    /// untrusted types from being constructed.
+    /// </remarks>
+    internal sealed class SafeMessagePackSerializerOptions : MessagePackSerializerOptions
+    {
+        /// <summary>
+        /// Initializes a new instance with the specified resolver.
+        /// </summary>
+        /// <param name="resolver">The formatter resolver to use.</param>
+        public SafeMessagePackSerializerOptions(IFormatterResolver resolver)
+            : base(resolver)
+        {
+        }
+
+        /// <summary>
+        /// Copy constructor used by <see cref="Clone"/>.
+        /// </summary>
+        private SafeMessagePackSerializerOptions(SafeMessagePackSerializerOptions copyFrom)
+            : base(copyFrom)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override MessagePackSerializerOptions Clone()
+            => new SafeMessagePackSerializerOptions(this);
+
+        /// <summary>
+        /// Validates that the type is allowed for deserialization before object instantiation.
+        /// Called by <see cref="MessagePack.Formatters.TypelessFormatter"/> during deserialization.
+        /// </summary>
+        /// <param name="type">The type about to be instantiated.</param>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when <paramref name="type"/> is not in the allowed whitelist.
+        /// </exception>
+        public override void ThrowIfDeserializingTypeIsDisallowed(Type type)
+        {
+            // Apply the built-in blocklist first (known-dangerous types)
+            base.ThrowIfDeserializingTypeIsDisallowed(type);
+
+            var fullName = type.FullName;
+            if (fullName == null)
+                throw new InvalidOperationException("Cannot deserialize a type with no FullName.");
+
+            if (!SafeTypelessFormatter.IsTypeAllowed(fullName))
+            {
+                throw new InvalidOperationException(
+                    $"MessagePack deserialization blocked: type '{fullName}' is not in the allowed type whitelist.");
+            }
+        }
+    }
+}

--- a/src/Bee.Base/SysInfo.cs
+++ b/src/Bee.Base/SysInfo.cs
@@ -13,7 +13,7 @@ namespace Bee.Base
         static SysInfo()
         {
             // Add the default allowed type namespaces for JSON-RPC data transfer
-            AllowedTypeNamespaces = new List<string> { "Bee.Base", "Bee.Definition", "Bee.Contracts" };
+            _allowedTypeNamespaces = new List<string> { "Bee.Base", "Bee.Definition", "Bee.Contracts" };
         }
 
         /// <summary>
@@ -52,11 +52,17 @@ namespace Bee.Base
         public static bool IsSingleFile { get; set; } = false;
 
         /// <summary>
-        /// Gets or sets the list of type namespaces allowed for JSON-RPC data transfer.
-        /// Only types in these namespaces are permitted for deserialization to ensure security.
-        /// Note: Bee.Base and Bee.Definition are built-in default namespaces and do not need to be specified.
+        /// Backing field for <see cref="AllowedTypeNamespaces"/>.
         /// </summary>
-        public static List<string> AllowedTypeNamespaces { get; set; }
+        private static List<string> _allowedTypeNamespaces;
+
+        /// <summary>
+        /// Gets the list of type namespaces allowed for JSON-RPC data transfer (read-only).
+        /// Only types in these namespaces are permitted for deserialization to ensure security.
+        /// Use <see cref="Initialize"/> to configure custom namespaces.
+        /// Note: Bee.Base, Bee.Definition, and Bee.Contracts are built-in default namespaces and do not need to be specified.
+        /// </summary>
+        public static IReadOnlyList<string> AllowedTypeNamespaces => _allowedTypeNamespaces;
 
         /// <summary>
         /// Validates whether the specified type name is in an allowed namespace.
@@ -81,7 +87,7 @@ namespace Bee.Base
         {
             Version = configuration.Version;
             IsDebugMode = configuration.IsDebugMode;
-            AllowedTypeNamespaces = BuildAllowedTypeNamespaces(configuration.AllowedTypeNamespaces);
+            _allowedTypeNamespaces = BuildAllowedTypeNamespaces(configuration.AllowedTypeNamespaces);
         }
 
         /// <summary>
@@ -89,10 +95,11 @@ namespace Bee.Base
         /// </summary>
         /// <param name="customNamespaces">User-defined namespace string, separated by '|'.</param>
         /// <returns>List of namespaces including system default and user-defined.</returns>
-        public static List<string> BuildAllowedTypeNamespaces(string customNamespaces)
+        internal static List<string> BuildAllowedTypeNamespaces(string customNamespaces)
         {
-            // Initialize HashSet to ensure no duplicates
-            var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            // Initialize HashSet to ensure no duplicates.
+            // Use Ordinal comparison to match .NET type name semantics (case-sensitive).
+            var allowed = new HashSet<string>(StringComparer.Ordinal)
             {
                 "Bee.Base",
                 "Bee.Definition",

--- a/src/Bee.Definition/Serialization/SafeTypelessFormatter.cs
+++ b/src/Bee.Definition/Serialization/SafeTypelessFormatter.cs
@@ -11,6 +11,24 @@ namespace Bee.Definition.Serialization
     /// against the allowed namespace whitelist defined in <see cref="SysInfo.IsTypeNameAllowed"/>.
     /// Prevents deserialization of arbitrary types to mitigate remote code execution risks.
     /// </summary>
+    /// <remarks>
+    /// This formatter applies two layers of defense:
+    /// <list type="number">
+    ///   <item>
+    ///     <description>
+    ///       <b>Pre-instantiation:</b> A custom <see cref="MessagePackSerializerOptions"/> override of
+    ///       <see cref="MessagePackSerializerOptions.ThrowIfDeserializingTypeIsDisallowed"/>
+    ///       validates the type BEFORE object construction inside <see cref="TypelessFormatter"/>.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///       <b>Post-instantiation (defense-in-depth):</b> After <see cref="TypelessFormatter"/> returns,
+    ///       this formatter validates the resulting object's type as a second safety net.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// </remarks>
     public sealed class SafeTypelessFormatter : IMessagePackFormatter<object>
     {
         /// <summary>
@@ -41,9 +59,7 @@ namespace Bee.Definition.Serialization
             "System.TimeSpan",
             "System.Guid",
             "System.Byte[]",
-            "System.DBNull",
-            "System.Data.DataTable",
-            "System.Data.DataRow"
+            "System.DBNull"
         };
 
         /// <summary>
@@ -64,6 +80,11 @@ namespace Bee.Definition.Serialization
         /// Deserializes an object value using the underlying <see cref="TypelessFormatter"/>,
         /// then validates the resulting type against the allowed type whitelist.
         /// </summary>
+        /// <remarks>
+        /// The primary pre-instantiation check is performed by the
+        /// <see cref="MessagePackSerializerOptions.ThrowIfDeserializingTypeIsDisallowed"/> override
+        /// inside <see cref="TypelessFormatter"/>. This post-deserialization check serves as a defense-in-depth safety net.
+        /// </remarks>
         /// <exception cref="InvalidOperationException">
         /// Thrown when the deserialized type is not in the allowed whitelist.
         /// </exception>
@@ -75,12 +96,30 @@ namespace Bee.Definition.Serialization
 
             var result = TypelessFormatter.Instance.Deserialize(ref reader, options);
 
+            // Defense-in-depth: validate the deserialized type even though
+            // SafeMessagePackSerializerOptions already performs pre-instantiation checks.
             if (result != null)
             {
                 ValidateType(result.GetType());
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Validates whether the specified type full name is in the allowed whitelist.
+        /// Used by both the formatter (post-check) and <see cref="SafeMessagePackSerializerOptions"/> (pre-check).
+        /// </summary>
+        /// <param name="fullName">The full name of the type to validate.</param>
+        /// <returns><c>true</c> if the type is allowed; otherwise, <c>false</c>.</returns>
+        public static bool IsTypeAllowed(string fullName)
+        {
+            // Allow well-known primitive types
+            if (AllowedPrimitiveTypes.Contains(fullName))
+                return true;
+
+            // Delegate to the application-level namespace whitelist
+            return SysInfo.IsTypeNameAllowed(fullName);
         }
 
         /// <summary>
@@ -93,16 +132,11 @@ namespace Bee.Definition.Serialization
             if (fullName == null)
                 throw new InvalidOperationException("Cannot deserialize a type with no FullName.");
 
-            // Allow well-known primitive types
-            if (AllowedPrimitiveTypes.Contains(fullName))
-                return;
-
-            // Delegate to the application-level whitelist
-            if (SysInfo.IsTypeNameAllowed(fullName))
-                return;
-
-            throw new InvalidOperationException(
-                $"MessagePack deserialization blocked: type '{fullName}' is not in the allowed type whitelist.");
+            if (!IsTypeAllowed(fullName))
+            {
+                throw new InvalidOperationException(
+                    $"MessagePack deserialization blocked: type '{fullName}' is not in the allowed type whitelist.");
+            }
         }
     }
 }

--- a/tests/Bee.Api.Core.UnitTests/SafeTypelessFormatterTests.cs
+++ b/tests/Bee.Api.Core.UnitTests/SafeTypelessFormatterTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Bee.Api.Core.MessagePack;
 using Bee.Definition.Collections;
+using Bee.Definition.Serialization;
 
 namespace Bee.Api.Core.UnitTests
 {
@@ -49,6 +50,37 @@ namespace Bee.Api.Core.UnitTests
             var restoredChild = restored["Child"].Value as ParameterCollection;
             Assert.NotNull(restoredChild);
             Assert.Equal("value", restoredChild["Nested"].Value);
+        }
+
+        [Theory]
+        [InlineData("System.Int32", true)]
+        [InlineData("System.String", true)]
+        [InlineData("System.Boolean", true)]
+        [InlineData("System.Decimal", true)]
+        [InlineData("System.DateTime", true)]
+        [InlineData("System.Guid", true)]
+        [InlineData("System.Byte[]", true)]
+        [InlineData("System.DBNull", true)]
+        [InlineData("Bee.Base.SomeClass", true)]
+        [InlineData("Bee.Definition.Collections.Parameter", true)]
+        [InlineData("Bee.Contracts.SomeDto", true)]
+        [DisplayName("IsTypeAllowed 應允許原始型別與白名單命名空間")]
+        public void IsTypeAllowed_AllowedTypes_ReturnsTrue(string fullName, bool expected)
+        {
+            Assert.Equal(expected, SafeTypelessFormatter.IsTypeAllowed(fullName));
+        }
+
+        [Theory]
+        [InlineData("System.Diagnostics.Process")]
+        [InlineData("System.IO.FileInfo")]
+        [InlineData("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter")]
+        [InlineData("Evil.Namespace.Exploit")]
+        [InlineData("System.Data.DataTable")]
+        [InlineData("System.Data.DataRow")]
+        [DisplayName("IsTypeAllowed 應拒絕不在白名單的型別")]
+        public void IsTypeAllowed_DisallowedTypes_ReturnsFalse(string fullName)
+        {
+            Assert.False(SafeTypelessFormatter.IsTypeAllowed(fullName));
         }
     }
 }

--- a/tests/Bee.Base.UnitTests/SysInfoSecurityTests.cs
+++ b/tests/Bee.Base.UnitTests/SysInfoSecurityTests.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+
+namespace Bee.Base.UnitTests
+{
+    /// <summary>
+    /// SysInfo 型別白名單安全性測試
+    /// </summary>
+    public class SysInfoSecurityTests
+    {
+        [Theory]
+        [InlineData("Bee.Base.SomeClass", true)]
+        [InlineData("Bee.Definition.Collections.Parameter", true)]
+        [InlineData("Bee.Contracts.MyDto", true)]
+        [InlineData("System.Byte[]", true)]
+        [DisplayName("IsTypeNameAllowed 應允許白名單內的型別")]
+        public void IsTypeNameAllowed_AllowedTypes_ReturnsTrue(string typeName, bool expected)
+        {
+            Assert.Equal(expected, SysInfo.IsTypeNameAllowed(typeName));
+        }
+
+        [Theory]
+        [InlineData("System.Diagnostics.Process")]
+        [InlineData("System.IO.FileInfo")]
+        [InlineData("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter")]
+        [InlineData("Evil.Namespace.Exploit")]
+        [InlineData("Bee")]
+        [InlineData("BeeBase.SomeClass")]
+        [DisplayName("IsTypeNameAllowed 應拒絕白名單外的型別")]
+        public void IsTypeNameAllowed_DisallowedTypes_ReturnsFalse(string typeName)
+        {
+            Assert.False(SysInfo.IsTypeNameAllowed(typeName));
+        }
+
+        [Fact]
+        [DisplayName("IsTypeNameAllowed 前綴比對應精確匹配命名空間分隔符")]
+        public void IsTypeNameAllowed_PrefixMustMatchNamespaceBoundary()
+        {
+            // "Bee.Base" is allowed, but "Bee.BaseExtra" should NOT match
+            Assert.True(SysInfo.IsTypeNameAllowed("Bee.Base.SomeClass"));
+            Assert.False(SysInfo.IsTypeNameAllowed("Bee.BaseExtra.SomeClass"));
+        }
+
+        [Fact]
+        [DisplayName("AllowedTypeNamespaces 應為唯讀，不可被外部替換")]
+        public void AllowedTypeNamespaces_IsReadOnly()
+        {
+            var list = SysInfo.AllowedTypeNamespaces;
+            Assert.NotNull(list);
+            Assert.IsAssignableFrom<IReadOnlyList<string>>(list);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **[嚴重]** 新增 `SafeMessagePackSerializerOptions`，覆寫 `ThrowIfDeserializingTypeIsDisallowed` 在 `TypelessFormatter` 實例化物件**之前**套用白名單檢查，修補原本 deserialize-then-validate 的安全缺口
- **[中等]** 從 `SafeTypelessFormatter.AllowedPrimitiveTypes` 移除 `DataTable`/`DataRow`（已有專屬 Formatter 處理）
- **[中等]** `SysInfo.AllowedTypeNamespaces` 改為 `IReadOnlyList<string>` 防止執行期被竄改
- **[低]** `BuildAllowedTypeNamespaces` 統一為 `StringComparer.Ordinal`，與型別名稱比對語意一致
- 新增 `SysInfoSecurityTests` 與擴充 `SafeTypelessFormatterTests` 涵蓋白名單驗證

## Test plan

- [ ] `SafeTypelessFormatterTests` — 原始型別與 Bee 命名空間往返序列化、`IsTypeAllowed` 允許/拒絕驗證
- [ ] `SysInfoSecurityTests` — `IsTypeNameAllowed` 白名單/黑名單、前綴精確匹配、唯讀性驗證
- [ ] 執行 `dotnet test` 確認無回歸

https://claude.ai/code/session_01K5MvijCBMzHD6EToQgsLby