### PR TITLE
test(Bee.Definition): 依計畫書補齊 P0/P1/P2 測試覆蓋

### DIFF
--- a/docs/plans/plan-bee-definition-test-coverage.md
+++ b/docs/plans/plan-bee-definition-test-coverage.md
@@ -1,0 +1,216 @@
+# Bee.Definition 測試覆蓋率提升計畫書
+
+## 1. 背景與目標
+
+`Bee.Definition` 是 Bee.NET 框架的定義中樞層，承載 FormSchema、TableSchema、FormLayout 等跨層資料契約（DTO），並定義各類列舉、常數、系統介面與序列化集合。它被 `Bee.Business`、`Bee.Api.Core`、`Bee.Repository` 等所有上層專案相依，其 DTO 的序列化正確性、資料結構完整性、集合語意皆為框架執行時正確性的基礎。
+
+目前測試檔僅 4 個（`DefineFuncTests`、`DefinitionSerializationTests`、`FormSchemaTests`、`SecurityKeysTests`），對應源碼超過 60 個公開型別，覆蓋顯著不足。
+
+**目標**：
+
+1. 補齊 `Bee.Definition` 具邏輯的 DTO／公開工具函式的單元測試，使 SonarCloud 顯示該專案的 Line Coverage 達成 **≥ 75%**。
+2. 所有具備可測試邏輯的 `public` 類別（建構子驗證、方法分支、序列化契約）至少有一個對應測試檔。
+3. FormSchema、TableSchema、FormLayout、Filter 等核心 DTO 的 MessagePack / XML / JSON 序列化 round-trip 路徑必須 **100%** 覆蓋。
+4. 不新增任何依賴資料庫、網路或檔案系統（mutable state）的測試；檔案 I／O 測試一律使用臨時目錄（`Path.GetTempPath()`），並在測試結束後清理。
+5. 安全相關類別（`EncryptionKeyProtector`、`MasterKeyProvider`）需涵蓋**錯誤路徑**（金鑰無效、來源缺失、已破壞的資料）。
+
+## 2. 現況盤點
+
+圖例：✅ 已完整覆蓋 / ⚠ 部分覆蓋 / ❌ 完全無測試 / n/a 不需測試（介面／純常數）
+
+### 2.1 根目錄（Top-Level）
+
+| 類別 | 類型 | 狀態 | 備註 |
+|------|------|------|------|
+| `DefineFunc` | static utility | ⚠ | 僅 `GetDefineType` 3 種情境；另 4 個方法未測 |
+| `DefinePathInfo` | static utility | ❌ | 7 個路徑組合方法完全未測 |
+| `SessionInfo` | DTO | ❌ | 實作 `IKeyObject`、`IUserInfo`；序列化、`ToString()` 未測 |
+| `SessionUser` | DTO | ❌ | 序列化 round-trip 未測 |
+| `UserInfo` | DTO | ❌ | 屬性賦值、`IUserInfo` 契約未測 |
+| `BackendInfo` | static config | ❌ | `Initialize`／元件建立邏輯未測 |
+| `WebsiteInfo` | static (placeholder) | n/a | 檔案為空 |
+| `SortField` | DTO | ❌ | 建構子參數驗證（`ArgumentException`）未測 |
+| `SortFieldCollection` | collection | ❌ | 新增／移除／序列化未測 |
+| 20＋ 純 `enum` 與常數類 | — | n/a | `SysFields`、`SysProgIds`、`SystemActions` 等，不具邏輯 |
+| 10＋ `I*` 介面 | — | n/a | 介面本身不測，由實作方覆蓋 |
+
+### 2.2 Attributes
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `ApiAccessControlAttribute` | ❌ | 建構子、`ProtectionLevel`／`AccessRequirement` 值繫結未測 |
+
+### 2.3 Collections
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `MessagePackCollectionBase` / `MessagePackCollectionItem` | ❌ | 基底類別行為（Owner、索引）未測 |
+| `MessagePackKeyCollectionBase` / `MessagePackKeyCollectionItem` | ❌ | Key lookup、重複 key 行為未測 |
+| `ListItem` / `ListItemCollection` | ⚠ | 僅序列化 round-trip；查詢／變更操作未測 |
+| `Parameter` / `ParameterCollection` | ⚠ | 僅序列化 round-trip；`DataTable`／`DataSet` 值轉換未測 |
+| `Property` / `PropertyCollection` | ❌ | 完全未測 |
+
+### 2.4 Database
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `DbField` / `DbFieldCollection` | ❌ | 欄位屬性、`IDefineField` 實作未測 |
+| `IndexField` / `IndexFieldCollection` | ❌ | 索引欄位設定未測 |
+| `TableSchema` / `TableSchemaIndex` / `TableSchemaIndexCollection` | ❌ | DTO 結構、序列化未測 |
+| `TableSchemaGenerator` | ❌ | 從 `FormSchema` 生成 `TableSchema` 的轉換邏輯未測 |
+| `IDefineField`（介面） | n/a | — |
+
+### 2.5 Filters
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `FilterCondition` | ⚠ | 僅在 `FilterGroup` round-trip 間接覆蓋；建構子、屬性未直接測 |
+| `FilterGroup` | ⚠ | 僅序列化；`LogicalOperator`、巢狀巢套層級未測 |
+| `FilterNode` | ⚠ | 間接覆蓋；`FilterNodeKind` 各分支未測 |
+| `FilterNodeCollection` | ⚠ | 間接覆蓋 |
+| `FilterNodeCollectionJsonConverter` | ⚠ | 僅正向 round-trip；錯誤 JSON 輸入未測 |
+
+### 2.6 Forms
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `FormField` / `FormFieldCollection` | ⚠ | `FormSchemaTests` 間接覆蓋結構；屬性邊界未測 |
+| `FormSchema` | ⚠ | 2 個 scenario 測試；序列化、欄位查找未測 |
+| `FormTable` / `FormTableCollection` | ⚠ | 間接覆蓋 |
+| `FieldMapping` / `FieldMappingCollection` | ❌ | 完全未測 |
+| `RelationFieldReference` / `RelationFieldReferenceCollection` | ⚠ | 間接覆蓋 |
+
+### 2.7 Layouts
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `FormLayout` | ❌ | 序列化、基本結構未測 |
+| `FormLayoutGenerator` | ❌ | 從 `FormSchema` 生成 layout 的邏輯未測 |
+| `LayoutColumn` / `LayoutColumnCollection` | ❌ | 欄位寬度、格式化屬性未測 |
+| `LayoutGrid` | ❌ | Columns 集合新增未測 |
+| `LayoutGroup` / `LayoutGroupCollection` | ❌ | 巢狀結構未測 |
+| `LayoutItem` / `LayoutItemBase` / `LayoutItemCollection` | ❌ | 完全未測 |
+
+### 2.8 Logging
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `LogEntry` | ❌ | 屬性、`DateTimeKind` 設定未測 |
+| `LogOptions` / `DbAccessAnomalyLogOptions` | ❌ | 預設值、屬性未測 |
+| `ConsoleLogWriter` | ❌ | 寫入格式、`ILogWriter` 契約未測 |
+| `NullLogWriter` | ❌ | Null Object 行為未測 |
+
+### 2.9 Security
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `EncryptionKeyProtector` | ⚠ | 僅正向解密（`SecurityKeysTests`）；錯誤金鑰、毀損資料未測 |
+| `MasterKeyProvider` | ⚠ | 正向路徑覆蓋；`MasterKeySourceType` 各來源、缺失情境未測 |
+| 3 個 `I*` 介面 | n/a | — |
+
+### 2.10 Serialization
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `SafeTypelessFormatter` | ❌ | MessagePack 型別白名單／黑名單、`SysInfo` 整合未測 |
+
+### 2.11 Settings（六個子命名空間）
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `SystemSettings` | ⚠ | 僅 XML round-trip；各子屬性結構未測 |
+| `DatabaseSettings`、`DbSchemaSettings`、`ProgramSettings`、`ClientSettings`、`MenuSettings` | ❌ | 預設值、序列化未測 |
+
+### 2.12 Storage
+
+| 類別 | 狀態 | 備註 |
+|------|------|------|
+| `FileDefineStorage` | ❌ | 讀取／寫入／不存在／權限錯誤情境未測 |
+| `IDefineStorage`（介面） | n/a | — |
+
+## 3. 優先級分類
+
+依「影響面 × 邏輯複雜度」分三級，依序執行。
+
+### P0 — 關鍵路徑（必做，影響所有上層專案）
+
+1. **`DefineFunc`**：`GetNumberFormatString`、`ToColumnControlType`（internal，需 `InternalsVisibleTo`）、`ToLayoutColumn`、`GetListLayout`、`GetDefineType` 的無效值分支。
+2. **`DefinePathInfo`**：7 個路徑方法 × 至少一個 assert，確認路徑組合格式（使用臨時 `BackendInfo.DefinePath`）。
+3. **核心 DTO 序列化 round-trip**（XML + JSON + MessagePack 三軌並行）：
+   - `SortField` / `SortFieldCollection`
+   - `FormSchema`（完整巢狀：Tables → Fields）
+   - `TableSchema`（含 Indexes）
+   - `FormLayout`（含 Grid / Group / Column 巢狀）
+   - `DatabaseSettings`、`DbSchemaSettings`、`ProgramSettings`、`ClientSettings`
+4. **`SortField` 建構子**：空字串、`null`、純空白應拋 `ArgumentException`。
+5. **`FilterGroup` / `FilterCondition` / `FilterNode`**：各 `FilterNodeKind`、`ComparisonOperator`、`LogicalOperator` 的分支；深度巢狀（≥ 3 層）序列化。
+
+### P1 — 高價值邏輯（次做）
+
+6. **`TableSchemaGenerator`**：從 `FormSchema` 生成 `TableSchema` 的欄位映射、主鍵推導、型別轉換。
+7. **`FormLayoutGenerator`**：從 `FormSchema` 生成預設 layout 的欄位順序、分組規則。
+8. **`MessagePackKeyCollectionBase`**：Key 查找、重複 key（預期例外或覆蓋）、`TryGetValue` 語意。
+9. **`EncryptionKeyProtector` 錯誤路徑**：金鑰長度錯誤、HMAC 驗證失敗、Base64 格式錯誤。
+10. **`MasterKeyProvider`**：`MasterKeySourceType.EnvironmentVariable` 與 `File` 各來源的讀取、缺失時的例外型別。
+11. **`FileDefineStorage`**：讀取不存在的檔案、寫入後回讀、序列化格式一致性（XML only）。
+12. **`SafeTypelessFormatter`**：允許的型別可 round-trip、`SysInfo` 黑名單型別被拒絕並拋出預期例外。
+
+### P2 — 補完覆蓋（完成後達標）
+
+13. **集合類完整操作**：`ListItemCollection`、`ParameterCollection`、`PropertyCollection`、`DbFieldCollection`、`FieldMappingCollection` 的 `Add` / `Remove` / `Clear` / `Contains` / 索引器。
+14. **DTO 屬性測試**：`SessionInfo`、`SessionUser`、`UserInfo`、`LogEntry`、`LogOptions`、`DbAccessAnomalyLogOptions` 的預設值、屬性 setter / getter、`ToString()`。
+15. **`ApiAccessControlAttribute`**：建構子組合（4 種 `ProtectionLevel` × 2 種 `AccessRequirement`）。
+16. **`ConsoleLogWriter` / `NullLogWriter`**：用 `StringWriter` 重導 `Console.Out` 驗證輸出；`NullLogWriter` 不產生副作用。
+
+## 4. 執行步驟
+
+1. **建立測試檔骨架**：依資料夾鏡射新增測試檔，命名為 `<類別名>Tests.cs`。例：
+   - `tests/Bee.Definition.UnitTests/DefinePathInfoTests.cs`
+   - `tests/Bee.Definition.UnitTests/Collections/ListItemCollectionTests.cs`
+   - `tests/Bee.Definition.UnitTests/Filters/FilterGroupTests.cs`
+2. **共用 fixture**：在 `Bee.Tests.Shared` 或本專案內新增 `DefinitionTestData` 靜態類，提供最小可用的 `FormSchema`、`TableSchema`、`FormLayout` 建構 helper，避免每個測試重複 30 行物件建構。
+3. **序列化 round-trip helper**：若 `Bee.Tests.Shared` 尚未有，新增 `SerializationRoundtripHelper`，泛型 API：`AssertXmlRoundtrip<T>(T)`、`AssertJsonRoundtrip<T>(T)`、`AssertMessagePackRoundtrip<T>(T)`。使用 `FluentAssertions` 或 `Assert.Equivalent` 比較結構。
+4. **Internal 成員可測**：確認 `Bee.Definition.csproj` 已設定 `InternalsVisibleTo("Bee.Definition.UnitTests")`；若無則新增於 `AssemblyInfo.cs` 或 csproj `<ItemGroup>`。
+5. **檔案 I/O 測試**：一律使用 `Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())` 建立隔離目錄，以 `IDisposable` fixture（`IAsyncLifetime`）清理；**不得**汙染 repo 的 `definition/` 目錄。
+6. **CI 相容**：涉及本機 DB／服務的測試用 `[LocalOnlyFact]`；本計畫目標應 **無** 此類測試（純 DTO／邏輯）。
+7. **執行驗證**：每批 P0／P1／P2 完成後執行：
+   ```bash
+   dotnet test tests/Bee.Definition.UnitTests/Bee.Definition.UnitTests.csproj \
+     --configuration Release --settings .runsettings \
+     --collect:"XPlat Code Coverage"
+   ```
+   回報新增測試數、當前行覆蓋率。
+
+## 5. 命名與品質要求
+
+- 測試方法命名：`<方法名>_<情境>_<預期結果>`（遵循 `.claude/rules/testing.md`）。
+- 所有測試加 `[DisplayName]` 中文描述。
+- `[Theory]` 優先於多個重複的 `[Fact]`，降低樣板碼。
+- 每個測試只驗證一個行為；避免多重 `Assert` 混驗。
+- 遵循 `sonarcloud.md` S2701：`Assert.True/False` 不可傳字面值。
+- 遵循 `code-style.md`：4 空格縮排、UTF-8 無 BOM、LF 行結尾。
+- 新增的 helper 類如設計為純 static，須加 `private` 建構子或改為 `static class`（S1118／S3442）。
+
+## 6. 驗收條件
+
+1. `dotnet test` 全部通過（本機 + CI）。
+2. `Bee.Definition` 專案 SonarCloud Line Coverage ≥ 75%。
+3. 所有列為 P0、P1 的類別至少一個測試檔存在。
+4. 無 `#pragma warning disable`、無跳過（`Skip=...`）測試（本機專屬情境除外）。
+5. 新增測試不引入對 `Bee.Repository`、`Bee.Api.*` 的相依（保持 `Bee.Definition` 測試獨立於上層）。
+
+## 7. 預估工作量
+
+| 階段 | 新增測試檔 | 測試方法數（概估） | 工時 |
+|------|-----------|-------------------|------|
+| P0 | 8–10 | 60–80 | 1.0 人日 |
+| P1 | 6–8 | 40–60 | 0.8 人日 |
+| P2 | 10–12 | 50–70 | 0.7 人日 |
+| **合計** | **24–30** | **150–210** | **2.5 人日** |
+
+## 8. 風險與備註
+
+- **MessagePack `[Serializable]` 結合**：部分 DTO（如 `SortField`）同時標記 `[MessagePackObject]` 與 `[Serializable]`，序列化測試需涵蓋三條獨立路徑，注意 `[Key]` 編號變更會破壞相容性。
+- **`InternalsVisibleTo`**：`DefineFunc.ToColumnControlType`、`ToLayoutColumn`、`GetListLayout` 為 `internal`；若未設定，需補設定或透過 `GetListLayout` 的公開入口間接測試。
+- **`BackendInfo` 全域狀態**：`BackendInfo.DefinePath` 為 process-wide 可變狀態，測試需使用 `[Collection("Initialize")]` 串接 `GlobalFixture` 避免平行測試相互干擾，或改以可注入的方式（若需重構，另案處理）。
+- **SonarCloud 覆蓋率計算**：以 `coverlet.collector` 產出的 `coverage.cobertura.xml` 為準；純 enum 與介面檔不計入行覆蓋率分母，實際達成 75% 的可行性高。

--- a/tests/Bee.Definition.UnitTests/Attributes/ApiAccessControlAttributeTests.cs
+++ b/tests/Bee.Definition.UnitTests/Attributes/ApiAccessControlAttributeTests.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using Bee.Definition.Attributes;
+
+namespace Bee.Definition.UnitTests.Attributes
+{
+    /// <summary>
+    /// ApiAccessControlAttribute 建構子與屬性測試。
+    /// </summary>
+    public class ApiAccessControlAttributeTests
+    {
+        [Theory]
+        [InlineData(ApiProtectionLevel.Public, ApiAccessRequirement.Anonymous)]
+        [InlineData(ApiProtectionLevel.Encoded, ApiAccessRequirement.Authenticated)]
+        [InlineData(ApiProtectionLevel.Encrypted, ApiAccessRequirement.Authenticated)]
+        [DisplayName("建構子應將 ProtectionLevel 與 AccessRequirement 原樣儲存")]
+        public void Constructor_SetsProperties(ApiProtectionLevel level, ApiAccessRequirement requirement)
+        {
+            // Act
+            var attr = new ApiAccessControlAttribute(level, requirement);
+
+            // Assert
+            Assert.Equal(level, attr.ProtectionLevel);
+            Assert.Equal(requirement, attr.AccessRequirement);
+        }
+
+        [Fact]
+        [DisplayName("建構子省略 AccessRequirement 時預設應為 Authenticated")]
+        public void Constructor_DefaultAccessRequirement_IsAuthenticated()
+        {
+            // Act
+            var attr = new ApiAccessControlAttribute(ApiProtectionLevel.Encrypted);
+
+            // Assert
+            Assert.Equal(ApiAccessRequirement.Authenticated, attr.AccessRequirement);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Collections/ListItemCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Collections/ListItemCollectionTests.cs
@@ -1,0 +1,73 @@
+using System.ComponentModel;
+using System.Data;
+using Bee.Definition.Collections;
+
+namespace Bee.Definition.UnitTests.Collections
+{
+    /// <summary>
+    /// ListItem 與 ListItemCollection 測試。
+    /// </summary>
+    public class ListItemCollectionTests
+    {
+        [Fact]
+        [DisplayName("ListItem 建構子應正確設定 Value 與 Text")]
+        public void ListItem_Constructor_SetsValueAndText()
+        {
+            // Act
+            var item = new ListItem("01", "項目一");
+
+            // Assert
+            Assert.Equal("01", item.Value);
+            Assert.Equal("項目一", item.Text);
+        }
+
+        [Fact]
+        [DisplayName("ListItem ToString 應回傳 Text")]
+        public void ListItem_ToString_ReturnsText()
+        {
+            // Arrange
+            var item = new ListItem("01", "項目一");
+
+            // Act & Assert
+            Assert.Equal("項目一", item.ToString());
+        }
+
+        [Fact]
+        [DisplayName("ListItemCollection Add(value,text) 應新增項目並回傳")]
+        public void Add_ValueAndText_AddsAndReturnsItem()
+        {
+            // Arrange
+            var collection = new ListItemCollection();
+
+            // Act
+            var added = collection.Add("A", "Alpha");
+
+            // Assert
+            Assert.Single(collection);
+            Assert.Same(added, collection["A"]);
+            Assert.Equal("Alpha", added.Text);
+        }
+
+        [Fact]
+        [DisplayName("FromTable 應依指定欄位填入 Value 與 Text")]
+        public void FromTable_PopulatesItemsFromDataTable()
+        {
+            // Arrange
+            var table = new DataTable();
+            table.Columns.Add("ValueCol", typeof(string));
+            table.Columns.Add("TextCol", typeof(string));
+            table.Rows.Add("01", "一");
+            table.Rows.Add("02", "二");
+
+            var collection = new ListItemCollection();
+
+            // Act
+            collection.FromTable(table, "ValueCol", "TextCol");
+
+            // Assert
+            Assert.Equal(2, collection.Count);
+            Assert.Equal("一", collection["01"].Text);
+            Assert.Equal("二", collection["02"].Text);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Collections/MessagePackKeyCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Collections/MessagePackKeyCollectionTests.cs
@@ -1,0 +1,139 @@
+using System.ComponentModel;
+using Bee.Definition.Collections;
+
+namespace Bee.Definition.UnitTests.Collections
+{
+    /// <summary>
+    /// MessagePackKeyCollectionBase / MessagePackKeyCollectionItem 行為測試。
+    /// 使用既有 <see cref="Parameter"/> / <see cref="ParameterCollection"/> 作為受測樣本。
+    /// </summary>
+    public class MessagePackKeyCollectionTests
+    {
+        [Fact]
+        [DisplayName("Add 項目後可依索引位置與 Key 取得項目")]
+        public void Add_Item_CanBeRetrievedByKeyAndIndex()
+        {
+            // Arrange
+            var collection = new ParameterCollection
+            {
+                new Parameter("P1", 100),
+                new Parameter("P2", "ABC")
+            };
+
+            // Act
+            var byKey = collection["P2"];
+            var byIndex = collection[0];
+
+            // Assert
+            Assert.Equal("P2", byKey.Name);
+            Assert.Equal("ABC", byKey.Value);
+            Assert.Equal("P1", byIndex.Name);
+        }
+
+        [Fact]
+        [DisplayName("Contains 應回傳 Key 是否存在")]
+        public void Contains_ReturnsWhetherKeyExists()
+        {
+            // Arrange
+            var collection = new ParameterCollection
+            {
+                new Parameter("P1", 1)
+            };
+
+            // Act & Assert
+            Assert.True(collection.Contains("P1"));
+            Assert.False(collection.Contains("missing"));
+        }
+
+        [Fact]
+        [DisplayName("Key 比對應忽略大小寫")]
+        public void Contains_IsCaseInsensitive()
+        {
+            // Arrange
+            var collection = new ParameterCollection
+            {
+                new Parameter("MyParam", 1)
+            };
+
+            // Act & Assert
+            Assert.True(collection.Contains("myparam"));
+            Assert.True(collection.Contains("MYPARAM"));
+        }
+
+        [Fact]
+        [DisplayName("Remove 應移除指定 Key 的項目")]
+        public void Remove_RemovesItemByKey()
+        {
+            // Arrange
+            var collection = new ParameterCollection
+            {
+                new Parameter("P1", 1),
+                new Parameter("P2", 2)
+            };
+
+            // Act
+            collection.Remove("P1");
+
+            // Assert
+            Assert.Single(collection);
+            Assert.False(collection.Contains("P1"));
+            Assert.True(collection.Contains("P2"));
+        }
+
+        [Fact]
+        [DisplayName("Insert 應將項目插入指定位置")]
+        public void Insert_AddsItemAtSpecifiedIndex()
+        {
+            // Arrange
+            var collection = new ParameterCollection
+            {
+                new Parameter("P1", 1),
+                new Parameter("P3", 3)
+            };
+
+            // Act
+            collection.Insert(1, new Parameter("P2", 2));
+
+            // Assert
+            Assert.Equal(3, collection.Count);
+            Assert.Equal("P2", collection[1].Name);
+        }
+
+        [Fact]
+        [DisplayName("Clear 應移除所有項目")]
+        public void Clear_RemovesAllItems()
+        {
+            // Arrange
+            var collection = new ParameterCollection
+            {
+                new Parameter("P1", 1),
+                new Parameter("P2", 2)
+            };
+
+            // Act
+            collection.Clear();
+
+            // Assert
+            Assert.Empty(collection);
+        }
+
+        [Fact]
+        [DisplayName("ItemsForSerialization 取值應回傳目前項目的拷貝")]
+        public void ItemsForSerialization_Get_ReturnsCurrentItems()
+        {
+            // Arrange
+            var collection = new ParameterCollection
+            {
+                new Parameter("P1", 1),
+                new Parameter("P2", 2)
+            };
+
+            // Act
+            var items = collection.ItemsForSerialization;
+
+            // Assert
+            Assert.NotNull(items);
+            Assert.Equal(2, items!.Count);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Collections/ParameterCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Collections/ParameterCollectionTests.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using Bee.Definition.Collections;
+
+namespace Bee.Definition.UnitTests.Collections
+{
+    /// <summary>
+    /// Parameter 與 ParameterCollection 測試。
+    /// </summary>
+    public class ParameterCollectionTests
+    {
+        [Fact]
+        [DisplayName("Parameter 建構子應正確設定 Name 與 Value")]
+        public void Parameter_Constructor_SetsNameAndValue()
+        {
+            // Act
+            var p = new Parameter("Count", 42);
+
+            // Assert
+            Assert.Equal("Count", p.Name);
+            Assert.Equal(42, p.Value);
+        }
+
+        [Fact]
+        [DisplayName("Parameter ToString 應回傳 Name=Value 格式")]
+        public void Parameter_ToString_ReturnsFormattedString()
+        {
+            // Arrange
+            var p = new Parameter("Count", 42);
+
+            // Act
+            var text = p.ToString();
+
+            // Assert
+            Assert.Contains("Count", text);
+            Assert.Contains("42", text);
+        }
+
+        [Fact]
+        [DisplayName("ParameterCollection Add(name,value) 新增項目應可依名稱查詢")]
+        public void Add_NameValue_AddsItem()
+        {
+            // Arrange
+            var collection = new ParameterCollection();
+
+            // Act
+            collection.Add("X", 100);
+
+            // Assert
+            Assert.Single(collection);
+            Assert.Equal(100, collection["X"].Value);
+        }
+
+        [Fact]
+        [DisplayName("ParameterCollection Add 同名應覆寫原值")]
+        public void Add_DuplicateName_ReplacesValue()
+        {
+            // Arrange
+            var collection = new ParameterCollection();
+            collection.Add("X", 100);
+
+            // Act
+            collection.Add("X", 200);
+
+            // Assert
+            Assert.Single(collection);
+            Assert.Equal(200, collection["X"].Value);
+        }
+
+        [Fact]
+        [DisplayName("GetValue<T> 存在應回傳轉型後的值")]
+        public void GetValueT_Existing_ReturnsTypedValue()
+        {
+            // Arrange
+            var collection = new ParameterCollection();
+            collection.Add("Age", 30);
+
+            // Act
+            var value = collection.GetValue<int>("Age");
+
+            // Assert
+            Assert.Equal(30, value);
+        }
+
+        [Fact]
+        [DisplayName("GetValue<T> 不存在應拋出 KeyNotFoundException")]
+        public void GetValueT_Missing_ThrowsKeyNotFoundException()
+        {
+            // Arrange
+            var collection = new ParameterCollection();
+
+            // Act & Assert
+            Assert.Throws<KeyNotFoundException>(() => collection.GetValue<int>("Missing"));
+        }
+
+        [Fact]
+        [DisplayName("GetValue<T> 帶預設值 不存在應回傳預設值")]
+        public void GetValueT_WithDefault_ReturnsDefaultWhenMissing()
+        {
+            // Arrange
+            var collection = new ParameterCollection();
+
+            // Act
+            var value = collection.GetValue<int>("Missing", 99);
+
+            // Assert
+            Assert.Equal(99, value);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Collections/PropertyCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Collections/PropertyCollectionTests.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel;
+using Bee.Definition.Collections;
+
+namespace Bee.Definition.UnitTests.Collections
+{
+    /// <summary>
+    /// Property 與 PropertyCollection 測試。
+    /// </summary>
+    public class PropertyCollectionTests
+    {
+        [Fact]
+        [DisplayName("Property 建構子應正確設定 Name 與 Value")]
+        public void Property_Constructor_SetsNameAndValue()
+        {
+            // Act
+            var prop = new Property("Key", "Value");
+
+            // Assert
+            Assert.Equal("Key", prop.Name);
+            Assert.Equal("Value", prop.Value);
+        }
+
+        [Fact]
+        [DisplayName("Property ToString 應回傳 Name=Value 格式")]
+        public void Property_ToString_ReturnsNameEqualsValue()
+        {
+            // Arrange
+            var prop = new Property("Key", "Value");
+
+            // Act & Assert
+            Assert.Equal("Key=Value", prop.ToString());
+        }
+
+        [Fact]
+        [DisplayName("PropertyCollection.Add(name,value) 應新增項目")]
+        public void Add_StringValue_AddsItem()
+        {
+            // Arrange
+            var collection = new PropertyCollection();
+
+            // Act
+            collection.Add("Theme", "Dark");
+
+            // Assert
+            Assert.Single(collection);
+            Assert.Equal("Dark", collection["Theme"].Value);
+        }
+
+        [Fact]
+        [DisplayName("GetValue 字串版 存在應回傳屬性值，否則回傳預設值")]
+        public void GetValue_String_ReturnsValueOrDefault()
+        {
+            // Arrange
+            var collection = new PropertyCollection();
+            collection.Add("A", "1");
+
+            // Act & Assert
+            Assert.Equal("1", collection.GetValue("A", "default"));
+            Assert.Equal("default", collection.GetValue("Missing", "default"));
+        }
+
+        [Fact]
+        [DisplayName("GetValue bool 版 存在應轉換為布林，否則回傳預設值")]
+        public void GetValue_Bool_ReturnsConvertedOrDefault()
+        {
+            // Arrange
+            var collection = new PropertyCollection();
+            collection.Add("Enabled", "true");
+
+            // Act & Assert
+            Assert.True(collection.GetValue("Enabled", false));
+            Assert.False(collection.GetValue("Missing", false));
+        }
+
+        [Fact]
+        [DisplayName("GetValue int 版 存在應轉換為整數，否則回傳預設值")]
+        public void GetValue_Int_ReturnsConvertedOrDefault()
+        {
+            // Arrange
+            var collection = new PropertyCollection();
+            collection.Add("Count", "42");
+
+            // Act & Assert
+            Assert.Equal(42, collection.GetValue("Count", 0));
+            Assert.Equal(99, collection.GetValue("Missing", 99));
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Database/TableSchemaGeneratorTests.cs
+++ b/tests/Bee.Definition.UnitTests/Database/TableSchemaGeneratorTests.cs
@@ -1,0 +1,150 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+
+namespace Bee.Definition.UnitTests.Database
+{
+    /// <summary>
+    /// TableSchemaGenerator 將 FormTable 轉換為 TableSchema 的測試。
+    /// </summary>
+    public class TableSchemaGeneratorTests
+    {
+        [Fact]
+        [DisplayName("Generate 傳入 null 應拋出 ArgumentNullException")]
+        public void Generate_NullFormTable_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => generator.Generate(null!));
+        }
+
+        [Fact]
+        [DisplayName("Generate 有 DbTableName 時應使用 DbTableName 作為表名")]
+        public void Generate_DbTableNameSpecified_UsesDbTableName()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+            var formTable = BuildFormTable(dbTableName: "ft_employee");
+
+            // Act
+            var schema = generator.Generate(formTable);
+
+            // Assert
+            Assert.Equal("ft_employee", schema.TableName);
+        }
+
+        [Fact]
+        [DisplayName("Generate 無 DbTableName 時應使用 TableName")]
+        public void Generate_NoDbTableName_UsesTableName()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+            var formTable = BuildFormTable(dbTableName: string.Empty);
+
+            // Act
+            var schema = generator.Generate(formTable);
+
+            // Assert
+            Assert.Equal("Employee", schema.TableName);
+        }
+
+        [Fact]
+        [DisplayName("Generate 應僅加入 DbField 類型欄位，忽略其他欄位類型")]
+        public void Generate_OnlyAddsDbFields()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+            var formTable = BuildFormTable();
+            // 加入非 DbField 類型的欄位，應被忽略
+            formTable.Fields!.Add(new FormField("virtual_field", "虛擬欄位", FieldDbType.String, FieldType.RelationField));
+
+            // Act
+            var schema = generator.Generate(formTable);
+
+            // Assert
+            Assert.DoesNotContain(schema.Fields!, f => f.FieldName == "virtual_field");
+        }
+
+        [Fact]
+        [DisplayName("Generate 應自動加入主鍵索引於 sys_no")]
+        public void Generate_AddsPrimaryKeyIndexOnSysNo()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+            var formTable = BuildFormTable();
+
+            // Act
+            var schema = generator.Generate(formTable);
+
+            // Assert
+            var pk = schema.GetPrimaryKey();
+            Assert.NotNull(pk);
+            Assert.True(pk!.PrimaryKey);
+            Assert.True(pk.Unique);
+        }
+
+        [Fact]
+        [DisplayName("Generate 應自動加入 sys_rowid 唯一索引")]
+        public void Generate_AddsUniqueIndexOnRowId()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+            var formTable = BuildFormTable();
+
+            // Act
+            var schema = generator.Generate(formTable);
+
+            // Assert
+            Assert.Contains(schema.Indexes!, idx =>
+                idx.IndexFields!.Contains(SysFields.RowId) && idx.Unique && !idx.PrimaryKey);
+        }
+
+        [Fact]
+        [DisplayName("Generate 欄位 MaxLength 應對應至 DbField.Length")]
+        public void Generate_MapsMaxLengthToDbFieldLength()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+            var formTable = new FormTable("Demo", "示範");
+            formTable.Fields!.Add(new FormField("name", "名稱", FieldDbType.String) { MaxLength = 50 });
+
+            // Act
+            var schema = generator.Generate(formTable);
+
+            // Assert
+            Assert.Equal(50, schema.Fields!["name"].Length);
+        }
+
+        [Fact]
+        [DisplayName("Generate 有 RelationProgId 的欄位應加入外鍵索引")]
+        public void Generate_FieldWithRelationProgId_AddsForeignKeyIndex()
+        {
+            // Arrange
+            var generator = new TableSchemaGenerator();
+            var formTable = BuildFormTable();
+            formTable.Fields!.Add(new FormField("dept_rowid", "部門", FieldDbType.String)
+            {
+                RelationProgId = "Department"
+            });
+
+            // Act
+            var schema = generator.Generate(formTable);
+
+            // Assert
+            Assert.Contains(schema.Indexes!, idx => idx.IndexFields!.Contains("dept_rowid") && !idx.Unique);
+        }
+
+        private static FormTable BuildFormTable(string dbTableName = "ft_employee")
+        {
+            var formTable = new FormTable("Employee", "員工") { DbTableName = dbTableName };
+            formTable.Fields!.Add(SysFields.No, "流水號", FieldDbType.AutoIncrement);
+            formTable.Fields!.Add(SysFields.RowId, "識別", FieldDbType.Guid);
+            formTable.Fields!.Add(SysFields.Id, "編號", FieldDbType.String);
+            formTable.Fields!.Add(SysFields.Name, "名稱", FieldDbType.String);
+            return formTable;
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/DefineFuncTests.cs
+++ b/tests/Bee.Definition.UnitTests/DefineFuncTests.cs
@@ -1,5 +1,8 @@
 using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Definition.Database;
 using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
 using Bee.Definition.Settings;
 
 namespace Bee.Definition.UnitTests
@@ -9,7 +12,11 @@ namespace Bee.Definition.UnitTests
         [Theory]
         [InlineData(DefineType.SystemSettings, typeof(SystemSettings))]
         [InlineData(DefineType.DatabaseSettings, typeof(DatabaseSettings))]
+        [InlineData(DefineType.DbSchemaSettings, typeof(DbSchemaSettings))]
+        [InlineData(DefineType.ProgramSettings, typeof(ProgramSettings))]
+        [InlineData(DefineType.TableSchema, typeof(TableSchema))]
         [InlineData(DefineType.FormSchema, typeof(FormSchema))]
+        [InlineData(DefineType.FormLayout, typeof(FormLayout))]
         [DisplayName("GetDefineType 傳入有效定義類型應回傳正確的型別")]
         public void GetDefineType_ValidType_ReturnsExpectedType(DefineType defineType, Type expectedType)
         {
@@ -18,6 +25,78 @@ namespace Bee.Definition.UnitTests
 
             // Assert
             Assert.Equal(expectedType, result);
+        }
+
+        [Fact]
+        [DisplayName("GetDefineType 傳入未支援類型應拋出 NotSupportedException")]
+        public void GetDefineType_UnsupportedType_ThrowsNotSupportedException()
+        {
+            // Arrange
+            var invalid = (DefineType)999;
+
+            // Act & Assert
+            Assert.Throws<NotSupportedException>(() => DefineFunc.GetDefineType(invalid));
+        }
+
+        [Theory]
+        [InlineData("Quantity", "N0")]
+        [InlineData("UnitPrice", "N2")]
+        [InlineData("Amount", "N2")]
+        [InlineData("Cost", "N4")]
+        [InlineData("quantity", "N0")]
+        [DisplayName("GetNumberFormatString 已知格式名稱應回傳對應格式字串")]
+        public void GetNumberFormatString_KnownFormat_ReturnsExpectedString(string numberFormat, string expected)
+        {
+            // Act
+            var result = DefineFunc.GetNumberFormatString(numberFormat);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Unknown")]
+        [InlineData(null)]
+        [DisplayName("GetNumberFormatString 空或未知格式應回傳空字串")]
+        public void GetNumberFormatString_EmptyOrUnknown_ReturnsEmpty(string? numberFormat)
+        {
+            // Act
+            var result = DefineFunc.GetNumberFormatString(numberFormat!);
+
+            // Assert
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("GetListLayout 應包含隱藏的 RowID 欄位並依 ListFields 加入顯示欄")]
+        public void GetListLayout_ValidSchema_ContainsRowIdAndListFields()
+        {
+            // Arrange
+            var schema = new FormSchema("Demo", "示範") { ListFields = "sys_id,sys_name" };
+            var table = schema.Tables!.Add("Demo", "示範");
+            table.Fields!.Add("sys_rowid", "唯一識別", FieldDbType.Guid);
+            table.Fields!.Add(new FormField("sys_id", "編號", FieldDbType.String) { Width = 150 });
+            table.Fields!.Add(new FormField("sys_name", "名稱", FieldDbType.String));
+
+            // Act
+            var grid = schema.GetListLayout();
+
+            // Assert
+            Assert.Equal("Demo", grid.TableName);
+            Assert.Equal(3, grid.Columns!.Count);
+
+            var rowIdColumn = grid.Columns[0];
+            Assert.Equal(SysFields.RowId, rowIdColumn.FieldName);
+            Assert.False(rowIdColumn.Visible);
+
+            var idColumn = grid.Columns[1];
+            Assert.Equal("sys_id", idColumn.FieldName);
+            Assert.Equal(150, idColumn.Width);
+
+            var nameColumn = grid.Columns[2];
+            Assert.Equal("sys_name", nameColumn.FieldName);
+            Assert.Equal(120, nameColumn.Width);
         }
     }
 }

--- a/tests/Bee.Definition.UnitTests/DefinePathInfoTests.cs
+++ b/tests/Bee.Definition.UnitTests/DefinePathInfoTests.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel;
+using System.IO;
+
+namespace Bee.Definition.UnitTests
+{
+    /// <summary>
+    /// DefinePathInfo 定義檔案路徑組合測試。
+    /// 每個測試自行設定並復原 <see cref="BackendInfo.DefinePath"/>，
+    /// 使用共享的 Initialize 集合避免與其他使用全域狀態的測試平行執行。
+    /// </summary>
+    [Collection("Initialize")]
+    public class DefinePathInfoTests
+    {
+        private const string TestRoot = "/tmp/bee-define-tests";
+
+        [Fact]
+        [DisplayName("GetSystemSettingsFilePath 應回傳定義根目錄下的 SystemSettings.xml")]
+        public void GetSystemSettingsFilePath_ValidDefinePath_ReturnsExpectedPath()
+        {
+            WithDefinePath(TestRoot, () =>
+            {
+                var path = DefinePathInfo.GetSystemSettingsFilePath();
+                Assert.Equal(Path.Combine(TestRoot, "SystemSettings.xml"), path);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetDatabaseSettingsFilePath 應回傳定義根目錄下的 DatabaseSettings.xml")]
+        public void GetDatabaseSettingsFilePath_ValidDefinePath_ReturnsExpectedPath()
+        {
+            WithDefinePath(TestRoot, () =>
+            {
+                var path = DefinePathInfo.GetDatabaseSettingsFilePath();
+                Assert.Equal(Path.Combine(TestRoot, "DatabaseSettings.xml"), path);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetProgramSettingsFilePath 應回傳定義根目錄下的 ProgramSettings.xml")]
+        public void GetProgramSettingsFilePath_ValidDefinePath_ReturnsExpectedPath()
+        {
+            WithDefinePath(TestRoot, () =>
+            {
+                var path = DefinePathInfo.GetProgramSettingsFilePath();
+                Assert.Equal(Path.Combine(TestRoot, "ProgramSettings.xml"), path);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetDbTableSettingsFilePath 應回傳定義根目錄下的 DbSchemaSettings.xml")]
+        public void GetDbTableSettingsFilePath_ValidDefinePath_ReturnsExpectedPath()
+        {
+            WithDefinePath(TestRoot, () =>
+            {
+                var path = DefinePathInfo.GetDbTableSettingsFilePath();
+                Assert.Equal(Path.Combine(TestRoot, "DbSchemaSettings.xml"), path);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetTableSchemaFilePath 應組合 TableSchema/<db>/<table>.TableSchema.xml")]
+        public void GetTableSchemaFilePath_ValidInput_ReturnsExpectedPath()
+        {
+            WithDefinePath(TestRoot, () =>
+            {
+                var path = DefinePathInfo.GetTableSchemaFilePath("common", "Employee");
+                var expected = Path.Combine(TestRoot, "TableSchema", "common", "Employee.TableSchema.xml");
+                Assert.Equal(expected, path);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetFormSchemaFilePath 應組合 FormSchema/<progId>.FormSchema.xml")]
+        public void GetFormSchemaFilePath_ValidInput_ReturnsExpectedPath()
+        {
+            WithDefinePath(TestRoot, () =>
+            {
+                var path = DefinePathInfo.GetFormSchemaFilePath("Employee");
+                var expected = Path.Combine(TestRoot, "FormSchema", "Employee.FormSchema.xml");
+                Assert.Equal(expected, path);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetFormLayoutFilePath 應組合 FormLayout/<layoutId>.FormLayout.xml")]
+        public void GetFormLayoutFilePath_ValidInput_ReturnsExpectedPath()
+        {
+            WithDefinePath(TestRoot, () =>
+            {
+                var path = DefinePathInfo.GetFormLayoutFilePath("EmployeeDefault");
+                var expected = Path.Combine(TestRoot, "FormLayout", "EmployeeDefault.FormLayout.xml");
+                Assert.Equal(expected, path);
+            });
+        }
+
+        /// <summary>
+        /// 暫時設定 <see cref="BackendInfo.DefinePath"/>，並在 action 執行完畢後復原原值。
+        /// </summary>
+        private static void WithDefinePath(string definePath, Action action)
+        {
+            var original = BackendInfo.DefinePath;
+            try
+            {
+                BackendInfo.DefinePath = definePath;
+                action();
+            }
+            finally
+            {
+                BackendInfo.DefinePath = original;
+            }
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/DtoPropertyTests.cs
+++ b/tests/Bee.Definition.UnitTests/DtoPropertyTests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+
+namespace Bee.Definition.UnitTests
+{
+    /// <summary>
+    /// SessionInfo / SessionUser / UserInfo 等 DTO 基本屬性測試。
+    /// </summary>
+    public class DtoPropertyTests
+    {
+        [Fact]
+        [DisplayName("SessionInfo GetKey 應回傳 AccessToken 的字串表示")]
+        public void SessionInfo_GetKey_ReturnsAccessTokenString()
+        {
+            // Arrange
+            var token = Guid.NewGuid();
+            var info = new SessionInfo { AccessToken = token };
+
+            // Act & Assert
+            Assert.Equal(token.ToString(), info.GetKey());
+        }
+
+        [Fact]
+        [DisplayName("SessionInfo 預設值應為空 Guid 與 zh-TW 文化")]
+        public void SessionInfo_Defaults_ReturnsExpectedValues()
+        {
+            // Act
+            var info = new SessionInfo();
+
+            // Assert
+            Assert.Equal(Guid.Empty, info.AccessToken);
+            Assert.Equal("zh-TW", info.Culture);
+            Assert.Equal("Asia/Taipei", info.TimeZone);
+            Assert.Empty(info.ApiEncryptionKey);
+        }
+
+        [Fact]
+        [DisplayName("SessionInfo ToString 應回傳 UserId : UserName 格式")]
+        public void SessionInfo_ToString_ReturnsFormattedString()
+        {
+            // Arrange
+            var info = new SessionInfo { UserId = "U01", UserName = "Alice" };
+
+            // Act & Assert
+            Assert.Equal("U01 : Alice", info.ToString());
+        }
+
+        [Fact]
+        [DisplayName("SessionUser ToString 應回傳 UserID : UserName 格式")]
+        public void SessionUser_ToString_ReturnsFormattedString()
+        {
+            // Arrange
+            var user = new SessionUser { UserID = "U02", UserName = "Bob" };
+
+            // Act & Assert
+            Assert.Equal("U02 : Bob", user.ToString());
+        }
+
+        [Fact]
+        [DisplayName("SessionUser 預設值應為空 Guid / MinValue")]
+        public void SessionUser_Defaults_ReturnsExpectedValues()
+        {
+            // Act
+            var user = new SessionUser();
+
+            // Assert
+            Assert.Equal(Guid.Empty, user.AccessToken);
+            Assert.Equal(DateTime.MinValue, user.EndTime);
+            Assert.False(user.OneTime);
+        }
+
+        [Fact]
+        [DisplayName("UserInfo 預設應使用 zh-TW 與 Asia/Taipei")]
+        public void UserInfo_Defaults_ReturnsExpectedCultureAndTimeZone()
+        {
+            // Act
+            var user = new UserInfo();
+
+            // Assert
+            Assert.Equal("zh-TW", user.Culture);
+            Assert.Equal("Asia/Taipei", user.TimeZone);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/DtoSerializationTests.cs
+++ b/tests/Bee.Definition.UnitTests/DtoSerializationTests.cs
@@ -1,0 +1,261 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Base.Serialization;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+
+namespace Bee.Definition.UnitTests
+{
+    /// <summary>
+    /// 核心 DTO 的 XML / JSON 序列化 round-trip 測試。
+    /// </summary>
+    public class DtoSerializationTests
+    {
+        [Fact]
+        [DisplayName("FormSchema 含主檔欄位 XML 序列化應正確還原結構")]
+        public void FormSchema_XmlRoundtrip_PreservesStructure()
+        {
+            // Arrange
+            var original = new FormSchema("Employee", "員工") { ListFields = "sys_id,sys_name" };
+            var table = original.Tables!.Add("Employee", "員工");
+            table.DbTableName = "ft_employee";
+            table.Fields!.Add("sys_id", "員工編號", FieldDbType.String);
+            table.Fields!.Add("sys_name", "員工姓名", FieldDbType.String);
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(original);
+            var restored = SerializeFunc.XmlToObject<FormSchema>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal("Employee", restored!.ProgId);
+            Assert.Equal("員工", restored.DisplayName);
+            Assert.Equal("sys_id,sys_name", restored.ListFields);
+            Assert.NotNull(restored.Tables);
+            Assert.Single(restored.Tables!);
+            Assert.Equal("ft_employee", restored.Tables![0].DbTableName);
+            Assert.Equal(2, restored.Tables[0].Fields!.Count);
+        }
+
+        [Fact]
+        [DisplayName("FormSchema JSON 序列化應正確還原結構")]
+        public void FormSchema_JsonRoundtrip_PreservesStructure()
+        {
+            // Arrange
+            var original = new FormSchema("Department", "部門");
+            var table = original.Tables!.Add("Department", "部門");
+            table.Fields!.Add("sys_id", "部門編號", FieldDbType.String);
+
+            // Act
+            var json = SerializeFunc.ObjectToJson(original);
+            var restored = SerializeFunc.JsonToObject<FormSchema>(json);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal("Department", restored!.ProgId);
+            Assert.Equal("部門", restored.DisplayName);
+        }
+
+        [Fact]
+        [DisplayName("TableSchema 含欄位與主鍵索引 XML 序列化應正確還原")]
+        public void TableSchema_XmlRoundtrip_PreservesFieldsAndIndexes()
+        {
+            // Arrange
+            var original = new TableSchema
+            {
+                TableName = "ft_employee",
+                DisplayName = "員工資料表"
+            };
+            original.Fields!.Add("sys_no", "流水號", FieldDbType.AutoIncrement);
+            original.Fields!.Add(SysFields.RowId, "識別", FieldDbType.Guid);
+            original.Fields!.Add("sys_id", "編號", FieldDbType.String, 20);
+            original.Indexes!.AddPrimaryKey("sys_no");
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(original);
+            var restored = SerializeFunc.XmlToObject<TableSchema>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal("ft_employee", restored!.TableName);
+            Assert.Equal(3, restored.Fields!.Count);
+            Assert.Equal(20, restored.Fields!["sys_id"].Length);
+
+            var pk = restored.GetPrimaryKey();
+            Assert.NotNull(pk);
+            Assert.True(pk!.PrimaryKey);
+            Assert.True(pk.Unique);
+        }
+
+        [Fact]
+        [DisplayName("TableSchema Clone 應深度複製欄位與索引")]
+        public void TableSchema_Clone_DeepCopies()
+        {
+            // Arrange
+            var original = new TableSchema { TableName = "ft_t", DisplayName = "T" };
+            original.Fields!.Add("sys_no", "流水號", FieldDbType.AutoIncrement);
+            original.Indexes!.AddPrimaryKey("sys_no");
+
+            // Act
+            var clone = original.Clone();
+            clone.Fields!["sys_no"].Caption = "Modified";
+
+            // Assert
+            Assert.Equal("ft_t", clone.TableName);
+            Assert.Single(clone.Fields!);
+            Assert.Single(clone.Indexes!);
+            Assert.Equal("流水號", original.Fields!["sys_no"].Caption);
+            Assert.Equal("Modified", clone.Fields!["sys_no"].Caption);
+        }
+
+        [Fact]
+        [DisplayName("FormLayout 含巢狀群組 XML 序列化應正確還原")]
+        public void FormLayout_XmlRoundtrip_PreservesStructure()
+        {
+            // Arrange
+            var original = new FormLayout
+            {
+                LayoutId = "EmployeeDefault",
+                DisplayName = "員工預設版面"
+            };
+            var group = new LayoutGroup
+            {
+                Name = "MainGroup",
+                Caption = "主要資料",
+                ShowCaption = true,
+                ColumnCount = 2
+            };
+            group.Items!.Add(new LayoutItem
+            {
+                FieldName = "sys_id",
+                Caption = "員工編號",
+                ControlType = ControlType.TextEdit
+            });
+            original.Groups!.Add(group);
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(original);
+            var restored = SerializeFunc.XmlToObject<FormLayout>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal("EmployeeDefault", restored!.LayoutId);
+            Assert.Single(restored.Groups!);
+            Assert.Equal("MainGroup", restored.Groups![0].Name);
+            Assert.Single(restored.Groups[0].Items!);
+        }
+
+        [Fact]
+        [DisplayName("FormLayout FindItem 應依欄位名稱回傳對應項目")]
+        public void FormLayout_FindItem_ReturnsMatchingItem()
+        {
+            // Arrange
+            var layout = new FormLayout { LayoutId = "Test", DisplayName = "Test" };
+            var group = new LayoutGroup { Name = "G1" };
+            group.Items!.Add(new LayoutItem { FieldName = "sys_id" });
+            group.Items.Add(new LayoutItem { FieldName = "sys_name" });
+            layout.Groups!.Add(group);
+
+            // Act
+            var found = layout.FindItem("sys_name");
+            var missing = layout.FindItem("nonexistent");
+
+            // Assert
+            Assert.NotNull(found);
+            Assert.Equal("sys_name", found!.FieldName);
+            Assert.Null(missing);
+        }
+
+        [Fact]
+        [DisplayName("DatabaseSettings XML 序列化應正確還原 Servers 與 Items")]
+        public void DatabaseSettings_XmlRoundtrip_PreservesCollections()
+        {
+            // Arrange
+            var original = new DatabaseSettings();
+            original.Items!.Add(new DatabaseItem
+            {
+                Id = "common",
+                DatabaseType = DatabaseType.SQLServer,
+                ConnectionString = "Server=.;Database=Test"
+            });
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(original);
+            var restored = SerializeFunc.XmlToObject<DatabaseSettings>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Single(restored!.Items!);
+            Assert.Equal("common", restored.Items![0].Id);
+            Assert.Equal(DatabaseType.SQLServer, restored.Items[0].DatabaseType);
+        }
+
+        [Fact]
+        [DisplayName("DatabaseSettings Clone 應建立獨立副本")]
+        public void DatabaseSettings_Clone_ProducesIndependentCopy()
+        {
+            // Arrange
+            var original = new DatabaseSettings();
+            original.Items!.Add(new DatabaseItem { Id = "common" });
+
+            // Act
+            var clone = original.Clone();
+            clone.Items!.Add(new DatabaseItem { Id = "reports" });
+
+            // Assert
+            Assert.Single(original.Items!);
+            Assert.Equal(2, clone.Items.Count);
+        }
+
+        [Fact]
+        [DisplayName("ProgramSettings XML 序列化應正確還原")]
+        public void ProgramSettings_XmlRoundtrip_Succeeds()
+        {
+            // Arrange
+            var original = new ProgramSettings();
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(original);
+            var restored = SerializeFunc.XmlToObject<ProgramSettings>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+        }
+
+        [Fact]
+        [DisplayName("DbSchemaSettings XML 序列化應正確還原")]
+        public void DbSchemaSettings_XmlRoundtrip_Succeeds()
+        {
+            // Arrange
+            var original = new DbSchemaSettings();
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(original);
+            var restored = SerializeFunc.XmlToObject<DbSchemaSettings>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+        }
+
+        [Fact]
+        [DisplayName("SystemSettings JSON 序列化應正確還原主要屬性")]
+        public void SystemSettings_JsonRoundtrip_PreservesConfiguration()
+        {
+            // Arrange
+            var original = new SystemSettings();
+            original.CommonConfiguration.Version = "4.0.1";
+            original.BackendConfiguration.DatabaseId = "common";
+
+            // Act
+            var json = SerializeFunc.ObjectToJson(original);
+            var restored = SerializeFunc.JsonToObject<SystemSettings>(json);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal("4.0.1", restored!.CommonConfiguration.Version);
+            Assert.Equal("common", restored.BackendConfiguration.DatabaseId);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Filters/FilterGroupTests.cs
+++ b/tests/Bee.Definition.UnitTests/Filters/FilterGroupTests.cs
@@ -1,0 +1,269 @@
+using System.ComponentModel;
+using Bee.Base.Serialization;
+using Bee.Definition.Filters;
+
+namespace Bee.Definition.UnitTests.Filters
+{
+    /// <summary>
+    /// FilterCondition / FilterGroup / FilterNode 邏輯與序列化測試。
+    /// </summary>
+    public class FilterGroupTests
+    {
+        [Fact]
+        [DisplayName("FilterCondition 建構子應正確設定欄位、運算子與值")]
+        public void FilterCondition_Constructor_SetsProperties()
+        {
+            // Act
+            var cond = new FilterCondition("Age", ComparisonOperator.GreaterThan, 18);
+
+            // Assert
+            Assert.Equal("Age", cond.FieldName);
+            Assert.Equal(ComparisonOperator.GreaterThan, cond.Operator);
+            Assert.Equal(18, cond.Value);
+            Assert.Null(cond.SecondValue);
+            Assert.Equal(FilterNodeKind.Condition, cond.Kind);
+        }
+
+        [Fact]
+        [DisplayName("FilterCondition Between 工廠方法應設定兩個值")]
+        public void FilterCondition_Between_SetsBothValues()
+        {
+            // Arrange
+            var from = new DateTime(2026, 1, 1);
+            var to = new DateTime(2026, 12, 31);
+
+            // Act
+            var cond = FilterCondition.Between("HireDate", from, to);
+
+            // Assert
+            Assert.Equal(ComparisonOperator.Between, cond.Operator);
+            Assert.Equal(from, cond.Value);
+            Assert.Equal(to, cond.SecondValue);
+        }
+
+        [Theory]
+        [InlineData("Equal")]
+        [InlineData("NotEqual")]
+        [InlineData("Contains")]
+        [InlineData("StartsWith")]
+        [InlineData("EndsWith")]
+        [DisplayName("FilterCondition 工廠方法應產生對應運算子")]
+        public void FilterCondition_FactoryMethods_ProduceExpectedOperator(string factory)
+        {
+            // Act
+            FilterCondition cond = factory switch
+            {
+                "Equal" => FilterCondition.Equal("F", 1),
+                "NotEqual" => FilterCondition.NotEqual("F", 1),
+                "Contains" => FilterCondition.Contains("F", "x"),
+                "StartsWith" => FilterCondition.StartsWith("F", "x"),
+                "EndsWith" => FilterCondition.EndsWith("F", "x"),
+                _ => throw new ArgumentOutOfRangeException(nameof(factory))
+            };
+
+            // Assert
+            var expected = factory switch
+            {
+                "Equal" => ComparisonOperator.Equal,
+                "NotEqual" => ComparisonOperator.NotEqual,
+                "Contains" => ComparisonOperator.Contains,
+                "StartsWith" => ComparisonOperator.StartsWith,
+                "EndsWith" => ComparisonOperator.EndsWith,
+                _ => throw new ArgumentOutOfRangeException(nameof(factory))
+            };
+            Assert.Equal(expected, cond.Operator);
+        }
+
+        [Fact]
+        [DisplayName("FilterCondition In 工廠方法應儲存值集合")]
+        public void FilterCondition_In_StoresEnumerable()
+        {
+            // Arrange
+            var values = new object[] { 1, 2, 3 };
+
+            // Act
+            var cond = FilterCondition.In("Id", values);
+
+            // Assert
+            Assert.Equal(ComparisonOperator.In, cond.Operator);
+            Assert.Same(values, cond.Value);
+        }
+
+        [Fact]
+        [DisplayName("FilterGroup.All 應建立 AND 群組並包含子節點")]
+        public void FilterGroup_All_CreatesAndGroupWithNodes()
+        {
+            // Arrange
+            var c1 = FilterCondition.Equal("A", 1);
+            var c2 = FilterCondition.Equal("B", 2);
+
+            // Act
+            var group = FilterGroup.All(c1, c2);
+
+            // Assert
+            Assert.Equal(LogicalOperator.And, group.Operator);
+            Assert.Equal(2, group.Nodes.Count);
+            Assert.Equal(FilterNodeKind.Group, group.Kind);
+        }
+
+        [Fact]
+        [DisplayName("FilterGroup.Any 應建立 OR 群組並包含子節點")]
+        public void FilterGroup_Any_CreatesOrGroupWithNodes()
+        {
+            // Act
+            var group = FilterGroup.Any(FilterCondition.Equal("A", 1));
+
+            // Assert
+            Assert.Equal(LogicalOperator.Or, group.Operator);
+            Assert.Single(group.Nodes);
+        }
+
+        [Fact]
+        [DisplayName("FilterGroup 建構子帶 LogicalOperator 應設定運算子")]
+        public void FilterGroup_Constructor_WithOperator_SetsOperator()
+        {
+            // Act
+            var group = new FilterGroup(LogicalOperator.Or);
+
+            // Assert
+            Assert.Equal(LogicalOperator.Or, group.Operator);
+            Assert.NotNull(group.Nodes);
+            Assert.Empty(group.Nodes);
+        }
+
+        [Fact]
+        [DisplayName("FilterGroup ShouldSerializeNodes 空集合應回傳 false")]
+        public void FilterGroup_ShouldSerializeNodes_EmptyCollection_ReturnsFalse()
+        {
+            // Arrange
+            var group = new FilterGroup();
+
+            // Act & Assert
+            Assert.False(group.ShouldSerializeNodes());
+        }
+
+        [Fact]
+        [DisplayName("FilterGroup ShouldSerializeNodes 非空集合應回傳 true")]
+        public void FilterGroup_ShouldSerializeNodes_NonEmpty_ReturnsTrue()
+        {
+            // Arrange
+            var group = FilterGroup.All(FilterCondition.Equal("A", 1));
+
+            // Act & Assert
+            Assert.True(group.ShouldSerializeNodes());
+        }
+
+        [Fact]
+        [DisplayName("FilterGroup 三層巢狀 XML 序列化應正確還原結構")]
+        public void FilterGroup_DeepNested_XmlRoundtrip_PreservesStructure()
+        {
+            // Arrange
+            var root = FilterGroup.All(
+                FilterCondition.Equal("A", 1),
+                FilterGroup.Any(
+                    FilterCondition.Equal("B", 2),
+                    FilterGroup.All(
+                        FilterCondition.Equal("C", 3),
+                        FilterCondition.Equal("D", 4)
+                    )
+                )
+            );
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(root);
+            var restored = SerializeFunc.XmlToObject<FilterGroup>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal(LogicalOperator.And, restored!.Operator);
+            Assert.Equal(2, restored.Nodes.Count);
+            Assert.IsType<FilterCondition>(restored.Nodes[0]);
+            Assert.IsType<FilterGroup>(restored.Nodes[1]);
+            var inner = (FilterGroup)restored.Nodes[1];
+            Assert.Equal(LogicalOperator.Or, inner.Operator);
+            Assert.IsType<FilterGroup>(inner.Nodes[1]);
+        }
+
+        [Fact]
+        [DisplayName("FilterCondition ToString Between 應包含 BETWEEN ... AND ...")]
+        public void FilterCondition_ToString_Between_FormatsBothValues()
+        {
+            // Arrange
+            var cond = FilterCondition.Between("Age", 10, 20);
+
+            // Act
+            var text = cond.ToString();
+
+            // Assert
+            Assert.Contains("BETWEEN", text);
+            Assert.Contains("AND", text);
+            Assert.Contains("10", text);
+            Assert.Contains("20", text);
+        }
+
+        [Theory]
+        [InlineData(ComparisonOperator.Equal, "=")]
+        [InlineData(ComparisonOperator.NotEqual, "<>")]
+        [InlineData(ComparisonOperator.GreaterThan, ">")]
+        [InlineData(ComparisonOperator.GreaterThanOrEqual, ">=")]
+        [InlineData(ComparisonOperator.LessThan, "<")]
+        [InlineData(ComparisonOperator.LessThanOrEqual, "<=")]
+        [InlineData(ComparisonOperator.Like, "LIKE")]
+        [InlineData(ComparisonOperator.In, "IN")]
+        [DisplayName("FilterCondition ToString 應依運算子輸出對應符號")]
+        public void FilterCondition_ToString_ReturnsExpectedOperatorSymbol(ComparisonOperator op, string expectedSymbol)
+        {
+            // Arrange
+            object value = op == ComparisonOperator.In ? (object)new object[] { 1, 2 } : 5;
+            var cond = new FilterCondition("F", op, value);
+
+            // Act
+            var text = cond.ToString();
+
+            // Assert
+            Assert.Contains(expectedSymbol, text);
+        }
+
+        [Fact]
+        [DisplayName("FilterCondition ToString Contains 應包含 %value%")]
+        public void FilterCondition_ToString_Contains_WrapsValueInPercent()
+        {
+            // Arrange
+            var cond = FilterCondition.Contains("Name", "Lee");
+
+            // Act
+            var text = cond.ToString();
+
+            // Assert
+            Assert.Contains("'%Lee%'", text);
+        }
+
+        [Fact]
+        [DisplayName("FilterCondition ToString StartsWith 應以 'value%' 結尾")]
+        public void FilterCondition_ToString_StartsWith_EndsWithPercent()
+        {
+            // Arrange
+            var cond = FilterCondition.StartsWith("Name", "Lee");
+
+            // Act
+            var text = cond.ToString();
+
+            // Assert
+            Assert.Contains("'Lee%'", text);
+        }
+
+        [Fact]
+        [DisplayName("FilterCondition ToString EndsWith 應以 '%value' 開頭")]
+        public void FilterCondition_ToString_EndsWith_StartsWithPercent()
+        {
+            // Arrange
+            var cond = FilterCondition.EndsWith("Name", "Lee");
+
+            // Act
+            var text = cond.ToString();
+
+            // Assert
+            Assert.Contains("'%Lee'", text);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Layouts/FormLayoutGeneratorTests.cs
+++ b/tests/Bee.Definition.UnitTests/Layouts/FormLayoutGeneratorTests.cs
@@ -1,0 +1,169 @@
+using System.ComponentModel;
+using System.Linq;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+
+namespace Bee.Definition.UnitTests.Layouts
+{
+    /// <summary>
+    /// FormLayoutGenerator 將 FormSchema 轉換為 FormLayout 的測試。
+    /// </summary>
+    public class FormLayoutGeneratorTests
+    {
+        [Fact]
+        [DisplayName("Generate 傳入 null 應拋出 ArgumentNullException")]
+        public void Generate_NullFormSchema_ThrowsArgumentNullException()
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => generator.Generate(null!));
+        }
+
+        [Fact]
+        [DisplayName("Generate 應將 ProgId / DisplayName 複製到 FormLayout")]
+        public void Generate_CopiesIdAndDisplayName()
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+            var schema = BuildSchema();
+
+            // Act
+            var layout = generator.Generate(schema);
+
+            // Assert
+            Assert.Equal("Employee", layout.LayoutId);
+            Assert.Equal("員工", layout.DisplayName);
+        }
+
+        [Fact]
+        [DisplayName("Generate 主檔 Group 應命名為 MainGroup 並為兩欄")]
+        public void Generate_CreatesMainGroupWithTwoColumns()
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+            var schema = BuildSchema();
+
+            // Act
+            var layout = generator.Generate(schema);
+
+            // Assert
+            var mainGroup = layout.Groups!.FirstOrDefault(g => g.Name == "MainGroup");
+            Assert.NotNull(mainGroup);
+            Assert.Equal(2, mainGroup!.ColumnCount);
+            Assert.True(mainGroup.ShowCaption);
+        }
+
+        [Fact]
+        [DisplayName("Generate 應忽略 Visible=false 的欄位")]
+        public void Generate_SkipsInvisibleFields()
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+            var schema = BuildSchema();
+            schema.MasterTable!.Fields!["sys_id"].Visible = false;
+
+            // Act
+            var layout = generator.Generate(schema);
+
+            // Assert
+            var mainGroup = layout.Groups!.First(g => g.Name == "MainGroup");
+            Assert.DoesNotContain(mainGroup.Items!.OfType<LayoutItem>(), item => item.FieldName == "sys_id");
+        }
+
+        [Theory]
+        [InlineData(FieldDbType.Boolean, ControlType.CheckEdit)]
+        [InlineData(FieldDbType.DateTime, ControlType.DateEdit)]
+        [InlineData(FieldDbType.Text, ControlType.MemoEdit)]
+        [InlineData(FieldDbType.String, ControlType.TextEdit)]
+        [DisplayName("Generate ControlType=Auto 應依 DbType 推導對應控制型態")]
+        public void Generate_AutoControlType_MapsDbTypeToControlType(FieldDbType dbType, ControlType expected)
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+            var schema = new FormSchema("Demo", "示範");
+            var table = schema.Tables!.Add("Demo", "示範");
+            table.Fields!.Add(new FormField("field", "欄位", dbType) { ControlType = ControlType.Auto });
+
+            // Act
+            var layout = generator.Generate(schema);
+
+            // Assert
+            var item = (LayoutItem)layout.Groups!.First().Items!.First();
+            Assert.Equal(expected, item.ControlType);
+        }
+
+        [Fact]
+        [DisplayName("Generate 有 LookupProgId 應設定到 LayoutItem.ProgId")]
+        public void Generate_LookupProgId_SetsLayoutItemProgId()
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+            var schema = new FormSchema("Demo", "示範");
+            var table = schema.Tables!.Add("Demo", "示範");
+            table.Fields!.Add(new FormField("dept_id", "部門", FieldDbType.String)
+            {
+                LookupProgId = "DeptLookup"
+            });
+
+            // Act
+            var layout = generator.Generate(schema);
+
+            // Assert
+            var item = (LayoutItem)layout.Groups!.First().Items!.First();
+            Assert.Equal("DeptLookup", item.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("Generate 無 Lookup 但有 RelationProgId 應設定到 LayoutItem.ProgId")]
+        public void Generate_RelationProgId_SetsLayoutItemProgId()
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+            var schema = new FormSchema("Demo", "示範");
+            var table = schema.Tables!.Add("Demo", "示範");
+            table.Fields!.Add(new FormField("dept_rowid", "部門", FieldDbType.String)
+            {
+                RelationProgId = "Department"
+            });
+
+            // Act
+            var layout = generator.Generate(schema);
+
+            // Assert
+            var item = (LayoutItem)layout.Groups!.First().Items!.First();
+            Assert.Equal("Department", item.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("Generate 多個 Table 應為主檔以外的每個 Table 建立 Group 與 Grid")]
+        public void Generate_MultipleTables_CreatesDetailGroupWithGrid()
+        {
+            // Arrange
+            var generator = new FormLayoutGenerator();
+            var schema = BuildSchema();
+            var detail = schema.Tables!.Add("EmployeeSkill", "員工技能");
+            detail.Fields!.Add("skill_name", "技能", FieldDbType.String);
+
+            // Act
+            var layout = generator.Generate(schema);
+
+            // Assert
+            var detailGroup = layout.Groups!.FirstOrDefault(g => g.Name == "EmployeeSkillGroup");
+            Assert.NotNull(detailGroup);
+            Assert.Single(detailGroup!.Items!);
+            Assert.IsType<LayoutGrid>(detailGroup.Items![0]);
+        }
+
+        private static FormSchema BuildSchema()
+        {
+            var schema = new FormSchema("Employee", "員工");
+            var master = schema.Tables!.Add("Employee", "員工");
+            master.Fields!.Add("sys_id", "編號", FieldDbType.String);
+            master.Fields!.Add("sys_name", "姓名", FieldDbType.String);
+            return schema;
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Logging/LoggingTests.cs
+++ b/tests/Bee.Definition.UnitTests/Logging/LoggingTests.cs
@@ -1,0 +1,161 @@
+using System.ComponentModel;
+using System.IO;
+using Bee.Definition.Logging;
+
+namespace Bee.Definition.UnitTests.Logging
+{
+    /// <summary>
+    /// Logging 模組基本行為測試：LogEntry、LogOptions、ConsoleLogWriter、NullLogWriter。
+    /// </summary>
+    public class LoggingTests
+    {
+        [Fact]
+        [DisplayName("LogEntry 預設值應包含本機名稱與當前時間")]
+        public void LogEntry_Defaults_PopulatesMachineAndTimestamp()
+        {
+            // Act
+            var entry = new LogEntry();
+
+            // Assert
+            Assert.Equal(Environment.MachineName, entry.MachineName);
+            Assert.NotEqual(default(DateTime), entry.Timestamp);
+            Assert.Equal(string.Empty, entry.Source);
+            Assert.Equal(string.Empty, entry.Message);
+            Assert.Null(entry.Exception);
+        }
+
+        [Fact]
+        [DisplayName("LogEntry ToString 應回傳類別名稱")]
+        public void LogEntry_ToString_ReturnsTypeName()
+        {
+            // Arrange
+            var entry = new LogEntry();
+
+            // Act & Assert
+            Assert.Equal(nameof(LogEntry), entry.ToString());
+        }
+
+        [Fact]
+        [DisplayName("LogOptions 預設應包含非 null 的 DbAccess 選項")]
+        public void LogOptions_Defaults_HasDbAccessOptions()
+        {
+            // Act
+            var options = new LogOptions();
+
+            // Assert
+            Assert.NotNull(options.DbAccess);
+            Assert.Equal(nameof(LogOptions), options.ToString());
+        }
+
+        [Fact]
+        [DisplayName("DbAccessAnomalyLogOptions 預設值應符合規格")]
+        public void DbAccessAnomalyLogOptions_Defaults_MatchExpected()
+        {
+            // Act
+            var options = new DbAccessAnomalyLogOptions();
+
+            // Assert
+            Assert.Equal(DbAccessAnomalyLogLevel.Warning, options.Level);
+            Assert.Equal(10000, options.AffectedRowThreshold);
+            Assert.Equal(10000, options.ResultRowThreshold);
+            Assert.Equal(300, options.ExecutionTimeThreshold);
+            Assert.Equal(nameof(DbAccessAnomalyLogOptions), options.ToString());
+        }
+
+        [Theory]
+        [InlineData(LogEntryType.Information)]
+        [InlineData(LogEntryType.Warning)]
+        [InlineData(LogEntryType.Error)]
+        [DisplayName("ConsoleLogWriter 寫入各類型應輸出到 Console 且不拋出例外")]
+        public void ConsoleLogWriter_Write_ProducesConsoleOutput(LogEntryType type)
+        {
+            // Arrange
+            var writer = new ConsoleLogWriter();
+            var entry = new LogEntry
+            {
+                EntryType = type,
+                Source = "Test",
+                Message = "Hello"
+            };
+
+            var originalOut = Console.Out;
+            var sb = new StringWriter();
+            Console.SetOut(sb);
+            try
+            {
+                // Act
+                writer.Write(entry);
+
+                // Assert
+                var output = sb.ToString();
+                Assert.Contains("Test", output);
+                Assert.Contains("Hello", output);
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+
+        [Fact]
+        [DisplayName("ConsoleLogWriter 附帶 Exception 應輸出例外資訊")]
+        public void ConsoleLogWriter_Write_WithException_OutputsExceptionText()
+        {
+            // Arrange
+            var writer = new ConsoleLogWriter();
+            var entry = new LogEntry
+            {
+                EntryType = LogEntryType.Error,
+                Source = "Svc",
+                Message = "Boom",
+                Exception = new InvalidOperationException("Oops")
+            };
+
+            var originalOut = Console.Out;
+            var sb = new StringWriter();
+            Console.SetOut(sb);
+            try
+            {
+                // Act
+                writer.Write(entry);
+
+                // Assert
+                Assert.Contains("Oops", sb.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+
+        [Fact]
+        [DisplayName("NullLogWriter 應不產生任何輸出且不拋出例外")]
+        public void NullLogWriter_Write_NoOp()
+        {
+            // Arrange
+            var writer = new NullLogWriter();
+            var entry = new LogEntry
+            {
+                EntryType = LogEntryType.Information,
+                Source = "Any",
+                Message = "ShouldNotAppear"
+            };
+
+            var originalOut = Console.Out;
+            var sb = new StringWriter();
+            Console.SetOut(sb);
+            try
+            {
+                // Act
+                writer.Write(entry);
+
+                // Assert
+                Assert.Equal(string.Empty, sb.ToString());
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Security/EncryptionKeyProtectorTests.cs
+++ b/tests/Bee.Definition.UnitTests/Security/EncryptionKeyProtectorTests.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using Bee.Base.Security;
+using Bee.Definition.Security;
+
+namespace Bee.Definition.UnitTests.Security
+{
+    /// <summary>
+    /// EncryptionKeyProtector 正常與錯誤路徑測試。
+    /// </summary>
+    public class EncryptionKeyProtectorTests
+    {
+        [Fact]
+        [DisplayName("GenerateEncryptedKey 使用有效 Master Key 應可後續解密還原")]
+        public void GenerateEncryptedKey_ValidMasterKey_CanBeDecrypted()
+        {
+            // Arrange
+            byte[] masterKey = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+
+            // Act
+            string base64 = EncryptionKeyProtector.GenerateEncryptedKey(masterKey);
+            byte[] decrypted = EncryptionKeyProtector.DecryptEncryptedKey(masterKey, base64);
+
+            // Assert
+            Assert.NotEmpty(base64);
+            Assert.Equal(64, decrypted.Length); // 256-bit AES + 256-bit HMAC = 64 bytes
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new byte[0])]
+        [DisplayName("GenerateEncryptedKey 傳入空 Master Key 應拋出 ArgumentException")]
+        public void GenerateEncryptedKey_EmptyMasterKey_ThrowsArgumentException(byte[]? masterKey)
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => EncryptionKeyProtector.GenerateEncryptedKey(masterKey!));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(new byte[0])]
+        [DisplayName("DecryptEncryptedKey 傳入空 Master Key 應拋出 ArgumentException")]
+        public void DecryptEncryptedKey_EmptyMasterKey_ThrowsArgumentException(byte[]? masterKey)
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                EncryptionKeyProtector.DecryptEncryptedKey(masterKey!, "SGVsbG8="));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("DecryptEncryptedKey 密文為空應拋出 ArgumentException")]
+        public void DecryptEncryptedKey_EmptyCipherText_ThrowsArgumentException(string? cipherText)
+        {
+            // Arrange
+            byte[] masterKey = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                EncryptionKeyProtector.DecryptEncryptedKey(masterKey, cipherText!));
+        }
+
+        [Fact]
+        [DisplayName("DecryptEncryptedKey 使用錯誤的 Master Key 應拋出例外")]
+        public void DecryptEncryptedKey_WrongMasterKey_Throws()
+        {
+            // Arrange
+            byte[] originalKey = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+            byte[] wrongKey = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+            string base64 = EncryptionKeyProtector.GenerateEncryptedKey(originalKey);
+
+            // Act & Assert
+            Assert.ThrowsAny<Exception>(() =>
+                EncryptionKeyProtector.DecryptEncryptedKey(wrongKey, base64));
+        }
+
+        [Fact]
+        [DisplayName("DecryptEncryptedKey 密文非 Base64 格式應拋出 FormatException")]
+        public void DecryptEncryptedKey_NonBase64CipherText_ThrowsFormatException()
+        {
+            // Arrange
+            byte[] masterKey = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+
+            // Act & Assert
+            Assert.Throws<FormatException>(() =>
+                EncryptionKeyProtector.DecryptEncryptedKey(masterKey, "@@not-base64@@"));
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderTests.cs
+++ b/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderTests.cs
@@ -1,0 +1,201 @@
+using System.ComponentModel;
+using System.IO;
+using Bee.Base.Security;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+
+namespace Bee.Definition.UnitTests.Security
+{
+    /// <summary>
+    /// MasterKeyProvider 來源載入與錯誤路徑測試。
+    /// </summary>
+    public class MasterKeyProviderTests
+    {
+        [Fact]
+        [DisplayName("GetMasterKey 檔案來源存在有效 Base64 應回傳對應位元組")]
+        public void GetMasterKey_FileSource_ReturnsBytes()
+        {
+            // Arrange
+            byte[] expected = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+            string filePath = Path.Combine(Path.GetTempPath(), $"bee-mk-{Guid.NewGuid()}.key");
+            File.WriteAllText(filePath, Convert.ToBase64String(expected));
+
+            try
+            {
+                // Act
+                byte[] actual = MasterKeyProvider.GetMasterKey(new MasterKeySource
+                {
+                    Type = MasterKeySourceType.File,
+                    Value = filePath
+                });
+
+                // Assert
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 檔案不存在且 autoCreate=false 應拋出 FileNotFoundException")]
+        public void GetMasterKey_FileMissing_NoAutoCreate_ThrowsFileNotFound()
+        {
+            // Arrange
+            string missing = Path.Combine(Path.GetTempPath(), $"bee-mk-missing-{Guid.NewGuid()}.key");
+
+            // Act & Assert
+            Assert.Throws<FileNotFoundException>(() =>
+                MasterKeyProvider.GetMasterKey(new MasterKeySource
+                {
+                    Type = MasterKeySourceType.File,
+                    Value = missing
+                }));
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 檔案不存在且 autoCreate=true 應建立檔案並回傳內容")]
+        public void GetMasterKey_FileMissing_AutoCreate_CreatesAndReturnsKey()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), $"bee-mk-auto-{Guid.NewGuid()}.key");
+
+            try
+            {
+                // Act
+                byte[] result = MasterKeyProvider.GetMasterKey(
+                    new MasterKeySource { Type = MasterKeySourceType.File, Value = filePath },
+                    autoCreate: true);
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotEmpty(result);
+                Assert.True(File.Exists(filePath));
+            }
+            finally
+            {
+                if (File.Exists(filePath)) File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 檔案內容非 Base64 應拋出 InvalidOperationException")]
+        public void GetMasterKey_InvalidBase64Content_ThrowsInvalidOperation()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), $"bee-mk-bad-{Guid.NewGuid()}.key");
+            File.WriteAllText(filePath, "@@not-base64@@");
+
+            try
+            {
+                // Act & Assert
+                var ex = Assert.Throws<InvalidOperationException>(() =>
+                    MasterKeyProvider.GetMasterKey(new MasterKeySource
+                    {
+                        Type = MasterKeySourceType.File,
+                        Value = filePath
+                    }));
+                Assert.IsType<FormatException>(ex.InnerException);
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 檔案內容為空應拋出 InvalidOperationException")]
+        public void GetMasterKey_EmptyFileContent_ThrowsInvalidOperation()
+        {
+            // Arrange
+            string filePath = Path.Combine(Path.GetTempPath(), $"bee-mk-empty-{Guid.NewGuid()}.key");
+            File.WriteAllText(filePath, "   ");
+
+            try
+            {
+                // Act & Assert
+                Assert.Throws<InvalidOperationException>(() =>
+                    MasterKeyProvider.GetMasterKey(new MasterKeySource
+                    {
+                        Type = MasterKeySourceType.File,
+                        Value = filePath
+                    }));
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 環境變數來源存在應回傳對應位元組")]
+        public void GetMasterKey_EnvironmentSource_ReturnsBytes()
+        {
+            // Arrange
+            string varName = $"BEE_TEST_MK_{Guid.NewGuid():N}";
+            byte[] expected = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+            Environment.SetEnvironmentVariable(varName, Convert.ToBase64String(expected));
+
+            try
+            {
+                // Act
+                byte[] actual = MasterKeyProvider.GetMasterKey(new MasterKeySource
+                {
+                    Type = MasterKeySourceType.Environment,
+                    Value = varName
+                });
+
+                // Assert
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(varName, null);
+            }
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 環境變數不存在且 autoCreate=false 應拋出 InvalidOperationException")]
+        public void GetMasterKey_EnvironmentMissing_NoAutoCreate_Throws()
+        {
+            // Arrange
+            string varName = $"BEE_TEST_MK_MISSING_{Guid.NewGuid():N}";
+            Environment.SetEnvironmentVariable(varName, null);
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                MasterKeyProvider.GetMasterKey(new MasterKeySource
+                {
+                    Type = MasterKeySourceType.Environment,
+                    Value = varName
+                }));
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 環境變數不存在且 autoCreate=true 應建立變數並回傳內容")]
+        public void GetMasterKey_EnvironmentMissing_AutoCreate_CreatesAndReturnsKey()
+        {
+            // Arrange
+            string varName = $"BEE_TEST_MK_AUTO_{Guid.NewGuid():N}";
+            Environment.SetEnvironmentVariable(varName, null);
+
+            try
+            {
+                // Act
+                byte[] result = MasterKeyProvider.GetMasterKey(
+                    new MasterKeySource { Type = MasterKeySourceType.Environment, Value = varName },
+                    autoCreate: true);
+
+                // Assert
+                Assert.NotNull(result);
+                Assert.NotEmpty(result);
+                Assert.False(string.IsNullOrEmpty(Environment.GetEnvironmentVariable(varName)));
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(varName, null);
+            }
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Serialization/SafeTypelessFormatterTests.cs
+++ b/tests/Bee.Definition.UnitTests/Serialization/SafeTypelessFormatterTests.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel;
+using Bee.Definition.Serialization;
+
+namespace Bee.Definition.UnitTests.Serialization
+{
+    /// <summary>
+    /// SafeTypelessFormatter 型別白名單驗證測試。
+    /// </summary>
+    public class SafeTypelessFormatterTests
+    {
+        [Theory]
+        [InlineData("System.Int32")]
+        [InlineData("System.String")]
+        [InlineData("System.Boolean")]
+        [InlineData("System.DateTime")]
+        [InlineData("System.Guid")]
+        [InlineData("System.Byte[]")]
+        [InlineData("System.DBNull")]
+        [InlineData("System.Data.DataTable")]
+        [DisplayName("IsTypeAllowed 內建原生型別應回傳 true")]
+        public void IsTypeAllowed_PrimitiveTypes_ReturnsTrue(string fullName)
+        {
+            // Act & Assert
+            Assert.True(SafeTypelessFormatter.IsTypeAllowed(fullName));
+        }
+
+        [Theory]
+        [InlineData("Bee.Base.SomeClass")]
+        [InlineData("Bee.Definition.Foo")]
+        [InlineData("Bee.Contracts.Dto")]
+        [InlineData("Bee.Api.Core.Something")]
+        [InlineData("Bee.Business.Employee")]
+        [DisplayName("IsTypeAllowed Bee.* 命名空間型別應回傳 true")]
+        public void IsTypeAllowed_BeeNamespaces_ReturnsTrue(string fullName)
+        {
+            // Act & Assert
+            Assert.True(SafeTypelessFormatter.IsTypeAllowed(fullName));
+        }
+
+        [Theory]
+        [InlineData("System.Diagnostics.Process")]
+        [InlineData("System.IO.File")]
+        [InlineData("SomeMalicious.Attacker.Type")]
+        [DisplayName("IsTypeAllowed 不在白名單的型別應回傳 false")]
+        public void IsTypeAllowed_UntrustedTypes_ReturnsFalse(string fullName)
+        {
+            // Act & Assert
+            Assert.False(SafeTypelessFormatter.IsTypeAllowed(fullName));
+        }
+
+        [Fact]
+        [DisplayName("SafeTypelessFormatter.Instance 應提供單例")]
+        public void Instance_IsNotNull()
+        {
+            // Act & Assert
+            Assert.NotNull(SafeTypelessFormatter.Instance);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/SortFieldTests.cs
+++ b/tests/Bee.Definition.UnitTests/SortFieldTests.cs
@@ -1,0 +1,137 @@
+using System.ComponentModel;
+using Bee.Base.Serialization;
+
+namespace Bee.Definition.UnitTests
+{
+    /// <summary>
+    /// SortField 與 SortFieldCollection 測試。
+    /// </summary>
+    public class SortFieldTests
+    {
+        [Fact]
+        [DisplayName("SortField 使用欄位名稱與方向建構應正確設定屬性")]
+        public void Constructor_ValidArguments_SetsProperties()
+        {
+            // Act
+            var sortField = new SortField("sys_id", SortDirection.Desc);
+
+            // Assert
+            Assert.Equal("sys_id", sortField.FieldName);
+            Assert.Equal(SortDirection.Desc, sortField.Direction);
+        }
+
+        [Fact]
+        [DisplayName("SortField 預設建構式應使用預設屬性值")]
+        public void DefaultConstructor_UsesDefaultValues()
+        {
+            // Act
+            var sortField = new SortField();
+
+            // Assert
+            Assert.Equal(string.Empty, sortField.FieldName);
+            Assert.Equal(SortDirection.Asc, sortField.Direction);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("SortField 欄位名稱為空白應拋出 ArgumentException")]
+        public void Constructor_EmptyFieldName_ThrowsArgumentException(string? fieldName)
+        {
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => new SortField(fieldName!, SortDirection.Asc));
+        }
+
+        [Fact]
+        [DisplayName("SortFieldCollection 新增項目後 Count 應正確反映")]
+        public void SortFieldCollection_Add_IncrementsCount()
+        {
+            // Arrange
+            var collection = new SortFieldCollection();
+
+            // Act
+            collection.Add(new SortField("sys_id", SortDirection.Asc));
+            collection.Add(new SortField("sys_no", SortDirection.Desc));
+
+            // Assert
+            Assert.Equal(2, collection.Count);
+            Assert.Equal("sys_id", collection[0].FieldName);
+            Assert.Equal(SortDirection.Desc, collection[1].Direction);
+        }
+
+        [Fact]
+        [DisplayName("SortFieldCollection 移除項目後 Count 應正確減少")]
+        public void SortFieldCollection_Remove_DecrementsCount()
+        {
+            // Arrange
+            var collection = new SortFieldCollection();
+            var field = new SortField("sys_id", SortDirection.Asc);
+            collection.Add(field);
+            collection.Add(new SortField("sys_no", SortDirection.Desc));
+
+            // Act
+            collection.Remove(field);
+
+            // Assert
+            Assert.Single(collection);
+            Assert.Equal("sys_no", collection[0].FieldName);
+        }
+
+        [Fact]
+        [DisplayName("SortField XML 序列化與反序列化應正確還原")]
+        public void SortField_XmlRoundtrip_Succeeds()
+        {
+            // Arrange
+            var original = new SortField("sys_id", SortDirection.Desc);
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(original);
+            var restored = SerializeFunc.XmlToObject<SortField>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal(original.FieldName, restored!.FieldName);
+            Assert.Equal(original.Direction, restored.Direction);
+        }
+
+        [Fact]
+        [DisplayName("SortField JSON 序列化與反序列化應正確還原")]
+        public void SortField_JsonRoundtrip_Succeeds()
+        {
+            // Arrange
+            var original = new SortField("sys_id", SortDirection.Desc);
+
+            // Act
+            var json = SerializeFunc.ObjectToJson(original);
+            var restored = SerializeFunc.JsonToObject<SortField>(json);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal(original.FieldName, restored!.FieldName);
+            Assert.Equal(original.Direction, restored.Direction);
+        }
+
+        [Fact]
+        [DisplayName("SortFieldCollection XML 序列化與反序列化應正確還原")]
+        public void SortFieldCollection_XmlRoundtrip_Succeeds()
+        {
+            // Arrange
+            var collection = new SortFieldCollection
+            {
+                new SortField("sys_id", SortDirection.Asc),
+                new SortField("sys_no", SortDirection.Desc)
+            };
+
+            // Act
+            var xml = SerializeFunc.ObjectToXml(collection);
+            var restored = SerializeFunc.XmlToObject<SortFieldCollection>(xml);
+
+            // Assert
+            Assert.NotNull(restored);
+            Assert.Equal(2, restored!.Count);
+            Assert.Equal("sys_id", restored[0].FieldName);
+            Assert.Equal(SortDirection.Desc, restored[1].Direction);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Storage/FileDefineStorageTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/FileDefineStorageTests.cs
@@ -1,0 +1,181 @@
+using System.ComponentModel;
+using System.IO;
+using Bee.Base.Data;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Definition.UnitTests.Storage
+{
+    /// <summary>
+    /// FileDefineStorage 讀寫 XML 檔案的行為測試。
+    /// 各測試使用隔離的臨時目錄做為 BackendInfo.DefinePath，避免互相汙染。
+    /// </summary>
+    [Collection("Initialize")]
+    public class FileDefineStorageTests
+    {
+        [Fact]
+        [DisplayName("SaveFormSchema / GetFormSchema 應可寫入後讀回相同結構")]
+        public void SaveAndGetFormSchema_RoundTrips()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+                var schema = new FormSchema("Demo", "示範");
+                var table = schema.Tables!.Add("Demo", "示範");
+                table.Fields!.Add("sys_id", "編號", FieldDbType.String);
+
+                // Act
+                storage.SaveFormSchema(schema);
+                var restored = storage.GetFormSchema("Demo");
+
+                // Assert
+                Assert.NotNull(restored);
+                Assert.Equal("Demo", restored!.ProgId);
+                Assert.Equal("示範", restored.DisplayName);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetFormSchema 檔案不存在應拋出 FileNotFoundException")]
+        public void GetFormSchema_FileNotFound_Throws()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+
+                // Act & Assert
+                Assert.Throws<FileNotFoundException>(() => storage.GetFormSchema("nonexistent"));
+            });
+        }
+
+        [Fact]
+        [DisplayName("SaveTableSchema / GetTableSchema 應可寫入後讀回")]
+        public void SaveAndGetTableSchema_RoundTrips()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+                var schema = new TableSchema { TableName = "ft_demo", DisplayName = "Demo" };
+                schema.Fields!.Add("sys_no", "流水號", FieldDbType.AutoIncrement);
+
+                // Act
+                storage.SaveTableSchema("common", schema);
+                var restored = storage.GetTableSchema("common", "ft_demo");
+
+                // Assert
+                Assert.NotNull(restored);
+                Assert.Equal("ft_demo", restored!.TableName);
+                Assert.Single(restored.Fields!);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetTableSchema 檔案不存在應拋出 FileNotFoundException")]
+        public void GetTableSchema_FileNotFound_Throws()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+
+                // Act & Assert
+                Assert.Throws<FileNotFoundException>(() => storage.GetTableSchema("common", "missing"));
+            });
+        }
+
+        [Fact]
+        [DisplayName("SaveFormLayout / GetFormLayout 應可寫入後讀回")]
+        public void SaveAndGetFormLayout_RoundTrips()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+                var layout = new FormLayout { LayoutId = "DemoLayout", DisplayName = "示範" };
+
+                // Act
+                storage.SaveFormLayout(layout);
+                var restored = storage.GetFormLayout("DemoLayout");
+
+                // Assert
+                Assert.NotNull(restored);
+                Assert.Equal("DemoLayout", restored!.LayoutId);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetFormLayout 檔案不存在應拋出 FileNotFoundException")]
+        public void GetFormLayout_FileNotFound_Throws()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+
+                // Act & Assert
+                Assert.Throws<FileNotFoundException>(() => storage.GetFormLayout("missing"));
+            });
+        }
+
+        [Fact]
+        [DisplayName("SaveDbSchemaSettings / GetDbSchemaSettings 應可寫入後讀回")]
+        public void SaveAndGetDbSchemaSettings_RoundTrips()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+                var settings = new DbSchemaSettings();
+
+                // Act
+                storage.SaveDbSchemaSettings(settings);
+                var restored = storage.GetDbSchemaSettings();
+
+                // Assert
+                Assert.NotNull(restored);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetDbSchemaSettings 檔案不存在應拋出 FileNotFoundException")]
+        public void GetDbSchemaSettings_FileNotFound_Throws()
+        {
+            WithTempDefinePath(() =>
+            {
+                // Arrange
+                var storage = new FileDefineStorage();
+
+                // Act & Assert
+                Assert.Throws<FileNotFoundException>(() => storage.GetDbSchemaSettings());
+            });
+        }
+
+        /// <summary>
+        /// 暫時將 <see cref="BackendInfo.DefinePath"/> 指向新建立的臨時目錄，
+        /// 測試結束後還原原值並刪除目錄。
+        /// </summary>
+        private static void WithTempDefinePath(Action action)
+        {
+            var original = BackendInfo.DefinePath;
+            var tempDir = Path.Combine(Path.GetTempPath(), $"bee-define-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                BackendInfo.DefinePath = tempDir;
+                action();
+            }
+            finally
+            {
+                BackendInfo.DefinePath = original;
+                if (Directory.Exists(tempDir))
+                    Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 摘要

依 `docs/plans/plan-bee-definition-test-coverage.md` 計畫書，為 `Bee.Definition` 專案補齊 P0 / P1 / P2 三階段單元測試，目標將 Line Coverage 拉升至 ≥ 75%。

新增 18 個測試檔、約 2400 行、涵蓋 60+ 個公開型別。

## 變更內容

### 計畫書 (`f0d3505`)
- `docs/plans/plan-bee-definition-test-coverage.md`：現況盤點、三階段優先級、驗收條件、風險備註

### 測試實作 (`410a85a`)

**P0（關鍵路徑）**
- `DefineFuncTests.cs`（擴充）：7 種 DefineType、無效型別例外、`GetNumberFormatString` 所有分支、`GetListLayout` 結構
- `DefinePathInfoTests.cs`：7 個路徑組合方法
- `SortFieldTests.cs`：建構子驗證 (`ArgumentException`) + XML/JSON round-trip
- `DtoSerializationTests.cs`：FormSchema / TableSchema / FormLayout / DatabaseSettings / ProgramSettings / DbSchemaSettings / SystemSettings 序列化與 Clone
- `Filters/FilterGroupTests.cs`：工廠方法、`ShouldSerializeNodes`、三層巢狀 round-trip、各 `ComparisonOperator` 的 `ToString`

**P1（高價值邏輯）**
- `Database/TableSchemaGeneratorTests.cs`：null guard、DbTableName 回退、主鍵/唯一/外鍵索引規則
- `Layouts/FormLayoutGeneratorTests.cs`：null guard、主/明細群組、Auto 控制型態對應、LookupProgId 優先序
- `Collections/MessagePackKeyCollectionTests.cs`：CRUD 與大小寫不敏感鍵
- `Security/EncryptionKeyProtectorTests.cs`：空金鑰/密文、錯誤金鑰、非 Base64
- `Security/MasterKeyProviderTests.cs`：File/Environment 兩種來源 × autoCreate × 錯誤路徑
- `Storage/FileDefineStorageTests.cs`：所有 getter 的 round-trip 與 `FileNotFoundException`
- `Serialization/SafeTypelessFormatterTests.cs`：型別白名單驗證

**P2（補完覆蓋）**
- `Collections/ListItemCollectionTests.cs`、`ParameterCollectionTests.cs`、`PropertyCollectionTests.cs`
- `DtoPropertyTests.cs`：SessionInfo / SessionUser / UserInfo 預設值與 ToString
- `Attributes/ApiAccessControlAttributeTests.cs`
- `Logging/LoggingTests.cs`：ConsoleLogWriter / NullLogWriter / LogEntry / LogOptions

## 設計注意

- 涉及 `BackendInfo.DefinePath` 全域狀態的測試一律使用 `[Collection("Initialize")]` 串接 `GlobalFixture`，避免與其他測試平行執行。
- 檔案 I/O 測試使用 `Path.GetTempPath() + Guid` 的隔離目錄，測試結束後清理，不汙染 repo。
- MessagePack 序列化測試僅限已在 `Bee.Definition` 內完成 resolver 設定的情境；原計畫的集合型 MessagePack round-trip 需要 Bee.Api.Core 層的 resolver，故本次未實作。

## Test Plan

- [ ] CI `build-ci.yml` 全部通過
- [ ] 所有新增測試通過
- [ ] SonarCloud 顯示 `Bee.Definition` Line Coverage 達 ≥ 75%
