### PR TITLE
fix(Bee.Definition): prevent file-lock race in MasterKeyProvider

### DIFF
--- a/src/Bee.Definition/Security/MasterKeyProvider.cs
+++ b/src/Bee.Definition/Security/MasterKeyProvider.cs
@@ -1,6 +1,7 @@
 using Bee.Definition.Settings;
 using System;
 using System.IO;
+using System.Threading;
 using Bee.Base;
 using Bee.Base.Security;
 
@@ -11,6 +12,9 @@ namespace Bee.Definition.Security
     /// </summary>
     public static class MasterKeyProvider
     {
+        private const int ReadRetryCount = 5;
+        private const int ReadRetryDelayMs = 50;
+
         /// <summary>
         /// Gets the master key content.
         /// </summary>
@@ -69,16 +73,53 @@ namespace Bee.Definition.Security
 
             if (!File.Exists(filePath))
             {
-                if (autoCreate)
+                if (!autoCreate)
+                    throw new FileNotFoundException("Master key file not found: " + filePath);
+
+                // Atomically create the file so concurrent callers (e.g. parallel test hosts
+                // sharing a Define folder) don't overwrite each other's keys. If another
+                // process wins the race, fall through to read the key it just wrote.
+                string newKey = GenerateNewKey();
+                try
                 {
-                    string newKey = GenerateNewKey();
-                    File.WriteAllText(filePath, newKey);
+                    using (var fs = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                    using (var writer = new StreamWriter(fs))
+                    {
+                        writer.Write(newKey);
+                    }
                     return newKey;
                 }
-                throw new FileNotFoundException("Master key file not found: " + filePath);
+                catch (IOException)
+                {
+                    // Another process created the file between our File.Exists check and
+                    // FileMode.CreateNew; fall through to read the winning key.
+                }
             }
 
-            return File.ReadAllText(filePath);
+            return ReadAllTextShared(filePath);
+        }
+
+        /// <summary>
+        /// Reads the entire file with <see cref="FileShare.ReadWrite"/> so concurrent
+        /// readers do not collide with the brief write/truncate lock held by another
+        /// process during file creation. Retries on transient <see cref="IOException"/>.
+        /// </summary>
+        /// <param name="filePath">The file path.</param>
+        private static string ReadAllTextShared(string filePath)
+        {
+            for (int attempt = 0; ; attempt++)
+            {
+                try
+                {
+                    using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using var reader = new StreamReader(fs);
+                    return reader.ReadToEnd();
+                }
+                catch (IOException) when (attempt < ReadRetryCount - 1)
+                {
+                    Thread.Sleep(ReadRetryDelayMs);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

修復 Windows CI 偶發失敗：

```
System.IO.IOException: The process cannot access the file
'D:\a\bee-library\bee-library\tests\Define\Master.key' because it is
being used by another process.
  at MasterKeyProvider.LoadFromFile (src/Bee.Definition/Security/MasterKeyProvider.cs:81)
  ...
  at Bee.Tests.Shared.GlobalFixture..ctor
```

`dotnet test Bee.Library.slnx` 預設併行執行多個測試組件（`Bee.Api.AspNetCore.UnitTests`、`Bee.Api.Client.UnitTests`、`Bee.Api.Core.UnitTests` 都繼承 `Bee.Tests.Shared.GlobalFixture`），三個 host process 同時呼叫 `BackendInfo.Initialize(autoCreate: true)` 進而觸發 `MasterKeyProvider.LoadFromFile` 時會有三處競態：

1. `File.Exists(path)` + `File.WriteAllText(path, key)` 是典型 TOCTOU，兩個 process 都認為檔案不存在就互相覆寫 master key。
2. `File.WriteAllText` 內部對新建檔案持短暫獨占鎖，與併行 `File.ReadAllText`（預設 `FileShare.Read`）的存取窗口不相容。
3. 無任何重試，瞬時 IO 干擾直接拋例外中止整個 fixture。

## Changes

- `autoCreate` 分支改用 `FileMode.CreateNew` 原子建立，輸家（`IOException`）直接 fall through 讀取贏家剛寫入的 key。
- 新增 `ReadAllTextShared(filePath)`：用 `FileStream(path, Open, Read, FileShare.ReadWrite)` 與 writer 的 `FileShare.Read` 共存。
- 加入短重試（5 × 50ms）僅吞 `IOException`，符合 `scanning.md` 對例外型別的要求。

## Test plan

- [ ] 觀察合併後 `build-ci.yml` 能穩定通過，特別是 `Bee.Api.AspNetCore.UnitTests` / `Bee.Api.Client.UnitTests` / `Bee.Api.Core.UnitTests` 併行執行時不再撞鎖。
- [ ] 本地以 `dotnet test Bee.Library.slnx -c Release` 連續執行數次確認無 regression（deleted `tests/Define/Master.key` 模擬首次啟動場景）。
- [ ] `Bee.Definition.UnitTests.SecurityKeysTests.InitializeSecurityKeys_ValidMasterKey_DecryptsKeysCorrectly` 仍通過，驗證單執行緒正常路徑無 regression。

https://claude.ai/code/session_01N8B1cEFM25groPFmhbi91p