### PR TITLE
test(Bee.Db): 補強單元測試覆蓋率（118 個新測試）

### DIFF
--- a/docs/plans/plan-bee-db-test-coverage.md
+++ b/docs/plans/plan-bee-db-test-coverage.md
@@ -1,0 +1,278 @@
+# Bee.Db 測試覆蓋率提升計畫書
+
+**狀態：✅ 已完成（2026-04-18）**
+
+## 完成摘要
+
+- **新增測試**：階段 1（13）+ 階段 2（74）+ 階段 3（31）= **118 個新測試**
+- **Bee.Db.UnitTests 總計**：248 通過 / 22 略過（CI 模式）
+- **新增測試檔（共 11 個）**：
+  - 階段 1：`DbCommandSpecTests`（補強）、`TableSchemaComparerTests`（補強）
+  - 階段 2：`DbCommandResultTests`、`DbParameterSpecTests`、`DbParameterSpecCollectionTests`、`DbConnectionScopeTests`、`DefaultParameterCollectorTests`、`FromBuilderTests`、`ILMapperTests`、`DbProviderManagerTests`、`SqlTableSchemaProviderStaticTests`、`SqlFormCommandBuilderTests`
+  - 階段 3：`DbAccessExtraTests`（17 tests）、`SelectCommandBuilderTests`（5 tests）、`DbAccessLoggerTests`（補強 +3）、`TableJoinCollectionTests`（6 tests）
+- **執行方式**：所有新測試皆為純邏輯測試，CI 模式（`CI=true`）下完整執行；不新增任何 `[LocalOnlyFact]`。
+
+## 1. 背景與目標
+
+`Bee.Db` 是 Bee.NET 框架的資料存取層，提供 ADO.NET 抽象、動態 SQL 生成、多資料庫識別符跳脫、以 IL emit 實現的 `DbDataReader → POCO` 高效映射、以及 Schema 探查與比較。下游被 `Bee.Repository`、`Bee.Business`、`Bee.Api.*` 等所有業務層套件依賴，是源碼掃描（SonarCloud / SAST）審視的高風險區。
+
+現況觀察：
+
+- 大量現有測試標記為 `[LocalOnlyFact]`／`[LocalOnlyTheory]`，在 CI（`CI=true`）時會被跳過，導致 SonarCloud 顯示的覆蓋率偏低。
+- 部分純邏輯類別（`DbCommandSpec`、`DbCommandResult`、`DbParameterSpec`、`DefaultParameterCollector`、`FromBuilder`、`SelectBuilder` 等）完全可在無資料庫情況下測試，目前完全或部分缺漏。
+- `DbAccessLogger`、`DbConnectionScope`、`InternalWhereBuilder` 邊界分支尚未涵蓋。
+
+**目標**：
+
+1. 在不依賴外部資料庫的前提下，補齊 `Bee.Db` 所有可純邏輯測試類別，使 SonarCloud 顯示的 `Bee.Db` Line Coverage 顯著提升（預期 ≥ 70%；扣除必須連 DB 的部分後 ≥ 85%）。
+2. 所有 `public` 類別至少有一個對應測試檔。
+3. 不新增任何需連接真實資料庫的測試；既有 `[LocalOnlyFact]` 測試保持原樣，不在本計畫範圍。
+4. 通過源碼掃描所列規則（`scanning.md` / `sonarcloud.md`）。
+
+## 2. 現況盤點
+
+下表以「資料夾分組」列出 `Bee.Db` 所有公開類別與目前測試狀態。
+
+圖例：✅ 已完整覆蓋 / ⚠ 部分覆蓋（多為 LocalOnly）／ ❌ 完全無測試
+
+### 2.1 根目錄
+
+| 類別 | 狀態 | 現有測試 | 備註 |
+|------|------|----------|------|
+| `DbAccess` | ⚠ | DbAccessTests（LocalOnly） | 純邏輯部分（建構子驗證、ToString、空 batch、null 參數）未測 |
+| `DbFunc` | ⚠ | DbFuncTests | 已涵蓋 `QuoteIdentifier`、`GetParameterPrefix`；`InferDbType`、`GetParameterName`、`SqlFormat`、`GetSqlDefaultValue` 未測 |
+| `DbCommandSpec` | ❌ | — | 三個建構子、佔位符解析（`{0}`、`{Name}`、`{{Name}}`、`{@Parameters}`）、`CommandTimeout` 限制邏輯未測 |
+| `DbCommandResult` | ❌ | — | 三個工廠方法 `ForRowsAffected`、`ForScalar`、`ForTable` 未測 |
+| `DbParameterSpec` | ❌ | — | 建構子推斷 DbType、`Name` 與 `Key` 同步、`ToString` 未測 |
+| `DbParameterSpecCollection` | ❌ | — | `Add(name, value)` 與 `Add(DbField)` 未測 |
+| `DbBatchSpec` / `DbBatchResult` / `DbCommandSpecCollection` / `DbCommandResultCollection` | ❌ | — | 屬性預設值即可 |
+| `DbConnectionScope` | ❌ | — | 純邏輯：null factory、null connection 防護；對「擁有連線」與「外部連線」的 Dispose 行為差異 |
+| `DataTableUpdateSpec` | ❌ | — | 屬性與預設值 |
+| `TableSchemaCommandBuilder` | ❌ | — | `BuildInsertCommand`、`BuildUpdateCommand`、`BuildDeleteCommand`、`BuildUpdateSpec` 可用記憶體 `TableSchema` 測試 |
+| `ILMapper<T>` | ❌ | — | `CreateMapFunc`／`MapToList`／`MapToEnumerable`／`ClearCache` 可用 `DataTable.CreateDataReader()` 測試 |
+| `DbCommandKind` / `JoinType`（enum） | n/a | — | enum 不單獨測試 |
+| `CommandTextVariable` | ❌ | — | 常數即可 |
+
+### 2.2 Logging
+
+| 類別 | 狀態 | 現有測試 | 備註 |
+|------|------|----------|------|
+| `DbAccessLogger` | ⚠ | DbAccessLoggerTests | `LogStart` 已測，`LogEnd` 與內部閾值分支未測 |
+| `DbLogContext` | ❌ | — | 屬性預設值與計時器初始化 |
+
+### 2.3 Manager
+
+| 類別 | 狀態 | 現有測試 | 備註 |
+|------|------|----------|------|
+| `DbConnectionManager` | ❌ | — | `GetConnectionInfo` 快取／重複呼叫／`Remove`／`Clear`／`Contains`／`Count`、空字串拋例外 |
+| `DbProviderManager` | ❌ | — | `RegisterProvider` 防 null、`GetFactory` 找不到時 `KeyNotFoundException` |
+| `DbConnectionInfo` | ❌ | — | 透過 `DbConnectionManager` 間接覆蓋；屬性 getter |
+
+### 2.4 Providers
+
+| 類別 | 狀態 | 現有測試 | 備註 |
+|------|------|----------|------|
+| `SelectCommandBuilder` | ⚠ | BuildSelectCommandTests（LocalOnly） | 純邏輯部分（空 tableName 拋例外、找不到 table 拋例外）可不依賴 DB |
+| `SqlFormCommandBuilder` | ⚠ | 同上 | `BuildInsertCommand`／`Update`／`Delete` 必拋 `NotSupportedException`；建構子 null 防護未測 |
+| `SqlCreateTableCommandBuilder` | ❌ | — | 透過記憶體 `TableSchema` 測試 `GetCommandText`（New / Upgrade 分支）、`ConverDbType` 各型別、`GetDefaultValue` 各型別 |
+| `SqlTableSchemaProvider` | ⚠ | LocalOnly | `GetFieldDbType` 與 `ParseDBDefaultValue` 為 `public static`，可純邏輯測試（覆蓋所有 SQL Server 型別映射分支） |
+| `IFormCommandBuilder` / `ICreateTableCommandBuilder` | n/a | — | 介面 |
+
+### 2.5 Query
+
+| 類別 | 狀態 | 現有測試 | 備註 |
+|------|------|----------|------|
+| `WhereBuilder` | ✅ | WhereBuilderTests | 已涵蓋多數情境；可補 `>`、`<`、`>=`、`<=`、`Like`、`StartsWith`、`EndsWith`、`NotEqual`、`IS NOT NULL`、`Between` 缺第二值＋`IgnoreIfNull`、未知 operator 等剩餘分支 |
+| `SortBuilder` | ✅ | SortBuilderTests | 已涵蓋；`selectContext` 重映射分支可補 |
+| `FromBuilder` | ❌ | — | `null`／空 joins 路徑、單一 join、多 join 排序 |
+| `SelectBuilder` | ❌ | — | 需要 `FormTable` fixture，可在 `tests/Define` 既有定義基礎上做 |
+| `SelectContextBuilder` | ❌ | — | 邏輯複雜，非 LocalOnly 仍可測 alias 進位（`A → B → … → Z → ZA`）與 SQL keyword 跳過 |
+| `SelectContext` / `QueryFieldMapping` / `QueryFieldMappingCollection` / `TableJoin` / `TableJoinCollection` / `WhereBuildResult` | ❌ | — | 屬性與 `ToString`、`FindRightAlias` |
+| `DefaultParameterCollector` | ❌ | — | 建構子防 null/empty prefix、`Add` 編號、`GetAll` 內容 |
+| `InternalWhereBuilder` | ❌ | — | 已被 `WhereBuilder` 間接覆蓋；剩餘錯誤分支（未知節點型別、IN 非 enumerable、空 FieldName）可直接針對 `WhereBuilder` 測 |
+| `IFromBuilder` / `ISelectBuilder` / `ISortBuilder` / `IWhereBuilder` / `IParameterCollector` | n/a | — | 介面 |
+
+### 2.6 Schema
+
+| 類別 | 狀態 | 現有測試 | 備註 |
+|------|------|----------|------|
+| `TableSchemaBuilder` | ⚠ | TableSchemaBuilderTests（LocalOnly） | 主要走 DB 路徑，純邏輯部分有限 |
+| `TableSchemaComparer` | ❌ | — | 可用記憶體 `TableSchema` 測試 New / Upgrade / 欄位差異 / 索引差異 / extension fields |
+
+## 3. 測試缺口優先級
+
+### P0（必補，純邏輯且影響 SonarCloud 覆蓋率最大）
+
+| 項目 | 理由 |
+|------|------|
+| `DbCommandSpec` | 程式碼最大且含正規式解析；佔位符 bug 直接造成 SQL 注入或語法錯誤 |
+| `DbFunc` 補完 | `InferDbType`／`SqlFormat`／`GetParameterName`／`GetSqlDefaultValue` 為 utility，全部可純邏輯測試 |
+| `TableSchemaCommandBuilder` | INSERT/UPDATE/DELETE 命令生成是 CRUD 核心，必須有單元測試保護 |
+| `SqlCreateTableCommandBuilder` | DDL 生成；`ConverDbType` 涵蓋所有 `FieldDbType` 分支才安全 |
+| `TableSchemaComparer` | Schema 升級邏輯，純邏輯且容易設計 fixture |
+| `WhereBuilder` 缺漏分支 | 補齊比較運算符與錯誤路徑 |
+
+### P1（應補）
+
+| 項目 | 理由 |
+|------|------|
+| `DbCommandResult` / `DbParameterSpec` / `DbParameterSpecCollection` | 結構簡單但被廣泛引用；測試成本低 |
+| `DbConnectionScope` | null factory、null connection、`Dispose` 不關閉外部連線等防護 |
+| `DefaultParameterCollector` | 純邏輯；含建構子防護分支 |
+| `FromBuilder` | 單純的字串組合，搭配 `TableJoinCollection` 即可測 |
+| `ILMapper<T>` | 用 `DataTable.CreateDataReader()` 即可建立記憶體 reader 進行測試 |
+| `DbProviderManager` / `DbConnectionManager` | 靜態管理器，需注意全域狀態還原（測試結束 `Clear()`） |
+| `SqlTableSchemaProvider` 純邏輯部分 | `GetFieldDbType`、`ParseDBDefaultValue` 為 `public static`，可表格驅動測試 |
+| `SqlFormCommandBuilder` `NotSupportedException` 分支 | 三個方法各補一行測試即可 |
+
+### P2（選補）
+
+- `SelectCommandBuilder` 純邏輯防護（空 tableName、找不到 table）
+- `SelectBuilder` / `SelectContextBuilder`（需 FormTable fixture）
+- 剩餘 collection/DTO 屬性測試
+- `DbAccessLogger.LogEnd` 閾值分支（涉及 `BackendInfo.LogOptions`，需注意全域狀態）
+
+## 4. 實施階段
+
+採三階段，每階段結束後執行 `dotnet test --configuration Release --settings .runsettings` 並觀察 SonarCloud 覆蓋率。
+
+### 階段 1：P0 核心（預估 2~3 日）
+
+1. **`DbCommandSpecTests`**
+   - 三個建構子：空 commandText 拋 `ArgumentNullException`、positional values 自動命名為 `p0/p1...`、named parameters 寫入 `Parameters`
+   - 佔位符解析：`{0}` → `@p0`、`{Name}` → `@Name`、`{{Name}}` → `{Name}`（escape）、`{@Parameters}` 展開為逗號清單
+   - `CommandTimeout` setter：≤0 用預設、超過 cap 套用 cap、合法值原樣使用
+   - `ResolveParameters` 例外：索引越界、空 name、找不到 named key
+   - `CreateCommand`：`null` connection 拋例外、`StoredProcedure` 跳過解析、參數名不重複加 prefix
+   - `ToString`
+
+2. **`DbFuncTests` 擴充**
+   - `InferDbType`：所有原生型別 + `null`/`DBNull` → `null` + 不支援型別 → `null`
+   - `GetParameterName`：四種 DB
+   - `SqlFormat`：用 `SqlClientFactory` 建立記憶體 `DbParameterCollection`
+   - `GetSqlDefaultValue`：所有 `FieldDbType` 分支（透過 `SqlCreateTableCommandBuilder` 間接覆蓋亦可，但直接測較直觀；此方法為 internal，需透過 `InternalsVisibleTo` 或經由 `SqlCreateTableCommandBuilder` 間接）
+
+3. **`TableSchemaCommandBuilderTests`**
+   - 用記憶體 `TableSchema`（含 `sys_rowid` PK + 數個 `DbField`）測試三個 `Build*Command`
+   - `BuildUpdateSpec` 包裝完整、null `DataTable` 拋例外
+   - 兩個建構子（顯式 DatabaseType / 隱式取 BackendInfo）
+
+4. **`SqlCreateTableCommandBuilderTests`**
+   - `ConverDbType` 各 `FieldDbType` 分支：`String`、`Text`、`Boolean`、`AutoIncrement`、`Short`、`Integer`、`Long`、`Decimal`（自訂 precision/scale）、`Currency`、`Date`、`DateTime`、`Guid`、`Binary`
+   - 不支援 `FieldDbType.Unknown` 拋例外
+   - `GetCommandText`：`UpgradeAction.New` 走 `CREATE TABLE`、`UpgradeAction.Upgrade` 走 drop/create/insert/rename 五段
+   - 主索引存在時包含 `CONSTRAINT ... PRIMARY KEY (...)` 字樣
+   - 含獨立索引時包含 `CREATE INDEX`／`CREATE UNIQUE INDEX`
+
+5. **`TableSchemaComparerTests`**
+   - `realTable == null` → `UpgradeAction.New`
+   - 完全相同 → `UpgradeAction.None`
+   - 欄位差異 → `UpgradeAction.Upgrade` 並標記欄位 `New`／`Upgrade`
+   - 索引差異 → `UpgradeAction.Upgrade` 並標記索引
+   - 實際表中多出的欄位 → `AddExtensionFields` 帶入結果
+
+6. **`WhereBuilderTests` 擴充**
+   - 比較運算符：`>`、`<`、`>=`、`<=`、`!=` 各一條測試
+   - `Like`、`StartsWith`、`EndsWith`
+   - 值為 null 且 operator 為 `NotEqual` → `IS NOT NULL`
+   - 值為 null 且 operator 不支援 → 拋 `InvalidOperationException`
+   - `Between` 缺 `SecondValue` 且 `IgnoreIfNull=true` → 空字串
+   - `Between` 缺 `SecondValue` 且 `IgnoreIfNull=false` → 拋例外
+   - `IN` 傳入非 enumerable → 拋例外
+   - 空 FieldName → 拋例外
+
+### 階段 2：P1 公開 API（預估 2 日）
+
+1. **`DbCommandResultTests`** — 三個 factory method 各回傳對應 Kind 與資料
+2. **`DbParameterSpecTests`** — 建構子正確推斷 DbType、Name/Key 同步、`ToString`
+3. **`DbParameterSpecCollectionTests`** — `Add(name, value)` 防空字串、`Add(DbField)` 設定來源欄位
+4. **`DbConnectionScopeTests`**
+   - `Create` null factory + null externalConnection → 拋例外
+   - 外部連線：State=Open → 不重新開啟、Dispose 不關閉連線
+   - 外部連線：State=Closed → 開啟後 Dispose 不關閉
+   - 用 SQLite in-memory（`Microsoft.Data.Sqlite`）作為輕量測試 DbProviderFactory；若引入 nuget 嫌重，改用一個 fake `DbConnection` 實作
+   - **替代方案**：直接以反射或測試替身（Moq 不在依賴內）實作最小 `DbConnection` mock；以 `System.Data.Common.DbProviderFactory` 子類別承載
+   - **更佳替代**：跳過此檔，僅測 null 參數防護分支（避免引入 mock 框架）
+5. **`DefaultParameterCollectorTests`**
+   - 建構子 null/empty prefix → `ArgumentException`
+   - `Add` 連續呼叫產生 `@p0`、`@p1`
+   - `GetAll` 回傳值與 key 對應正確
+6. **`FromBuilderTests`**
+   - 空 joins → `FROM [Main] A`
+   - 單一 join → 含 `LEFT JOIN [Right] B ON A.x = B.y`
+   - 多 join 依 RightAlias 排序
+7. **`ILMapperTests`**
+   - 用 `DataTable.CreateDataReader()` 製作 reader
+   - 屬性大小寫不一致仍能對映（`StringComparer.OrdinalIgnoreCase`）
+   - DBNull 欄位不寫入屬性（保留預設值）
+   - `MapToList` 與 `MapToEnumerable` 結果一致
+   - `ClearCache` 與 `CacheCount`：建立 → cache > 0 → 清空 → 0
+   - 沒有無參數建構子的型別 → 拋 `InvalidOperationException`
+8. **`DbProviderManagerTests`**
+   - `RegisterProvider` null factory → `ArgumentNullException`
+   - `GetFactory` 未註冊 → `KeyNotFoundException`
+   - 重複 `RegisterProvider` 後新值取代舊值
+9. **`SqlTableSchemaProviderStaticTests`**
+   - `GetFieldDbType` 各 SQL 型別分支（含 `NVARCHAR(-1)` → `Text`、`DECIMAL(19,4)` → `Currency`）
+   - `ParseDBDefaultValue` 各型別分支（`NVARCHAR` 雙層剝除、`INT`／`BIT`／`DATETIME`、不支援型別 → 空字串、與內建預設一致 → 空字串）
+10. **`SqlFormCommandBuilderTests`**
+    - 三個 `BuildXxxCommand` 都拋 `NotSupportedException`
+    - 建構子 null FormSchema → `ArgumentNullException`
+    - 建構子 progID 不存在 → `ArgumentException`
+
+### 階段 3：P2 補強與收斂（預估 1 日）
+
+1. **`DbAccessTests` 擴充純邏輯部分**
+   - 建構子：空 databaseId 拋 `ArgumentException`、null external connection 拋 `ArgumentNullException`
+   - `Execute(null)` / `ExecuteBatch(null)` / `ExecuteBatch(空 commands)` / `UpdateDataTable(null)` 各拋對應例外
+   - `ToString` 包含 DatabaseType 名稱
+2. **`SqlFormCommandBuilder` / `SelectCommandBuilder` 純邏輯防護**
+   - `Build` 空 tableName → `ArgumentException`
+   - 找不到 table → `InvalidOperationException`
+3. **`DbAccessLoggerTests` 擴充**
+   - `LogEnd` null context → `ArgumentNullException`
+   - `LogEnd` 在 `LogOptions == null` 時不擲例外
+4. **`TableJoinCollectionTests`** — `FindRightAlias`：null/empty/找不到/找到
+5. **覆蓋率收斂**
+   - 本機產出 coverage 報告：
+     ```bash
+     dotnet test tests/Bee.Db.UnitTests/Bee.Db.UnitTests.csproj \
+         --configuration Release \
+         --settings .runsettings \
+         /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
+     ```
+   - 對照 SonarCloud 的 Bee.Db Line Coverage，確認顯著提升
+   - 對於走不到的 `[LocalOnlyFact]` 路徑（如 ADO.NET 連線、IL emit 對不存在 column 的處理），在 PR 描述中註記
+
+## 5. 測試撰寫規範（遵循 `.claude/rules/testing.md`）
+
+- 測試檔放在 `tests/Bee.Db.UnitTests/` 根目錄，檔名 `<SutClassName>Tests.cs`
+- 方法命名：`<方法>_<情境>_<預期結果>`
+- 使用 `[Fact]` / `[Theory]`；本計畫範圍內**不再新增** `[LocalOnlyFact]`
+- 每個測試一律加 `[DisplayName]` 中文描述
+- 測試傳入 `null` 驗邊界時使用 `null!`
+- 不依賴外部資料庫；需要 `BackendInfo`／`SysInfo` 的測試使用 `[Collection("Initialize")]` 共用既有 `DbGlobalFixture`
+- `DbProviderManager` 等靜態狀態相關測試：若會修改全域狀態，置於獨立 collection 避免汙染其他測試
+- 安全相關測試：佔位符解析必須驗證**不會將 raw value 拼接進 SQL**
+
+## 6. 風險與注意事項
+
+1. **`DbConnectionManager` / `DbProviderManager` 為靜態類**：被全域 `DbGlobalFixture` 預先初始化。新增測試若呼叫 `Clear()` 或 `RegisterProvider()` 會汙染既有測試；建議只測「預期失敗」的分支（null、KeyNotFound），不破壞既有註冊。
+2. **`DbCommandSpec.CreateCommand` 需要 `DbConnection`**：可透過 `Microsoft.Data.SqlClient.SqlConnection` 不開啟連線即可建立 `SqlCommand`；測試中只檢查 `CommandText`、`Parameters`，不執行。
+3. **`ILMapper<T>` 的 IL emit**：`DataTable.CreateDataReader()` 產生的 `DataTableReader` 是 `DbDataReader` 的實作，可直接餵入。
+4. **`TableSchemaComparer` 與 `TableSchema`**：需要建立 `TableSchema` 物件，注意 `Indexes` 與 `Fields` 的初始化順序。
+5. **覆蓋率不等於品質**：每個測試至少 1 個 `Assert`；佔位符解析等安全相關測試需要驗證實際輸出而非僅檢查不擲例外。
+6. **`DbFunc.GetSqlDefaultValue` 為 internal**：可透過已對 `Bee.Db.UnitTests` 開放的 `InternalsVisibleTo`（如已設定）直接測；若未設定，改透過 `SqlCreateTableCommandBuilder.GetCommandText` 間接覆蓋。需先確認 `Bee.Db.csproj` 是否有 `InternalsVisibleTo`。
+
+## 7. 預期成果
+
+- Bee.Db 覆蓋率從目前（受 LocalOnly 影響）的低水位顯著提升，預期 SonarCloud 顯示 ≥ 70%
+- 所有 P0 類別 ≥ 90% 行覆蓋
+- 新增約 10~12 個測試檔，約 80~120 個測試案例
+- 通過源碼掃描（無新增 SonarCloud / Roslyn 警告）
+- 對 `DbCommandSpec` 佔位符解析（最易出錯的安全相關邏輯）建立完整安全網
+
+## 8. 執行後續
+
+- 本計畫執行完畢且合併後，依 `CLAUDE.md` 工作流程由使用者要求才將本文件移至 `docs/plans/archive/`
+- 若階段 1 完成後發現估時偏差過大，回報並調整階段 2、3 範圍

--- a/tests/Bee.Db.UnitTests/DbAccessExtraTests.cs
+++ b/tests/Bee.Db.UnitTests/DbAccessExtraTests.cs
@@ -1,0 +1,182 @@
+using System.ComponentModel;
+using Microsoft.Data.SqlClient;
+
+namespace Bee.Db.UnitTests
+{
+    [Collection("Initialize")]
+    public class DbAccessExtraTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("DbAccess(string) databaseId 為空白應擲 ArgumentException")]
+        public void Constructor_EmptyDatabaseId_Throws(string databaseId)
+        {
+            Assert.Throws<ArgumentException>(() => new DbAccess(databaseId));
+        }
+
+        [Fact]
+        [DisplayName("DbAccess(string) databaseId 為 null 應擲 ArgumentException")]
+        public void Constructor_NullDatabaseId_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => new DbAccess((string)null!));
+        }
+
+        [Fact]
+        [DisplayName("DbAccess(DbConnection) 連線為 null 應擲 ArgumentNullException")]
+        public void Constructor_NullExternalConnection_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DbAccess((System.Data.Common.DbConnection)null!));
+        }
+
+        [Fact]
+        [DisplayName("Execute(null) 應擲 ArgumentNullException")]
+        public void Execute_NullCommand_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            Assert.Throws<ArgumentNullException>(() => dbAccess.Execute(null!));
+        }
+
+        [Fact]
+        [DisplayName("Execute(spec, null transaction) 應擲 ArgumentNullException")]
+        public void Execute_NullTransaction_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+            var spec = new DbCommandSpec(DbCommandKind.Scalar, "SELECT 1");
+
+            Assert.Throws<ArgumentNullException>(() => dbAccess.Execute(spec, null!));
+        }
+
+        [Fact]
+        [DisplayName("ExecuteAsync(null) 應擲 ArgumentNullException")]
+        public async Task ExecuteAsync_NullCommand_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await dbAccess.ExecuteAsync(null!));
+        }
+
+        [Fact]
+        [DisplayName("ExecuteAsync(spec, null transaction) 應擲 ArgumentNullException")]
+        public async Task ExecuteAsync_NullTransaction_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+            var spec = new DbCommandSpec(DbCommandKind.Scalar, "SELECT 1");
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await dbAccess.ExecuteAsync(spec, null!));
+        }
+
+        [Fact]
+        [DisplayName("ExecuteBatch(null) 應擲 ArgumentNullException")]
+        public void ExecuteBatch_NullBatch_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            Assert.Throws<ArgumentNullException>(() => dbAccess.ExecuteBatch(null!));
+        }
+
+        [Fact]
+        [DisplayName("ExecuteBatch 空 Commands 應擲 ArgumentException")]
+        public void ExecuteBatch_EmptyCommands_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+            var batch = new DbBatchSpec();
+            // Commands 預設為新的空集合
+
+            Assert.Throws<ArgumentException>(() => dbAccess.ExecuteBatch(batch));
+        }
+
+        [Fact]
+        [DisplayName("ExecuteBatchAsync(null) 應擲 ArgumentNullException")]
+        public async Task ExecuteBatchAsync_NullBatch_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await dbAccess.ExecuteBatchAsync(null!));
+        }
+
+        [Fact]
+        [DisplayName("ExecuteBatchAsync 空 Commands 應擲 ArgumentException")]
+        public async Task ExecuteBatchAsync_EmptyCommands_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+            var batch = new DbBatchSpec();
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                async () => await dbAccess.ExecuteBatchAsync(batch));
+        }
+
+        [Fact]
+        [DisplayName("UpdateDataTable(null) 應擲 ArgumentNullException")]
+        public void UpdateDataTable_NullSpec_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            Assert.Throws<ArgumentNullException>(() => dbAccess.UpdateDataTable(null!));
+        }
+
+        [Fact]
+        [DisplayName("UpdateDataTable spec 全為 null command 應擲 ArgumentException")]
+        public void UpdateDataTable_AllNullCommands_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+            var spec = new DataTableUpdateSpec
+            {
+                DataTable = new System.Data.DataTable(),
+                InsertCommand = null,
+                UpdateCommand = null,
+                DeleteCommand = null
+            };
+
+            Assert.Throws<ArgumentException>(() => dbAccess.UpdateDataTable(spec));
+        }
+
+        [Fact]
+        [DisplayName("Query(null) 應擲 ArgumentNullException")]
+        public void Query_NullCommand_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            Assert.Throws<ArgumentNullException>(() => dbAccess.Query<object>(null!));
+        }
+
+        [Fact]
+        [DisplayName("QueryAsync(null) 應擲 ArgumentNullException")]
+        public async Task QueryAsync_NullCommand_Throws()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await dbAccess.QueryAsync<object>(null!));
+        }
+
+        [Fact]
+        [DisplayName("ToString 應包含 DatabaseType 與 Provider 名稱")]
+        public void ToString_ContainsTypeAndProvider()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+
+            var text = dbAccess.ToString();
+
+            Assert.Contains("DbAccess", text);
+            Assert.Contains("DatabaseType", text);
+            Assert.Contains("Provider", text);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbAccessLoggerTests.cs
+++ b/tests/Bee.Db.UnitTests/DbAccessLoggerTests.cs
@@ -36,5 +36,42 @@ namespace Bee.Db.UnitTests
             var context = DbAccessLogger.LogStart(command);
             Assert.Throws<ArgumentNullException>(() => DbAccessLogger.LogError(context, null!));
         }
+
+        [Fact]
+        [DisplayName("LogStart 應回傳含 CommandText 與 DatabaseId 的 context 並啟動 Stopwatch")]
+        public void LogStart_ReturnsContextWithRunningStopwatch()
+        {
+            var command = new Bee.Db.DbCommandSpec(
+                Bee.Db.DbCommandKind.Scalar, "SELECT 1");
+
+            var context = DbAccessLogger.LogStart(command, "common");
+
+            Assert.NotNull(context);
+            Assert.Equal("SELECT 1", context.CommandText);
+            Assert.Equal("common", context.DatabaseId);
+            Assert.True(context.Stopwatch.IsRunning);
+        }
+
+        [Fact]
+        [DisplayName("LogEnd context 為 null 應擲出 ArgumentNullException")]
+        public void LogEnd_NullContext_ThrowsArgumentNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => DbAccessLogger.LogEnd(null!));
+        }
+
+        [Fact]
+        [DisplayName("LogEnd 應停止 Stopwatch 且 LogOptions 為 null 不應擲例外")]
+        public void LogEnd_StopsStopwatchAndDoesNotThrowWhenLogOptionsNull()
+        {
+            // BackendInfo.LogOptions 在無設定 fixture 時通常為 null，LogEnd 應安全 return
+            var command = new Bee.Db.DbCommandSpec(
+                Bee.Db.DbCommandKind.Scalar, "SELECT 1");
+            var context = DbAccessLogger.LogStart(command);
+
+            var ex = Record.Exception(() => DbAccessLogger.LogEnd(context, affectedRows: 0));
+
+            Assert.Null(ex);
+            Assert.False(context.Stopwatch.IsRunning);
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/DbCommandResultTests.cs
+++ b/tests/Bee.Db.UnitTests/DbCommandResultTests.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel;
+using System.Data;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbCommandResultTests
+    {
+        [Fact]
+        [DisplayName("ForRowsAffected 應回傳 NonQuery Kind 並設定 RowsAffected")]
+        public void ForRowsAffected_SetsKindAndRows()
+        {
+            var result = DbCommandResult.ForRowsAffected(7);
+
+            Assert.Equal(DbCommandKind.NonQuery, result.Kind);
+            Assert.Equal(7, result.RowsAffected);
+            Assert.Null(result.Scalar);
+            Assert.Null(result.Table);
+        }
+
+        [Fact]
+        [DisplayName("ForScalar 應回傳 Scalar Kind 並保留 value")]
+        public void ForScalar_SetsKindAndScalar()
+        {
+            var result = DbCommandResult.ForScalar(123);
+
+            Assert.Equal(DbCommandKind.Scalar, result.Kind);
+            Assert.Equal(123, result.Scalar);
+            Assert.Equal(0, result.RowsAffected);
+            Assert.Null(result.Table);
+        }
+
+        [Fact]
+        [DisplayName("ForScalar value 為 null 仍回傳 Scalar Kind")]
+        public void ForScalar_NullValue_ReturnsScalarKind()
+        {
+            var result = DbCommandResult.ForScalar(null);
+
+            Assert.Equal(DbCommandKind.Scalar, result.Kind);
+            Assert.Null(result.Scalar);
+        }
+
+        [Fact]
+        [DisplayName("ForTable 應回傳 DataTable Kind 並保留 table 參考")]
+        public void ForTable_SetsKindAndTable()
+        {
+            var table = new DataTable("demo");
+            var result = DbCommandResult.ForTable(table);
+
+            Assert.Equal(DbCommandKind.DataTable, result.Kind);
+            Assert.Same(table, result.Table);
+            Assert.Equal(0, result.RowsAffected);
+            Assert.Null(result.Scalar);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbCommandSpecTests.cs
+++ b/tests/Bee.Db.UnitTests/DbCommandSpecTests.cs
@@ -1,0 +1,382 @@
+using System.ComponentModel;
+using System.Data;
+using Bee.Definition;
+using Microsoft.Data.SqlClient;
+
+namespace Bee.Db.UnitTests
+{
+    [Collection("Initialize")]
+    public class DbCommandSpecTests
+    {
+        #region 建構子測試
+
+        [Fact]
+        [DisplayName("預設建構子應建立空的命令規格")]
+        public void DefaultConstructor_CreatesEmptySpec()
+        {
+            var spec = new DbCommandSpec();
+
+            Assert.Equal(DbCommandKind.NonQuery, spec.Kind);
+            Assert.Equal(string.Empty, spec.CommandText);
+            Assert.Equal(CommandType.Text, spec.CommandType);
+            Assert.Equal(30, spec.CommandTimeout);
+            Assert.NotNull(spec.Parameters);
+            Assert.Empty(spec.Parameters);
+        }
+
+        [Fact]
+        [DisplayName("位置參數建構子應依序加入名稱為 p0、p1 的參數")]
+        public void PositionalConstructor_AddsP0P1Parameters()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE A = {0} AND B = {1}", "x", 123);
+
+            Assert.Equal(DbCommandKind.Scalar, spec.Kind);
+            Assert.Equal("SELECT * FROM T WHERE A = {0} AND B = {1}", spec.CommandText);
+            Assert.Equal(2, spec.Parameters.Count);
+            Assert.Equal("p0", spec.Parameters[0].Name);
+            Assert.Equal("x", spec.Parameters[0].Value);
+            Assert.Equal("p1", spec.Parameters[1].Name);
+            Assert.Equal(123, spec.Parameters[1].Value);
+        }
+
+        [Fact]
+        [DisplayName("位置參數建構子未提供值時不應建立任何參數")]
+        public void PositionalConstructor_NoValues_CreatesNoParameters()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery, "SELECT 1");
+
+            Assert.Empty(spec.Parameters);
+        }
+
+        [Fact]
+        [DisplayName("具名參數建構子應將字典內容加入 Parameters")]
+        public void NamedConstructor_AddsParameters()
+        {
+            var dict = new Dictionary<string, object>
+            {
+                { "Id", 1 },
+                { "Name", "Bee" }
+            };
+
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE Id = {Id} AND Name = {Name}", dict);
+
+            Assert.Equal(2, spec.Parameters.Count);
+            Assert.Equal(1, spec.Parameters["Id"].Value);
+            Assert.Equal("Bee", spec.Parameters["Name"].Value);
+        }
+
+        [Fact]
+        [DisplayName("具名參數建構子傳入 null 字典時應建立空 Parameters")]
+        public void NamedConstructor_NullDictionary_CreatesNoParameters()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery, "SELECT 1", parameters: null);
+
+            Assert.Empty(spec.Parameters);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("位置參數建構子 commandText 為空時應擲出 ArgumentNullException")]
+        public void PositionalConstructor_EmptyCommandText_Throws(string? commandText)
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DbCommandSpec(DbCommandKind.NonQuery, commandText!));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("具名參數建構子 commandText 為空時應擲出 ArgumentNullException")]
+        public void NamedConstructor_EmptyCommandText_Throws(string? commandText)
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DbCommandSpec(DbCommandKind.NonQuery, commandText!, new Dictionary<string, object>()));
+        }
+
+        #endregion
+
+        #region CommandTimeout setter 測試
+
+        [Fact]
+        [DisplayName("CommandTimeout 設為 0 應套用預設值 30")]
+        public void CommandTimeout_Zero_UsesDefault()
+        {
+            var spec = new DbCommandSpec { CommandTimeout = 0 };
+            Assert.Equal(30, spec.CommandTimeout);
+        }
+
+        [Fact]
+        [DisplayName("CommandTimeout 設為負值應套用預設值 30")]
+        public void CommandTimeout_Negative_UsesDefault()
+        {
+            var spec = new DbCommandSpec { CommandTimeout = -10 };
+            Assert.Equal(30, spec.CommandTimeout);
+        }
+
+        [Fact]
+        [DisplayName("CommandTimeout 設為合法值且未超過 cap 應原樣使用")]
+        public void CommandTimeout_WithinCap_UsesValue()
+        {
+            var spec = new DbCommandSpec { CommandTimeout = 45 };
+            Assert.Equal(45, spec.CommandTimeout);
+        }
+
+        [Fact]
+        [DisplayName("CommandTimeout 設為超過 cap 應套用 cap 值")]
+        public void CommandTimeout_ExceedsCap_UsesCap()
+        {
+            int original = BackendInfo.MaxDbCommandTimeout;
+            try
+            {
+                BackendInfo.MaxDbCommandTimeout = 60;
+                var spec = new DbCommandSpec { CommandTimeout = 9999 };
+                Assert.Equal(60, spec.CommandTimeout);
+            }
+            finally
+            {
+                BackendInfo.MaxDbCommandTimeout = original;
+            }
+        }
+
+        [Fact]
+        [DisplayName("MaxDbCommandTimeout cap 為 0 時不限制 CommandTimeout")]
+        public void CommandTimeout_NoCap_UsesValue()
+        {
+            int original = BackendInfo.MaxDbCommandTimeout;
+            try
+            {
+                BackendInfo.MaxDbCommandTimeout = 0;
+                var spec = new DbCommandSpec { CommandTimeout = 9999 };
+                Assert.Equal(9999, spec.CommandTimeout);
+            }
+            finally
+            {
+                BackendInfo.MaxDbCommandTimeout = original;
+            }
+        }
+
+        #endregion
+
+        #region 佔位符解析（透過 CreateCommand 驗證）
+
+        [Fact]
+        [DisplayName("CreateCommand 應將位置佔位符 {0} 解析為帶前綴的參數名稱")]
+        public void CreateCommand_PositionalPlaceholder_ResolvesToPrefixedName()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE A = {0} AND B = {1}", "x", 1);
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal("SELECT * FROM T WHERE A = @p0 AND B = @p1", cmd.CommandText);
+            Assert.Equal(2, cmd.Parameters.Count);
+            Assert.Equal("@p0", cmd.Parameters[0].ParameterName);
+            Assert.Equal("x", cmd.Parameters[0].Value);
+            Assert.Equal("@p1", cmd.Parameters[1].ParameterName);
+            Assert.Equal(1, cmd.Parameters[1].Value);
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 應將具名佔位符 {Name} 解析為帶前綴的參數名稱")]
+        public void CreateCommand_NamedPlaceholder_ResolvesToPrefixedName()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE Id = {Id}",
+                new Dictionary<string, object> { { "Id", 99 } });
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal("SELECT * FROM T WHERE Id = @Id", cmd.CommandText);
+            Assert.Single(cmd.Parameters);
+            Assert.Equal("@Id", cmd.Parameters[0].ParameterName);
+        }
+
+        [Fact]
+        [DisplayName("具名佔位符應不分大小寫匹配")]
+        public void CreateCommand_NamedPlaceholder_CaseInsensitive()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE Id = {ID}",
+                new Dictionary<string, object> { { "id", 1 } });
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal("SELECT * FROM T WHERE Id = @id", cmd.CommandText);
+        }
+
+        [Fact]
+        [DisplayName("{@Parameters} 應展開為以逗號分隔的所有參數佔位符")]
+        public void CreateCommand_AtParametersToken_ExpandsToCommaList()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery,
+                "EXEC sp_test {@Parameters}", "a", "b", "c");
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal("EXEC sp_test @p0,@p1,@p2", cmd.CommandText);
+            Assert.Equal(3, cmd.Parameters.Count);
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand StoredProcedure 不應解析 CommandText 中的佔位符")]
+        public void CreateCommand_StoredProcedure_SkipsPlaceholderResolution()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery, "sp_GetUser")
+            {
+                CommandType = CommandType.StoredProcedure
+            };
+            spec.Parameters.Add("UserId", 42);
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal("sp_GetUser", cmd.CommandText);
+            Assert.Equal(CommandType.StoredProcedure, cmd.CommandType);
+            Assert.Single(cmd.Parameters);
+            Assert.Equal("@UserId", cmd.Parameters[0].ParameterName);
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 應傳入 CommandTimeout 至 DbCommand")]
+        public void CreateCommand_AppliesCommandTimeout()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery, "SELECT 1") { CommandTimeout = 45 };
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal(45, cmd.CommandTimeout);
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 參數值為 null 應綁定為 DBNull")]
+        public void CreateCommand_NullValue_BindsDBNull()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery,
+                "UPDATE T SET A = {0}", new object[] { null! });
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal(DBNull.Value, cmd.Parameters[0].Value);
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 參數名稱已含前綴時不應重複加上前綴")]
+        public void CreateCommand_NameWithPrefix_NotDuplicated()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery, "SELECT 1");
+            spec.Parameters.Add("@X", 1);
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            Assert.Equal("@X", cmd.Parameters[0].ParameterName);
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 應將 DbType、Size、SourceColumn、SourceVersion 傳遞給 DbParameter")]
+        public void CreateCommand_PropagatesParameterMetadata()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery, "UPDATE T SET A = {0}", "x");
+            var p = spec.Parameters[0];
+            p.Size = 50;
+            p.SourceColumn = "A";
+            p.SourceVersion = DataRowVersion.Original;
+            p.IsNullable = true;
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.SQLServer, conn);
+
+            var dp = cmd.Parameters[0];
+            Assert.Equal(DbType.String, dp.DbType);
+            Assert.Equal(50, dp.Size);
+            Assert.Equal("A", dp.SourceColumn);
+            Assert.Equal(DataRowVersion.Original, dp.SourceVersion);
+            Assert.True(dp.IsNullable);
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 連線為 null 時應擲出 ArgumentNullException")]
+        public void CreateCommand_NullConnection_Throws()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery, "SELECT 1");
+
+            Assert.Throws<ArgumentNullException>(() =>
+                spec.CreateCommand(DatabaseType.SQLServer, null!));
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 在 CommandText 為空時應擲出 InvalidOperationException")]
+        public void CreateCommand_EmptyCommandText_Throws()
+        {
+            var spec = new DbCommandSpec();
+
+            using var conn = new SqlConnection();
+            Assert.Throws<InvalidOperationException>(() =>
+                spec.CreateCommand(DatabaseType.SQLServer, conn));
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 位置佔位符索引越界時應擲出 InvalidOperationException")]
+        public void CreateCommand_IndexOutOfRange_Throws()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE A = {0} AND B = {5}", "x");
+
+            using var conn = new SqlConnection();
+            Assert.Throws<InvalidOperationException>(() =>
+                spec.CreateCommand(DatabaseType.SQLServer, conn));
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand 具名佔位符找不到對應參數時應擲出 InvalidOperationException")]
+        public void CreateCommand_UnknownNamedKey_Throws()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE Id = {Missing}",
+                new Dictionary<string, object> { { "Id", 1 } });
+
+            using var conn = new SqlConnection();
+            Assert.Throws<InvalidOperationException>(() =>
+                spec.CreateCommand(DatabaseType.SQLServer, conn));
+        }
+
+        [Fact]
+        [DisplayName("CreateCommand Oracle 資料庫應使用冒號參數前綴")]
+        public void CreateCommand_Oracle_UsesColonPrefix()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT * FROM T WHERE A = {0}", "x");
+
+            using var conn = new SqlConnection();
+            using var cmd = spec.CreateCommand(DatabaseType.Oracle, conn);
+
+            Assert.Equal("SELECT * FROM T WHERE A = :p0", cmd.CommandText);
+            Assert.Equal(":p0", cmd.Parameters[0].ParameterName);
+        }
+
+        #endregion
+
+        #region ToString 測試
+
+        [Fact]
+        [DisplayName("ToString 應回傳 CommandText")]
+        public void ToString_ReturnsCommandText()
+        {
+            var spec = new DbCommandSpec(DbCommandKind.Scalar, "SELECT 1");
+            Assert.Equal("SELECT 1", spec.ToString());
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbConnectionScopeTests.cs
+++ b/tests/Bee.Db.UnitTests/DbConnectionScopeTests.cs
@@ -1,0 +1,113 @@
+using System.ComponentModel;
+using System.Data;
+using System.Data.Common;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbConnectionScopeTests
+    {
+        [Fact]
+        [DisplayName("Create externalConnection=null 且 factory=null 應擲 ArgumentNullException")]
+        public void Create_NullFactoryAndNullExternal_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                DbConnectionScope.Create(null, null!, "irrelevant"));
+        }
+
+        [Fact]
+        [DisplayName("CreateAsync externalConnection=null 且 factory=null 應擲 ArgumentNullException")]
+        public async Task CreateAsync_NullFactoryAndNullExternal_Throws()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await DbConnectionScope.CreateAsync(null, null!, "irrelevant"));
+        }
+
+        [Fact]
+        [DisplayName("外部連線為 Open 狀態時 Create 不會重新開啟，且 Dispose 不關閉連線")]
+        public void Create_ExternalOpenConnection_NotReopenedNotClosed()
+        {
+            var fake = new FakeDbConnection { CurrentState = ConnectionState.Open };
+
+            using (var scope = DbConnectionScope.Create(fake, null!, "ignored"))
+            {
+                Assert.Same(fake, scope.Connection);
+                Assert.Equal(0, fake.OpenCount);
+            }
+
+            Assert.Equal(0, fake.DisposeCount);
+            Assert.Equal(ConnectionState.Open, fake.State);
+        }
+
+        [Fact]
+        [DisplayName("外部連線為 Closed 狀態時 Create 會開啟，但 Dispose 不關閉")]
+        public void Create_ExternalClosedConnection_OpenedButNotDisposed()
+        {
+            var fake = new FakeDbConnection { CurrentState = ConnectionState.Closed };
+
+            using (var scope = DbConnectionScope.Create(fake, null!, "ignored"))
+            {
+                Assert.Same(fake, scope.Connection);
+                Assert.Equal(1, fake.OpenCount);
+            }
+
+            Assert.Equal(0, fake.DisposeCount);
+        }
+
+        [Fact]
+        [DisplayName("CreateAsync 外部連線為 Closed 狀態時應呼叫 OpenAsync")]
+        public async Task CreateAsync_ExternalClosedConnection_OpensAsync()
+        {
+            var fake = new FakeDbConnection { CurrentState = ConnectionState.Closed };
+
+            using (var scope = await DbConnectionScope.CreateAsync(fake, null!, "ignored"))
+            {
+                Assert.Same(fake, scope.Connection);
+                Assert.Equal(1, fake.OpenAsyncCount);
+            }
+
+            Assert.Equal(0, fake.DisposeCount);
+        }
+
+        // 最小可用的 DbConnection 實作，用來模擬 State 與 Open/Dispose 行為
+        private sealed class FakeDbConnection : DbConnection
+        {
+            public ConnectionState CurrentState { get; set; } = ConnectionState.Closed;
+            public int OpenCount { get; private set; }
+            public int OpenAsyncCount { get; private set; }
+            public int DisposeCount { get; private set; }
+
+            [System.Diagnostics.CodeAnalysis.AllowNull]
+            public override string ConnectionString { get; set; } = string.Empty;
+            public override string Database => string.Empty;
+            public override string DataSource => string.Empty;
+            public override string ServerVersion => "0.0";
+            public override ConnectionState State => CurrentState;
+
+            public override void ChangeDatabase(string databaseName) { }
+            public override void Close() => CurrentState = ConnectionState.Closed;
+            public override void Open()
+            {
+                OpenCount++;
+                CurrentState = ConnectionState.Open;
+            }
+
+            public override Task OpenAsync(System.Threading.CancellationToken cancellationToken)
+            {
+                OpenAsyncCount++;
+                CurrentState = ConnectionState.Open;
+                return Task.CompletedTask;
+            }
+
+            protected override DbCommand CreateDbCommand() => throw new NotSupportedException();
+
+            protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+                => throw new NotSupportedException();
+
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing) DisposeCount++;
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbFuncTests.cs
+++ b/tests/Bee.Db.UnitTests/DbFuncTests.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel;
+using System.Data;
 using Bee.Definition;
+using Microsoft.Data.SqlClient;
 
 namespace Bee.Db.UnitTests
 {
@@ -62,6 +64,107 @@ namespace Bee.Db.UnitTests
         {
             var result = DbFunc.GetParameterPrefix(dbType);
             Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("GetParameterPrefix 不支援的資料庫類型應擲出 NotSupportedException")]
+        public void GetParameterPrefix_UnsupportedType_Throws()
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                DbFunc.GetParameterPrefix((DatabaseType)999));
+        }
+
+        #endregion
+
+        #region GetParameterName 測試
+
+        [Theory]
+        [InlineData(DatabaseType.SQLServer, "Id", "@Id")]
+        [InlineData(DatabaseType.MySQL, "Id", "@Id")]
+        [InlineData(DatabaseType.SQLite, "Id", "@Id")]
+        [InlineData(DatabaseType.Oracle, "Id", ":Id")]
+        [DisplayName("GetParameterName 應依資料庫類型加上對應前綴")]
+        public void GetParameterName_AppendsPrefix(DatabaseType dbType, string name, string expected)
+        {
+            var result = DbFunc.GetParameterName(dbType, name);
+            Assert.Equal(expected, result);
+        }
+
+        #endregion
+
+        #region InferDbType 測試
+
+        public static IEnumerable<object[]> InferDbType_Inputs()
+        {
+            yield return new object[] { "abc", DbType.String };
+            yield return new object[] { 1, DbType.Int32 };
+            yield return new object[] { (long)1, DbType.Int64 };
+            yield return new object[] { (short)1, DbType.Int16 };
+            yield return new object[] { (byte)1, DbType.Byte };
+            yield return new object[] { true, DbType.Boolean };
+            yield return new object[] { new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), DbType.DateTime };
+            yield return new object[] { 1.5m, DbType.Decimal };
+            yield return new object[] { 1.5d, DbType.Double };
+            yield return new object[] { 1.5f, DbType.Single };
+            yield return new object[] { Guid.NewGuid(), DbType.Guid };
+            yield return new object[] { new byte[] { 1, 2 }, DbType.Binary };
+            yield return new object[] { TimeSpan.FromSeconds(1), DbType.Time };
+        }
+
+        [Theory]
+        [MemberData(nameof(InferDbType_Inputs))]
+        [DisplayName("InferDbType 應依值的型別回傳對應 DbType")]
+        public void InferDbType_KnownTypes_ReturnsExpected(object value, DbType expected)
+        {
+            var result = DbFunc.InferDbType(value);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("InferDbType 對 null 值應回傳 null")]
+        public void InferDbType_Null_ReturnsNull()
+        {
+            Assert.Null(DbFunc.InferDbType(null!));
+        }
+
+        [Fact]
+        [DisplayName("InferDbType 對 DBNull 應回傳 null")]
+        public void InferDbType_DBNull_ReturnsNull()
+        {
+            Assert.Null(DbFunc.InferDbType(DBNull.Value));
+        }
+
+        [Fact]
+        [DisplayName("InferDbType 對不支援型別應回傳 null")]
+        public void InferDbType_UnsupportedType_ReturnsNull()
+        {
+            Assert.Null(DbFunc.InferDbType(new object()));
+        }
+
+        #endregion
+
+        #region SqlFormat 測試
+
+        [Fact]
+        [DisplayName("SqlFormat 應將 {0}/{1} 替換為對應參數名稱")]
+        public void SqlFormat_ReplacesPositionalPlaceholders()
+        {
+            using var cmd = new SqlCommand();
+            cmd.Parameters.Add(new SqlParameter("@p0", "x"));
+            cmd.Parameters.Add(new SqlParameter("@p1", 1));
+
+            var result = DbFunc.SqlFormat("SELECT * FROM T WHERE A = {0} AND B = {1}", cmd.Parameters);
+
+            Assert.Equal("SELECT * FROM T WHERE A = @p0 AND B = @p1", result);
+        }
+
+        [Fact]
+        [DisplayName("SqlFormat 空 Parameters 集合應原樣回傳")]
+        public void SqlFormat_EmptyParameters_ReturnsOriginal()
+        {
+            using var cmd = new SqlCommand();
+            var result = DbFunc.SqlFormat("SELECT 1", cmd.Parameters);
+            Assert.Equal("SELECT 1", result);
         }
 
         #endregion

--- a/tests/Bee.Db.UnitTests/DbFuncTests.cs
+++ b/tests/Bee.Db.UnitTests/DbFuncTests.cs
@@ -94,22 +94,22 @@ namespace Bee.Db.UnitTests
 
         #region InferDbType 測試
 
-        public static IEnumerable<object[]> InferDbType_Inputs()
+        public static TheoryData<object, DbType> InferDbType_Inputs() => new()
         {
-            yield return new object[] { "abc", DbType.String };
-            yield return new object[] { 1, DbType.Int32 };
-            yield return new object[] { (long)1, DbType.Int64 };
-            yield return new object[] { (short)1, DbType.Int16 };
-            yield return new object[] { (byte)1, DbType.Byte };
-            yield return new object[] { true, DbType.Boolean };
-            yield return new object[] { new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), DbType.DateTime };
-            yield return new object[] { 1.5m, DbType.Decimal };
-            yield return new object[] { 1.5d, DbType.Double };
-            yield return new object[] { 1.5f, DbType.Single };
-            yield return new object[] { Guid.NewGuid(), DbType.Guid };
-            yield return new object[] { new byte[] { 1, 2 }, DbType.Binary };
-            yield return new object[] { TimeSpan.FromSeconds(1), DbType.Time };
-        }
+            { "abc", DbType.String },
+            { 1, DbType.Int32 },
+            { (long)1, DbType.Int64 },
+            { (short)1, DbType.Int16 },
+            { (byte)1, DbType.Byte },
+            { true, DbType.Boolean },
+            { new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), DbType.DateTime },
+            { 1.5m, DbType.Decimal },
+            { 1.5d, DbType.Double },
+            { 1.5f, DbType.Single },
+            { Guid.NewGuid(), DbType.Guid },
+            { new byte[] { 1, 2 }, DbType.Binary },
+            { TimeSpan.FromSeconds(1), DbType.Time },
+        };
 
         [Theory]
         [MemberData(nameof(InferDbType_Inputs))]

--- a/tests/Bee.Db.UnitTests/DbParameterSpecCollectionTests.cs
+++ b/tests/Bee.Db.UnitTests/DbParameterSpecCollectionTests.cs
@@ -1,0 +1,111 @@
+using System.ComponentModel;
+using System.Data;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbParameterSpecCollectionTests
+    {
+        [Fact]
+        [DisplayName("Add(name, value) 應推斷 DbType 並加入集合")]
+        public void Add_NameValue_AddsAndInfersDbType()
+        {
+            var collection = new DbParameterSpecCollection();
+
+            var spec = collection.Add("p1", 100);
+
+            Assert.Single(collection);
+            Assert.Equal("p1", spec.Name);
+            Assert.Equal(100, spec.Value);
+            Assert.Equal(DbType.Int32, spec.DbType);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("Add(name, value) 名稱為空白應擲 ArgumentException")]
+        public void Add_NameValue_EmptyName_Throws(string? name)
+        {
+            var collection = new DbParameterSpecCollection();
+
+            Assert.Throws<ArgumentException>(() => collection.Add(name!, 1));
+        }
+
+        [Fact]
+        [DisplayName("Add(DbField) 應依欄位定義建立參數並設定 SourceColumn")]
+        public void Add_DbField_BuildsFromField()
+        {
+            var field = new DbField
+            {
+                FieldName = "name",
+                DbType = FieldDbType.String,
+                Length = 50,
+                AllowNull = false
+            };
+            var collection = new DbParameterSpecCollection();
+
+            var spec = collection.Add(field);
+
+            Assert.Equal("name", spec.Name);
+            Assert.Equal("name", spec.SourceColumn);
+            Assert.Equal(DataRowVersion.Current, spec.SourceVersion);
+            Assert.Equal(DbType.String, spec.DbType);
+            Assert.Equal(50, spec.Size);
+            Assert.NotNull(spec.Value);
+        }
+
+        [Fact]
+        [DisplayName("Add(DbField) AllowNull 為 true 時 Value 應為 null")]
+        public void Add_DbField_AllowNull_NullValue()
+        {
+            var field = new DbField
+            {
+                FieldName = "memo",
+                DbType = FieldDbType.String,
+                Length = 100,
+                AllowNull = true
+            };
+            var collection = new DbParameterSpecCollection();
+
+            var spec = collection.Add(field);
+
+            Assert.Null(spec.Value);
+        }
+
+        [Fact]
+        [DisplayName("Add(DbField) 非 String 型別 Size 應為 0")]
+        public void Add_DbField_NonString_SizeIsZero()
+        {
+            var field = new DbField
+            {
+                FieldName = "age",
+                DbType = FieldDbType.Integer,
+                Length = 4
+            };
+            var collection = new DbParameterSpecCollection();
+
+            var spec = collection.Add(field);
+
+            Assert.Equal(0, spec.Size);
+        }
+
+        [Fact]
+        [DisplayName("Add(DbField) 可指定 SourceVersion")]
+        public void Add_DbField_RespectsSourceVersion()
+        {
+            var field = new DbField
+            {
+                FieldName = "id",
+                DbType = FieldDbType.Integer
+            };
+            var collection = new DbParameterSpecCollection();
+
+            var spec = collection.Add(field, DataRowVersion.Original);
+
+            Assert.Equal(DataRowVersion.Original, spec.SourceVersion);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbParameterSpecTests.cs
+++ b/tests/Bee.Db.UnitTests/DbParameterSpecTests.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel;
+using System.Data;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbParameterSpecTests
+    {
+        [Fact]
+        [DisplayName("無參數建構子預設值正確")]
+        public void DefaultConstructor_DefaultValues()
+        {
+            var spec = new DbParameterSpec();
+
+            Assert.Null(spec.Value);
+            Assert.Null(spec.DbType);
+            Assert.Null(spec.Size);
+            Assert.False(spec.IsNullable);
+            Assert.Equal(string.Empty, spec.SourceColumn);
+            Assert.Equal(DataRowVersion.Current, spec.SourceVersion);
+        }
+
+        [Fact]
+        [DisplayName("帶值建構子應推斷 DbType")]
+        public void ValueConstructor_InfersDbType()
+        {
+            var spec = new DbParameterSpec("p1", "hello");
+
+            Assert.Equal("p1", spec.Name);
+            Assert.Equal("hello", spec.Value);
+            Assert.Equal(DbType.String, spec.DbType);
+        }
+
+        [Fact]
+        [DisplayName("Name 與 Key 應同步")]
+        public void Name_SyncsWithKey()
+        {
+            var spec = new DbParameterSpec();
+            spec.Name = "userName";
+            Assert.Equal("userName", spec.Key);
+
+            spec.Key = "another";
+            Assert.Equal("another", spec.Name);
+        }
+
+        [Fact]
+        [DisplayName("ToString 應回傳 'Name = Value'")]
+        public void ToString_FormatsNameAndValue()
+        {
+            var spec = new DbParameterSpec("age", 30);
+
+            Assert.Equal("age = 30", spec.ToString());
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbProviderManagerTests.cs
+++ b/tests/Bee.Db.UnitTests/DbProviderManagerTests.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using System.Data.Common;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Microsoft.Data.SqlClient;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbProviderManagerTests
+    {
+        [Fact]
+        [DisplayName("RegisterProvider factory 為 null 應擲 ArgumentNullException")]
+        public void RegisterProvider_NullFactory_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                DbProviderManager.RegisterProvider(DatabaseType.SQLServer, null!));
+        }
+
+        [Fact]
+        [DisplayName("GetFactory 未註冊型別應擲 KeyNotFoundException")]
+        public void GetFactory_UnregisteredType_Throws()
+        {
+            // Oracle 在測試專案中未註冊（fixture 僅註冊 SQLServer）
+            Assert.Throws<KeyNotFoundException>(() =>
+                DbProviderManager.GetFactory(DatabaseType.Oracle));
+        }
+
+        [Collection("Initialize")]
+        public class WithInitializedFixture
+        {
+            [Fact]
+            [DisplayName("GetFactory 已註冊型別應回傳對應 factory（透過 fixture 註冊）")]
+            public void GetFactory_RegisteredType_ReturnsFactory()
+            {
+                var factory = DbProviderManager.GetFactory(DatabaseType.SQLServer);
+
+                Assert.NotNull(factory);
+                Assert.IsAssignableFrom<DbProviderFactory>(factory);
+            }
+
+            [Fact]
+            [DisplayName("RegisterProvider 重複呼叫應以新值取代舊值")]
+            public void RegisterProvider_ReplacesExistingFactory()
+            {
+                // 紀錄目前 factory，測試結束後還原
+                var original = DbProviderManager.GetFactory(DatabaseType.SQLServer);
+                try
+                {
+                    DbProviderManager.RegisterProvider(DatabaseType.SQLServer, SqlClientFactory.Instance);
+                    var fetched = DbProviderManager.GetFactory(DatabaseType.SQLServer);
+
+                    Assert.Same(SqlClientFactory.Instance, fetched);
+                }
+                finally
+                {
+                    DbProviderManager.RegisterProvider(DatabaseType.SQLServer, original);
+                }
+            }
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/DbProviderManagerTests.cs
+++ b/tests/Bee.Db.UnitTests/DbProviderManagerTests.cs
@@ -35,7 +35,7 @@ namespace Bee.Db.UnitTests
                 var factory = DbProviderManager.GetFactory(DatabaseType.SQLServer);
 
                 Assert.NotNull(factory);
-                Assert.IsAssignableFrom<DbProviderFactory>(factory);
+                Assert.IsType<DbProviderFactory>(factory, exactMatch: false);
             }
 
             [Fact]

--- a/tests/Bee.Db.UnitTests/DefaultParameterCollectorTests.cs
+++ b/tests/Bee.Db.UnitTests/DefaultParameterCollectorTests.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+using Bee.Db.Query;
+
+namespace Bee.Db.UnitTests
+{
+    public class DefaultParameterCollectorTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [DisplayName("建構子 prefix 為 null 或空字串應擲 ArgumentException")]
+        public void Constructor_NullOrEmptyPrefix_Throws(string? prefix)
+        {
+            Assert.Throws<ArgumentException>(() => new DefaultParameterCollector(prefix!));
+        }
+
+        [Fact]
+        [DisplayName("建構子應正確記錄 Prefix")]
+        public void Constructor_ValidPrefix_StoresPrefix()
+        {
+            var collector = new DefaultParameterCollector("@");
+
+            Assert.Equal("@", collector.Prefix);
+        }
+
+        [Fact]
+        [DisplayName("Add 連續呼叫應產生 @p0、@p1、@p2 並回傳對應名稱")]
+        public void Add_SequentialCalls_GeneratesIncrementingNames()
+        {
+            var collector = new DefaultParameterCollector("@");
+
+            string n0 = collector.Add(1);
+            string n1 = collector.Add("x");
+            string n2 = collector.Add(3.14);
+
+            Assert.Equal("@p0", n0);
+            Assert.Equal("@p1", n1);
+            Assert.Equal("@p2", n2);
+        }
+
+        [Fact]
+        [DisplayName("GetAll 應回傳所有已加入的參數鍵值對")]
+        public void GetAll_ReturnsAllAddedParameters()
+        {
+            var collector = new DefaultParameterCollector("@");
+            collector.Add(10);
+            collector.Add("abc");
+
+            var all = collector.GetAll();
+
+            Assert.Equal(2, all.Count);
+            Assert.Equal(10, all["@p0"]);
+            Assert.Equal("abc", all["@p1"]);
+        }
+
+        [Fact]
+        [DisplayName("Add 應接受不同型別的 prefix（例如 Oracle 的 ':'）")]
+        public void Add_OraclePrefix_GeneratesColonNames()
+        {
+            var collector = new DefaultParameterCollector(":");
+
+            string n0 = collector.Add(1);
+
+            Assert.Equal(":p0", n0);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/FromBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/FromBuilderTests.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using Bee.Db.Query;
+using Bee.Definition;
+
+namespace Bee.Db.UnitTests
+{
+    public class FromBuilderTests
+    {
+        [Fact]
+        [DisplayName("Build joins=null 應僅產生主表 FROM 子句")]
+        public void Build_NullJoins_ReturnsMainTableOnly()
+        {
+            var builder = new FromBuilder(DatabaseType.SQLServer);
+
+            var result = builder.Build("st_user", null!);
+
+            Assert.Equal("FROM [st_user] A", result);
+        }
+
+        [Fact]
+        [DisplayName("Build 空 joins 應僅產生主表 FROM 子句")]
+        public void Build_EmptyJoins_ReturnsMainTableOnly()
+        {
+            var builder = new FromBuilder(DatabaseType.SQLServer);
+
+            var result = builder.Build("st_user", new TableJoinCollection());
+
+            Assert.Equal("FROM [st_user] A", result);
+        }
+
+        [Fact]
+        [DisplayName("Build 單一 join 應產生 LEFT JOIN 子句")]
+        public void Build_SingleJoin_ProducesLeftJoinClause()
+        {
+            var joins = new TableJoinCollection();
+            joins.Add(new TableJoin
+            {
+                Key = "j1",
+                JoinType = JoinType.Left,
+                LeftTable = "st_user",
+                LeftAlias = "A",
+                LeftField = "dept_id",
+                RightTable = "st_dept",
+                RightAlias = "B",
+                RightField = "dept_id"
+            });
+
+            var builder = new FromBuilder(DatabaseType.SQLServer);
+            var result = builder.Build("st_user", joins);
+
+            Assert.Contains("FROM [st_user] A", result);
+            Assert.Contains("LEFT JOIN [st_dept] B ON A.[dept_id] = B.[dept_id]", result);
+        }
+
+        [Fact]
+        [DisplayName("Build 多個 join 應依 RightAlias 排序")]
+        public void Build_MultipleJoins_OrderedByRightAlias()
+        {
+            var joins = new TableJoinCollection();
+            joins.Add(new TableJoin
+            {
+                Key = "jc",
+                JoinType = JoinType.Left,
+                LeftTable = "main", LeftAlias = "A", LeftField = "f1",
+                RightTable = "tbl_c", RightAlias = "C", RightField = "f1"
+            });
+            joins.Add(new TableJoin
+            {
+                Key = "jb",
+                JoinType = JoinType.Left,
+                LeftTable = "main", LeftAlias = "A", LeftField = "f2",
+                RightTable = "tbl_b", RightAlias = "B", RightField = "f2"
+            });
+
+            var builder = new FromBuilder(DatabaseType.SQLServer);
+            var result = builder.Build("main", joins);
+
+            int posB = result.IndexOf("[tbl_b] B", StringComparison.Ordinal);
+            int posC = result.IndexOf("[tbl_c] C", StringComparison.Ordinal);
+            Assert.True(posB > 0 && posC > 0);
+            Assert.True(posB < posC);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/ILMapperTests.cs
+++ b/tests/Bee.Db.UnitTests/ILMapperTests.cs
@@ -1,0 +1,158 @@
+using System.ComponentModel;
+using System.Data;
+
+namespace Bee.Db.UnitTests
+{
+    public class ILMapperTests
+    {
+        public class SamplePoco
+        {
+            public int Id { get; set; }
+            public string Name { get; set; } = string.Empty;
+            public bool Active { get; set; }
+        }
+
+        public class NoCtorPoco
+        {
+            public int Id { get; }
+
+            public NoCtorPoco(int id)
+            {
+                Id = id;
+            }
+        }
+
+        private static DataTable BuildTable()
+        {
+            var table = new DataTable();
+            table.Columns.Add("Id", typeof(int));
+            table.Columns.Add("Name", typeof(string));
+            table.Columns.Add("Active", typeof(bool));
+            table.Rows.Add(1, "Alice", true);
+            table.Rows.Add(2, "Bob", false);
+            return table;
+        }
+
+        [Fact]
+        [DisplayName("CreateMapFunc 應依 reader 欄位產生對應 mapper")]
+        public void CreateMapFunc_MapsAllMatchingFields()
+        {
+            ILMapper<SamplePoco>.ClearCache();
+            using var reader = BuildTable().CreateDataReader();
+            reader.Read();
+
+            var mapper = ILMapper<SamplePoco>.CreateMapFunc(reader);
+            var result = mapper(reader);
+
+            Assert.Equal(1, result.Id);
+            Assert.Equal("Alice", result.Name);
+            Assert.True(result.Active);
+        }
+
+        [Fact]
+        [DisplayName("欄位名稱應採大小寫不敏感比對")]
+        public void CreateMapFunc_CaseInsensitiveFieldMatching()
+        {
+            ILMapper<SamplePoco>.ClearCache();
+            var table = new DataTable();
+            table.Columns.Add("ID", typeof(int));   // 大小寫不同
+            table.Columns.Add("name", typeof(string));
+            table.Rows.Add(99, "Carol");
+
+            using var reader = table.CreateDataReader();
+            reader.Read();
+
+            var mapper = ILMapper<SamplePoco>.CreateMapFunc(reader);
+            var result = mapper(reader);
+
+            Assert.Equal(99, result.Id);
+            Assert.Equal("Carol", result.Name);
+        }
+
+        [Fact]
+        [DisplayName("DBNull 欄位應保留屬性預設值")]
+        public void CreateMapFunc_DBNullField_KeepsDefaultValue()
+        {
+            ILMapper<SamplePoco>.ClearCache();
+            var table = new DataTable();
+            table.Columns.Add("Id", typeof(int));
+            table.Columns.Add("Name", typeof(string));
+            table.Rows.Add(1, DBNull.Value);
+
+            using var reader = table.CreateDataReader();
+            reader.Read();
+
+            var mapper = ILMapper<SamplePoco>.CreateMapFunc(reader);
+            var result = mapper(reader);
+
+            Assert.Equal(1, result.Id);
+            Assert.Equal(string.Empty, result.Name);  // 屬性初始值
+        }
+
+        [Fact]
+        [DisplayName("MapToList 應將所有 row 對映到 List<T>")]
+        public void MapToList_MapsAllRows()
+        {
+            ILMapper<SamplePoco>.ClearCache();
+            using var reader = BuildTable().CreateDataReader();
+            // 取得 mapper 前需要 Read() 才能取 schema；改用先建構 mapper 再丟進 MapToList
+            // 由於 BuildTable 後又重建 reader 不切實際，使用獨立的 reader 取 mapper
+            using var schemaReader = BuildTable().CreateDataReader();
+            schemaReader.Read();
+            var mapper = ILMapper<SamplePoco>.CreateMapFunc(schemaReader);
+
+            var list = ILMapper<SamplePoco>.MapToList(reader, mapper);
+
+            Assert.Equal(2, list.Count);
+            Assert.Equal("Alice", list[0].Name);
+            Assert.Equal("Bob", list[1].Name);
+        }
+
+        [Fact]
+        [DisplayName("MapToEnumerable 應與 MapToList 結果一致")]
+        public void MapToEnumerable_MatchesMapToList()
+        {
+            ILMapper<SamplePoco>.ClearCache();
+            using var schemaReader = BuildTable().CreateDataReader();
+            schemaReader.Read();
+            var mapper = ILMapper<SamplePoco>.CreateMapFunc(schemaReader);
+
+            using var reader = BuildTable().CreateDataReader();
+            var enumerated = ILMapper<SamplePoco>.MapToEnumerable(reader, mapper).ToList();
+
+            Assert.Equal(2, enumerated.Count);
+            Assert.Equal(1, enumerated[0].Id);
+            Assert.Equal(2, enumerated[1].Id);
+        }
+
+        [Fact]
+        [DisplayName("ClearCache 應清空指定型別的 cache")]
+        public void ClearCache_RemovesEntriesForType()
+        {
+            ILMapper<SamplePoco>.ClearCache();
+            using var reader = BuildTable().CreateDataReader();
+            reader.Read();
+            ILMapper<SamplePoco>.CreateMapFunc(reader);
+
+            Assert.True(ILMapper<SamplePoco>.CacheCount > 0);
+
+            ILMapper<SamplePoco>.ClearCache();
+
+            Assert.Equal(0, ILMapper<SamplePoco>.CacheCount);
+        }
+
+        [Fact]
+        [DisplayName("不具無參數建構子的型別應擲 InvalidOperationException")]
+        public void CreateMapFunc_NoParameterlessCtor_Throws()
+        {
+            ILMapper<NoCtorPoco>.ClearCache();
+            var table = new DataTable();
+            table.Columns.Add("Id", typeof(int));
+            table.Rows.Add(1);
+            using var reader = table.CreateDataReader();
+            reader.Read();
+
+            Assert.Throws<InvalidOperationException>(() => ILMapper<NoCtorPoco>.CreateMapFunc(reader));
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/SelectCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/SelectCommandBuilderTests.cs
@@ -1,0 +1,72 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers;
+using Bee.Definition;
+using Bee.Definition.Forms;
+
+namespace Bee.Db.UnitTests
+{
+    public class SelectCommandBuilderTests
+    {
+        private static FormSchema BuildSimpleSchema()
+        {
+            var schema = new FormSchema("demo", "Demo Form");
+            var table = schema.Tables!.Add("demo", "Demo Table");
+            table.DbTableName = "tb_demo";
+            table.Fields!.Add("Id", "Id", FieldDbType.Integer);
+            table.Fields!.AddStringField("Name", "Name", 50);
+            return schema;
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("Build tableName 為空白應擲 ArgumentException")]
+        public void Build_EmptyTableName_Throws(string tableName)
+        {
+            var schema = BuildSimpleSchema();
+            var builder = new SelectCommandBuilder(schema, DatabaseType.SQLServer);
+
+            Assert.Throws<ArgumentException>(() => builder.Build(tableName, string.Empty));
+        }
+
+        [Fact]
+        [DisplayName("Build tableName 為 null 應擲 ArgumentException")]
+        public void Build_NullTableName_Throws()
+        {
+            var schema = BuildSimpleSchema();
+            var builder = new SelectCommandBuilder(schema, DatabaseType.SQLServer);
+
+            Assert.Throws<ArgumentException>(() => builder.Build(null!, string.Empty));
+        }
+
+        [Fact]
+        [DisplayName("Build 簡易 schema 應產生含 SELECT 與 FROM 的命令")]
+        public void Build_SimpleSchema_ProducesSelectAndFromClauses()
+        {
+            var schema = BuildSimpleSchema();
+            var builder = new SelectCommandBuilder(schema, DatabaseType.SQLServer);
+
+            var spec = builder.Build("demo", string.Empty);
+
+            Assert.NotNull(spec);
+            Assert.Equal(DbCommandKind.DataTable, spec.Kind);
+            Assert.Contains("SELECT", spec.CommandText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("FROM", spec.CommandText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("tb_demo", spec.CommandText);
+        }
+
+        [Fact]
+        [DisplayName("Build 指定 selectFields 應只包含指定欄位")]
+        public void Build_WithSelectFields_RestrictsColumns()
+        {
+            var schema = BuildSimpleSchema();
+            var builder = new SelectCommandBuilder(schema, DatabaseType.SQLServer);
+
+            var spec = builder.Build("demo", "Id");
+
+            Assert.NotNull(spec);
+            Assert.Contains("Id", spec.CommandText);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlCreateTableCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlCreateTableCommandBuilderTests.cs
@@ -1,0 +1,240 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.SqlServer;
+using Bee.Definition;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    public class SqlCreateTableCommandBuilderTests
+    {
+        private static TableSchema BuildSchema(FieldDbType dbType, int length = 0,
+            int precision = 18, int scale = 0, bool allowNull = false, string defaultValue = "")
+        {
+            var schema = new TableSchema { TableName = "st_demo" };
+            schema.Fields!.Add(SysFields.RowId, "Row ID", FieldDbType.Guid);
+            var field = schema.Fields.Add("col", "Col", dbType, length);
+            field.Precision = precision;
+            field.Scale = scale;
+            field.AllowNull = allowNull;
+            field.DefaultValue = defaultValue;
+            schema.Indexes!.AddPrimaryKey(SysFields.RowId);
+            return schema;
+        }
+
+        #region ConverDbType 各 FieldDbType 分支
+
+        [Theory]
+        [InlineData(FieldDbType.Boolean, "[bit]")]
+        [InlineData(FieldDbType.AutoIncrement, "[int] IDENTITY(1,1)")]
+        [InlineData(FieldDbType.Short, "[smallint]")]
+        [InlineData(FieldDbType.Integer, "[int]")]
+        [InlineData(FieldDbType.Long, "[bigint]")]
+        [InlineData(FieldDbType.Currency, "[decimal](19,4)")]
+        [InlineData(FieldDbType.Date, "[date]")]
+        [InlineData(FieldDbType.DateTime, "[datetime]")]
+        [InlineData(FieldDbType.Guid, "[uniqueidentifier]")]
+        [InlineData(FieldDbType.Binary, "[varbinary](max)")]
+        [InlineData(FieldDbType.Text, "[nvarchar](max)")]
+        [DisplayName("GetCommandText 應為各 FieldDbType 產生對應的 SQL Server 型別字串")]
+        public void GetCommandText_FieldDbType_GeneratesCorrectColumnType(FieldDbType dbType, string expectedFragment)
+        {
+            var schema = BuildSchema(dbType);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains(expectedFragment, sql);
+        }
+
+        [Fact]
+        [DisplayName("GetCommandText String 型別應使用指定的長度")]
+        public void GetCommandText_String_UsesLength()
+        {
+            var schema = BuildSchema(FieldDbType.String, length: 50);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("[nvarchar](50)", sql);
+        }
+
+        [Fact]
+        [DisplayName("GetCommandText Decimal 應使用指定的 Precision/Scale")]
+        public void GetCommandText_Decimal_UsesPrecisionAndScale()
+        {
+            var schema = BuildSchema(FieldDbType.Decimal, precision: 12, scale: 3);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("[decimal](12,3)", sql);
+        }
+
+        [Fact]
+        [DisplayName("GetCommandText 不支援的 FieldDbType 應擲出 InvalidOperationException")]
+        public void GetCommandText_UnknownDbType_Throws()
+        {
+            var schema = BuildSchema(FieldDbType.Unknown);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            Assert.Throws<InvalidOperationException>(() => builder.GetCommandText(schema));
+        }
+
+        #endregion
+
+        #region 結構與分支
+
+        [Fact]
+        [DisplayName("GetCommandText UpgradeAction.New 應產生 CREATE TABLE 語句")]
+        public void GetCommandText_New_GeneratesCreateTable()
+        {
+            var schema = BuildSchema(FieldDbType.Integer);
+            schema.UpgradeAction = DbUpgradeAction.New;
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("-- Create table st_demo", sql);
+            Assert.Contains("CREATE TABLE [st_demo]", sql);
+        }
+
+        [Fact]
+        [DisplayName("GetCommandText UpgradeAction.Upgrade 應走 drop/create/insert/rename 五段")]
+        public void GetCommandText_Upgrade_GeneratesUpgradeScript()
+        {
+            var schema = BuildSchema(FieldDbType.Integer);
+            schema.UpgradeAction = DbUpgradeAction.Upgrade;
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("-- Upgrade table st_demo", sql);
+            Assert.Contains("-- Drop temporary table", sql);
+            Assert.Contains("-- Create temporary table", sql);
+            Assert.Contains("-- Move data", sql);
+            Assert.Contains("-- Drop old table", sql);
+            Assert.Contains("-- Rename temporary table", sql);
+            Assert.Contains("CREATE TABLE [tmp_st_demo]", sql);
+            Assert.Contains("INSERT INTO [tmp_st_demo]", sql);
+            Assert.Contains("EXEC sp_rename", sql);
+        }
+
+        [Fact]
+        [DisplayName("含 PrimaryKey 索引時應產生 CONSTRAINT ... PRIMARY KEY 語句")]
+        public void GetCommandText_PrimaryKey_GeneratesConstraint()
+        {
+            var schema = BuildSchema(FieldDbType.Integer);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("CONSTRAINT [pk_st_demo] PRIMARY KEY", sql);
+            Assert.Contains("[sys_rowid]", sql);
+        }
+
+        [Fact]
+        [DisplayName("含獨立索引時應產生 CREATE INDEX 與 CREATE UNIQUE INDEX")]
+        public void GetCommandText_Indexes_GeneratesCreateIndex()
+        {
+            var schema = BuildSchema(FieldDbType.Integer);
+            schema.Indexes!.Add("ix_{0}_col", "col", false);
+            schema.Indexes!.Add("uk_{0}_col", "col", true);
+
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("CREATE INDEX [ix_st_demo_col] ON [st_demo]", sql);
+            Assert.Contains("CREATE UNIQUE INDEX [uk_st_demo_col] ON [st_demo]", sql);
+        }
+
+        [Fact]
+        [DisplayName("AllowNull 欄位應產生 NULL 標記且無 DEFAULT 子句")]
+        public void GetCommandText_AllowNull_GeneratesNullWithoutDefault()
+        {
+            var schema = BuildSchema(FieldDbType.Integer, allowNull: true);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("[col] [int] NULL", sql);
+            Assert.DoesNotContain("[col] [int] NULL DEFAULT", sql);
+        }
+
+        [Fact]
+        [DisplayName("非 AllowNull Integer 欄位應產生 NOT NULL DEFAULT (0)")]
+        public void GetCommandText_NotNullInteger_GeneratesDefaultZero()
+        {
+            var schema = BuildSchema(FieldDbType.Integer);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("[col] [int] NOT NULL DEFAULT (0)", sql);
+        }
+
+        [Fact]
+        [DisplayName("String 欄位應產生 N'...' 預設值")]
+        public void GetCommandText_String_GeneratesNStringDefault()
+        {
+            var schema = BuildSchema(FieldDbType.String, length: 20);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("DEFAULT (N'')", sql);
+        }
+
+        [Fact]
+        [DisplayName("自訂 DefaultValue 應寫入 DEFAULT 子句")]
+        public void GetCommandText_CustomDefault_AppliedToColumn()
+        {
+            var schema = BuildSchema(FieldDbType.Integer, defaultValue: "42");
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("DEFAULT (42)", sql);
+        }
+
+        [Fact]
+        [DisplayName("DateTime 欄位應使用 getdate() 作為預設值")]
+        public void GetCommandText_DateTime_DefaultGetdate()
+        {
+            var schema = BuildSchema(FieldDbType.DateTime);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("DEFAULT (getdate())", sql);
+        }
+
+        [Fact]
+        [DisplayName("Guid 欄位應使用 newid() 作為預設值")]
+        public void GetCommandText_Guid_DefaultNewid()
+        {
+            var schema = BuildSchema(FieldDbType.Guid);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("DEFAULT (newid())", sql);
+        }
+
+        [Fact]
+        [DisplayName("AutoIncrement 欄位不應產生 DEFAULT 子句")]
+        public void GetCommandText_AutoIncrement_NoDefault()
+        {
+            var schema = BuildSchema(FieldDbType.AutoIncrement);
+            var builder = new SqlCreateTableCommandBuilder();
+
+            string sql = builder.GetCommandText(schema);
+
+            Assert.Contains("[col] [int] IDENTITY(1,1) NOT NULL", sql);
+            Assert.DoesNotContain("[col] [int] IDENTITY(1,1) NOT NULL DEFAULT", sql);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlFormCommandBuilderTests.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel;
+using Bee.Db.Providers.SqlServer;
+using Bee.Definition.Forms;
+
+namespace Bee.Db.UnitTests
+{
+    [Collection("Initialize")]
+    public class SqlFormCommandBuilderTests
+    {
+        [Fact]
+        [DisplayName("FormSchema 建構子 null 應擲 ArgumentNullException")]
+        public void Constructor_NullFormSchema_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new SqlFormCommandBuilder((FormSchema)null!));
+        }
+
+        [Fact]
+        [DisplayName("ProgID 建構子找不到 FormSchema 檔案應擲例外")]
+        public void Constructor_UnknownProgId_Throws()
+        {
+            // 實際路徑是 LocalDefineAccess → FileDefineStorage.GetFormSchema → ValidateFilePath
+            // 找不到檔案會擲 FileNotFoundException，未走到原始碼裡的 ArgumentException 分支
+            Assert.Throws<System.IO.FileNotFoundException>(() => new SqlFormCommandBuilder("__not_exists__"));
+        }
+
+        [Fact]
+        [DisplayName("BuildInsertCommand 應擲 NotSupportedException")]
+        public void BuildInsertCommand_Throws()
+        {
+            var builder = new SqlFormCommandBuilder(new FormSchema());
+
+            Assert.Throws<NotSupportedException>(() => builder.BuildInsertCommand());
+        }
+
+        [Fact]
+        [DisplayName("BuildUpdateCommand 應擲 NotSupportedException")]
+        public void BuildUpdateCommand_Throws()
+        {
+            var builder = new SqlFormCommandBuilder(new FormSchema());
+
+            Assert.Throws<NotSupportedException>(() => builder.BuildUpdateCommand());
+        }
+
+        [Fact]
+        [DisplayName("BuildDeleteCommand 應擲 NotSupportedException")]
+        public void BuildDeleteCommand_Throws()
+        {
+            var builder = new SqlFormCommandBuilder(new FormSchema());
+
+            Assert.Throws<NotSupportedException>(() => builder.BuildDeleteCommand());
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlTableSchemaProviderStaticTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlTableSchemaProviderStaticTests.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.SqlServer;
+using Bee.Definition;
+
+namespace Bee.Db.UnitTests
+{
+    public class SqlTableSchemaProviderStaticTests
+    {
+        #region GetFieldDbType
+
+        [Theory]
+        [InlineData("NCHAR", 0, 0, 0, FieldDbType.String)]
+        [InlineData("NVARCHAR", 0, 0, 50, FieldDbType.String)]
+        [InlineData("NVARCHAR", 0, 0, -1, FieldDbType.Text)]
+        [InlineData("BIT", 0, 0, 0, FieldDbType.Boolean)]
+        [InlineData("SMALLINT", 0, 0, 0, FieldDbType.Short)]
+        [InlineData("INT", 0, 0, 0, FieldDbType.Integer)]
+        [InlineData("BIGINT", 0, 0, 0, FieldDbType.Long)]
+        [InlineData("FLOAT", 0, 0, 0, FieldDbType.Decimal)]
+        [InlineData("DECIMAL", 19, 4, 0, FieldDbType.Currency)]
+        [InlineData("DECIMAL", 12, 3, 0, FieldDbType.Decimal)]
+        [InlineData("DATE", 0, 0, 0, FieldDbType.Date)]
+        [InlineData("DATETIME", 0, 0, 0, FieldDbType.DateTime)]
+        [InlineData("UNIQUEIDENTIFIER", 0, 0, 0, FieldDbType.Guid)]
+        [InlineData("VARBINARY", 0, 0, 0, FieldDbType.Binary)]
+        [InlineData("XML", 0, 0, 0, FieldDbType.Unknown)]
+        [DisplayName("GetFieldDbType 應正確映射各 SQL Server 型別")]
+        public void GetFieldDbType_VariousSqlTypes_MapsCorrectly(
+            string dataType, int precision, int scale, int length, FieldDbType expected)
+        {
+            var result = SqlTableSchemaProvider.GetFieldDbType(dataType, precision, scale, length);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("GetFieldDbType 應對輸入字串大小寫不敏感")]
+        public void GetFieldDbType_CaseInsensitive()
+        {
+            Assert.Equal(FieldDbType.Integer, SqlTableSchemaProvider.GetFieldDbType("int", 0, 0, 0));
+            Assert.Equal(FieldDbType.Boolean, SqlTableSchemaProvider.GetFieldDbType("Bit", 0, 0, 0));
+        }
+
+        #endregion
+
+        #region ParseDBDefaultValue
+
+        [Theory]
+        [InlineData("VARCHAR", "('hello')", "", "hello")]
+        [InlineData("CHAR", "('A')", "", "A")]
+        [InlineData("NVARCHAR", "(N'world')", "", "world")]
+        [InlineData("NCHAR", "(N'X')", "", "X")]
+        [InlineData("INT", "((42))", "", "42")]
+        [InlineData("BIT", "((1))", "", "1")]
+        [InlineData("DATE", "(getdate())", "", "getdate()")]
+        [InlineData("DATETIME", "(getdate())", "", "getdate()")]
+        [InlineData("UNIQUEIDENTIFIER", "(newid())", "", "newid()")]
+        [DisplayName("ParseDBDefaultValue 應依型別剝除外層括號或前綴")]
+        public void ParseDBDefaultValue_StripsWrappers(
+            string dataType, string defaultValue, string originalDefault, string expected)
+        {
+            var result = SqlTableSchemaProvider.ParseDBDefaultValue(dataType, defaultValue, originalDefault);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("ParseDBDefaultValue 與內建預設值相同時應回傳空字串")]
+        public void ParseDBDefaultValue_MatchesBuiltinDefault_ReturnsEmpty()
+        {
+            // INT 預設值通常為 "0"；((0)) 剝層後變成 "0"，與內建預設值相同
+            var result = SqlTableSchemaProvider.ParseDBDefaultValue("INT", "((0))", "0");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("ParseDBDefaultValue 不支援的型別應回傳空字串")]
+        public void ParseDBDefaultValue_UnknownType_ReturnsEmpty()
+        {
+            var result = SqlTableSchemaProvider.ParseDBDefaultValue("XML", "<root/>", "");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/TableJoinCollectionTests.cs
+++ b/tests/Bee.Db.UnitTests/TableJoinCollectionTests.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+using Bee.Db.Query;
+
+namespace Bee.Db.UnitTests
+{
+    public class TableJoinCollectionTests
+    {
+        private static TableJoinCollection BuildSampleCollection()
+        {
+            var collection = new TableJoinCollection();
+            collection.Add(new TableJoin
+            {
+                Key = "join1",
+                LeftTable = "tb_main",
+                LeftAlias = "M",
+                LeftField = "id",
+                RightTable = "tb_detail",
+                RightAlias = "D",
+                RightField = "main_id"
+            });
+            collection.Add(new TableJoin
+            {
+                Key = "join2",
+                LeftTable = "tb_main",
+                LeftAlias = "M",
+                LeftField = "user_id",
+                RightTable = "tb_user",
+                RightAlias = "U",
+                RightField = "id"
+            });
+            return collection;
+        }
+
+        [Fact]
+        [DisplayName("FindRightAlias rightAlias 為 null 應回傳 null")]
+        public void FindRightAlias_NullAlias_ReturnsNull()
+        {
+            var collection = BuildSampleCollection();
+
+            Assert.Null(collection.FindRightAlias(null!));
+        }
+
+        [Fact]
+        [DisplayName("FindRightAlias rightAlias 為空字串應回傳 null")]
+        public void FindRightAlias_EmptyAlias_ReturnsNull()
+        {
+            var collection = BuildSampleCollection();
+
+            Assert.Null(collection.FindRightAlias(string.Empty));
+        }
+
+        [Fact]
+        [DisplayName("FindRightAlias 找到對應 alias 應回傳該 TableJoin")]
+        public void FindRightAlias_Found_ReturnsMatchingJoin()
+        {
+            var collection = BuildSampleCollection();
+
+            var join = collection.FindRightAlias("U");
+
+            Assert.NotNull(join);
+            Assert.Equal("tb_user", join!.RightTable);
+        }
+
+        [Fact]
+        [DisplayName("FindRightAlias 採大小寫敏感比對（StrFunc.Equals 解析為 object.Equals）")]
+        public void FindRightAlias_CaseSensitive_DifferentCaseReturnsNull()
+        {
+            // StrFunc 沒有定義 static Equals，此呼叫實際解析至 object.Equals(object, object)
+            // → 字串比對為 ordinal case-sensitive
+            var collection = BuildSampleCollection();
+
+            Assert.Null(collection.FindRightAlias("d"));
+        }
+
+        [Fact]
+        [DisplayName("FindRightAlias 找不到對應 alias 應回傳 null")]
+        public void FindRightAlias_NotFound_ReturnsNull()
+        {
+            var collection = BuildSampleCollection();
+
+            Assert.Null(collection.FindRightAlias("X"));
+        }
+
+        [Fact]
+        [DisplayName("空集合 FindRightAlias 應回傳 null")]
+        public void FindRightAlias_EmptyCollection_ReturnsNull()
+        {
+            var collection = new TableJoinCollection();
+
+            Assert.Null(collection.FindRightAlias("anything"));
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/TableSchemaCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaCommandBuilderTests.cs
@@ -1,0 +1,180 @@
+using System.ComponentModel;
+using System.Data;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    [Collection("Initialize")]
+    public class TableSchemaCommandBuilderTests
+    {
+        private static TableSchema BuildSampleSchema()
+        {
+            var schema = new TableSchema { TableName = "st_demo" };
+            schema.Fields!.Add(SysFields.RowId, "Row ID", FieldDbType.Guid);
+            schema.Fields!.Add("name", "Name", FieldDbType.String, 50);
+            schema.Fields!.Add("age", "Age", FieldDbType.Integer);
+            schema.Indexes!.AddPrimaryKey(SysFields.RowId);
+            return schema;
+        }
+
+        #region 建構子測試
+
+        [Fact]
+        [DisplayName("建構子 TableSchema 為 null 應擲出 ArgumentNullException")]
+        public void Constructor_NullTableSchema_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new TableSchemaCommandBuilder(DatabaseType.SQLServer, null!));
+        }
+
+        [Fact]
+        [DisplayName("單參數建構子應採用 BackendInfo 的 DatabaseType")]
+        public void Constructor_SingleArg_UsesBackendDatabaseType()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(schema);
+            Assert.Equal(BackendInfo.DatabaseType, builder.DatabaseType);
+            Assert.Same(schema, builder.TableSchema);
+        }
+
+        [Fact]
+        [DisplayName("雙參數建構子應使用顯式指定的 DatabaseType")]
+        public void Constructor_TwoArgs_UsesSpecifiedDatabaseType()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(DatabaseType.MySQL, schema);
+            Assert.Equal(DatabaseType.MySQL, builder.DatabaseType);
+        }
+
+        #endregion
+
+        #region BuildInsertCommand 測試
+
+        [Fact]
+        [DisplayName("BuildInsertCommand 應產生 INSERT 語句並含全部非自增欄位")]
+        public void BuildInsertCommand_ContainsAllNonAutoIncrementFields()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(DatabaseType.SQLServer, schema);
+
+            var cmd = builder.BuildInsertCommand();
+
+            Assert.Contains("Insert Into [st_demo]", cmd.CommandText);
+            Assert.Contains("[sys_rowid]", cmd.CommandText);
+            Assert.Contains("[name]", cmd.CommandText);
+            Assert.Contains("[age]", cmd.CommandText);
+            Assert.Contains("@sys_rowid", cmd.CommandText);
+            Assert.Contains("@name", cmd.CommandText);
+            Assert.Contains("@age", cmd.CommandText);
+            Assert.Equal(3, cmd.Parameters.Count);
+        }
+
+        [Fact]
+        [DisplayName("BuildInsertCommand 應略過 AutoIncrement 欄位")]
+        public void BuildInsertCommand_SkipsAutoIncrementField()
+        {
+            var schema = new TableSchema { TableName = "st_demo" };
+            schema.Fields!.Add(SysFields.RowId, "Row ID", FieldDbType.Guid);
+            schema.Fields!.Add("seq", "Seq", FieldDbType.AutoIncrement);
+            schema.Fields!.Add("name", "Name", FieldDbType.String, 30);
+            schema.Indexes!.AddPrimaryKey(SysFields.RowId);
+
+            var builder = new TableSchemaCommandBuilder(DatabaseType.SQLServer, schema);
+            var cmd = builder.BuildInsertCommand();
+
+            Assert.DoesNotContain("[seq]", cmd.CommandText);
+            Assert.DoesNotContain("@seq", cmd.CommandText);
+            Assert.False(cmd.Parameters.Contains("seq"));
+        }
+
+        #endregion
+
+        #region BuildUpdateCommand 測試
+
+        [Fact]
+        [DisplayName("BuildUpdateCommand 應產生 UPDATE 語句並以主鍵為 WHERE 條件")]
+        public void BuildUpdateCommand_HasSetClauseAndPrimaryKeyWhere()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(DatabaseType.SQLServer, schema);
+
+            var cmd = builder.BuildUpdateCommand();
+
+            Assert.Contains("Update [st_demo] Set", cmd.CommandText);
+            Assert.Contains("[name]=@name", cmd.CommandText);
+            Assert.Contains("[age]=@age", cmd.CommandText);
+            Assert.Contains("Where [sys_rowid]=@sys_rowid", cmd.CommandText);
+            // 非 PK 欄位 + 1 PK 欄位
+            Assert.Equal(3, cmd.Parameters.Count);
+        }
+
+        [Fact]
+        [DisplayName("BuildUpdateCommand 主鍵參數應使用 Original 版本")]
+        public void BuildUpdateCommand_KeyParameterUsesOriginalVersion()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(DatabaseType.SQLServer, schema);
+
+            var cmd = builder.BuildUpdateCommand();
+
+            Assert.Equal(DataRowVersion.Original, cmd.Parameters[SysFields.RowId].SourceVersion);
+            Assert.Equal(DataRowVersion.Current, cmd.Parameters["name"].SourceVersion);
+        }
+
+        #endregion
+
+        #region BuildDeleteCommand 測試
+
+        [Fact]
+        [DisplayName("BuildDeleteCommand 應產生 DELETE 語句並以主鍵為 WHERE 條件")]
+        public void BuildDeleteCommand_HasPrimaryKeyWhere()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(DatabaseType.SQLServer, schema);
+
+            var cmd = builder.BuildDeleteCommand();
+
+            Assert.Contains("Delete From [st_demo]", cmd.CommandText);
+            Assert.Contains("Where [sys_rowid]=@sys_rowid", cmd.CommandText);
+            Assert.Single(cmd.Parameters);
+            Assert.Equal(DataRowVersion.Original, cmd.Parameters[SysFields.RowId].SourceVersion);
+        }
+
+        #endregion
+
+        #region BuildUpdateSpec 測試
+
+        [Fact]
+        [DisplayName("BuildUpdateSpec 應同時包裝 Insert/Update/Delete 命令與 DataTable")]
+        public void BuildUpdateSpec_PackagesAllThreeCommands()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(DatabaseType.SQLServer, schema);
+            var dataTable = new DataTable("st_demo");
+
+            var spec = builder.BuildUpdateSpec(dataTable);
+
+            Assert.Same(dataTable, spec.DataTable);
+            Assert.NotNull(spec.InsertCommand);
+            Assert.NotNull(spec.UpdateCommand);
+            Assert.NotNull(spec.DeleteCommand);
+            Assert.Contains("Insert Into", spec.InsertCommand!.CommandText);
+            Assert.Contains("Update", spec.UpdateCommand!.CommandText);
+            Assert.Contains("Delete From", spec.DeleteCommand!.CommandText);
+        }
+
+        [Fact]
+        [DisplayName("BuildUpdateSpec DataTable 為 null 應擲出 ArgumentNullException")]
+        public void BuildUpdateSpec_NullDataTable_Throws()
+        {
+            var schema = BuildSampleSchema();
+            var builder = new TableSchemaCommandBuilder(DatabaseType.SQLServer, schema);
+
+            Assert.Throws<ArgumentNullException>(() => builder.BuildUpdateSpec(null!));
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/TableSchemaComparerTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaComparerTests.cs
@@ -1,0 +1,158 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Schema;
+using Bee.Definition;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    [Collection("Initialize")]
+    public class TableSchemaComparerTests
+    {
+        private static TableSchema BuildBaseSchema(string tableName = "st_demo")
+        {
+            var schema = new TableSchema { TableName = tableName };
+            schema.Fields!.Add(SysFields.RowId, "Row ID", FieldDbType.Guid);
+            schema.Fields!.Add("name", "Name", FieldDbType.String, 50);
+            schema.Indexes!.AddPrimaryKey(SysFields.RowId);
+            return schema;
+        }
+
+        // 模擬從資料庫讀回的真實資料表結構，索引名稱已經是格式化後的字串（非樣板）
+        private static TableSchema BuildRealSchema(string tableName = "st_demo")
+        {
+            var schema = new TableSchema { TableName = tableName };
+            schema.Fields!.Add(SysFields.RowId, "Row ID", FieldDbType.Guid);
+            schema.Fields!.Add("name", "Name", FieldDbType.String, 50);
+            var pk = new TableSchemaIndex
+            {
+                Name = $"pk_{tableName}",
+                PrimaryKey = true,
+                Unique = true
+            };
+            pk.IndexFields!.Add(SysFields.RowId);
+            schema.Indexes!.Add(pk);
+            return schema;
+        }
+
+        [Fact]
+        [DisplayName("RealTable 為 null 時整張表應標記為 New")]
+        public void Compare_NullRealTable_MarksTableAsNew()
+        {
+            var define = BuildBaseSchema();
+            var comparer = new TableSchemaComparer(define, null);
+
+            var result = comparer.Compare();
+
+            Assert.Equal(DbUpgradeAction.New, result.UpgradeAction);
+        }
+
+        [Fact]
+        [DisplayName("結構完全相同時 UpgradeAction 應為 None")]
+        public void Compare_IdenticalSchemas_ReturnsNone()
+        {
+            var define = BuildBaseSchema();
+            var real = BuildRealSchema();
+            var comparer = new TableSchemaComparer(define, real);
+
+            var result = comparer.Compare();
+
+            Assert.Equal(DbUpgradeAction.None, result.UpgradeAction);
+        }
+
+        [Fact]
+        [DisplayName("實際表缺少欄位時應將欄位標記為 New 並升級表")]
+        public void Compare_MissingField_MarksFieldAsNewAndUpgradesTable()
+        {
+            var define = BuildBaseSchema();
+            define.Fields!.Add("age", "Age", FieldDbType.Integer);
+
+            var real = BuildRealSchema();
+            var comparer = new TableSchemaComparer(define, real);
+
+            var result = comparer.Compare();
+
+            Assert.Equal(DbUpgradeAction.Upgrade, result.UpgradeAction);
+            Assert.Equal(DbUpgradeAction.New, result.Fields!["age"].UpgradeAction);
+        }
+
+        [Fact]
+        [DisplayName("欄位定義不同時應將欄位標記為 Upgrade 並升級表")]
+        public void Compare_DifferentField_MarksFieldAsUpgrade()
+        {
+            var define = BuildBaseSchema();
+            var real = BuildRealSchema();
+            real.Fields!["name"].Length = 30;  // 與 define 的 50 不同
+
+            var comparer = new TableSchemaComparer(define, real);
+            var result = comparer.Compare();
+
+            Assert.Equal(DbUpgradeAction.Upgrade, result.UpgradeAction);
+            Assert.Equal(DbUpgradeAction.Upgrade, result.Fields!["name"].UpgradeAction);
+        }
+
+        [Fact]
+        [DisplayName("實際表缺少索引時應將索引標記為 New 並升級表")]
+        public void Compare_MissingIndex_MarksIndexAsNew()
+        {
+            var define = BuildBaseSchema();
+            define.Indexes!.Add("ix_{0}_name", "name", false);
+            var real = BuildRealSchema();
+
+            var comparer = new TableSchemaComparer(define, real);
+            var result = comparer.Compare();
+
+            Assert.Equal(DbUpgradeAction.Upgrade, result.UpgradeAction);
+            var idx = result.Indexes!["ix_{0}_name"];
+            Assert.Equal(DbUpgradeAction.New, idx.UpgradeAction);
+        }
+
+        [Fact]
+        [DisplayName("索引定義不同時應將索引標記為 Upgrade")]
+        public void Compare_DifferentIndex_MarksIndexAsUpgrade()
+        {
+            var define = BuildBaseSchema();
+            define.Indexes!.Add("ix_{0}_name", "name", true);
+
+            var real = BuildRealSchema();
+            // 真實表的索引名稱已格式化為 "ix_st_demo_name"，且 unique 標記不同
+            real.Indexes!.Add("ix_st_demo_name", "name", false);
+
+            var comparer = new TableSchemaComparer(define, real);
+            var result = comparer.Compare();
+
+            Assert.Equal(DbUpgradeAction.Upgrade, result.UpgradeAction);
+            Assert.Equal(DbUpgradeAction.Upgrade, result.Indexes!["ix_{0}_name"].UpgradeAction);
+        }
+
+        [Fact]
+        [DisplayName("實際表多出的欄位應追加到比較結果中")]
+        public void Compare_ExtraFieldInRealTable_AppendsExtensionField()
+        {
+            var define = BuildBaseSchema();
+            // 觸發 Upgrade 才會走 AddExtensionFields
+            define.Fields!.Add("age", "Age", FieldDbType.Integer);
+
+            var real = BuildRealSchema();
+            real.Fields!.Add("legacy_col", "Legacy", FieldDbType.String, 10);
+
+            var comparer = new TableSchemaComparer(define, real);
+            var result = comparer.Compare();
+
+            Assert.Equal(DbUpgradeAction.Upgrade, result.UpgradeAction);
+            Assert.True(result.Fields!.Contains("legacy_col"));
+        }
+
+        [Fact]
+        [DisplayName("DefineTable 與 RealTable 屬性應正確暴露於 Comparer")]
+        public void Properties_ExposeInputs()
+        {
+            var define = BuildBaseSchema();
+            var real = BuildRealSchema();
+            var comparer = new TableSchemaComparer(define, real);
+
+            Assert.Same(define, comparer.DefineTable);
+            Assert.Same(real, comparer.RealTable);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/WhereBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/WhereBuilderTests.cs
@@ -112,5 +112,143 @@ namespace Bee.Db.UnitTests
             Assert.Equal(string.Empty, result.WhereClause);
         }
 
+        [Fact]
+        [DisplayName("Build root 為 null 應回傳空 WhereBuildResult")]
+        public void Build_NullRoot_ReturnsEmptyResult()
+        {
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(null, null);
+            Assert.Equal(string.Empty, result.WhereClause);
+        }
+
+        [Theory]
+        [InlineData(ComparisonOperator.GreaterThan, ">")]
+        [InlineData(ComparisonOperator.GreaterThanOrEqual, ">=")]
+        [InlineData(ComparisonOperator.LessThan, "<")]
+        [InlineData(ComparisonOperator.LessThanOrEqual, "<=")]
+        [InlineData(ComparisonOperator.NotEqual, "<>")]
+        [DisplayName("Build 各比較運算符應產生對應 SQL 運算子")]
+        public void Build_ComparisonOperators_BuildExpectedSql(ComparisonOperator op, string sqlOp)
+        {
+            var root = new FilterCondition { FieldName = "Age", Operator = op, Value = 18 };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(root, null, includeWhereKeyword: false);
+            Assert.Equal($"Age {sqlOp} @p0", result.WhereClause);
+            Assert.Equal(18, result.Parameters!["@p0"]);
+        }
+
+        [Fact]
+        [DisplayName("Build Like 條件應使用原始值")]
+        public void Build_Like_UsesRawValue()
+        {
+            var root = new FilterCondition { FieldName = "Name", Operator = ComparisonOperator.Like, Value = "Lee%" };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(root, null, includeWhereKeyword: false);
+            Assert.Equal("Name LIKE @p0", result.WhereClause);
+            Assert.Equal("Lee%", result.Parameters!["@p0"]);
+        }
+
+        [Fact]
+        [DisplayName("Build StartsWith 應在尾端加上萬用字元")]
+        public void Build_StartsWith_AddsTrailingWildcard()
+        {
+            var root = FilterCondition.StartsWith("Name", "Lee");
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(root, null, includeWhereKeyword: false);
+            Assert.Equal("Name LIKE @p0", result.WhereClause);
+            Assert.Equal("Lee%", result.Parameters!["@p0"]);
+        }
+
+        [Fact]
+        [DisplayName("Build EndsWith 應在開頭加上萬用字元")]
+        public void Build_EndsWith_AddsLeadingWildcard()
+        {
+            var root = FilterCondition.EndsWith("Name", "Lee");
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(root, null, includeWhereKeyword: false);
+            Assert.Equal("Name LIKE @p0", result.WhereClause);
+            Assert.Equal("%Lee", result.Parameters!["@p0"]);
+        }
+
+        [Fact]
+        [DisplayName("Build NotEqual 配合 null 值應產生 IS NOT NULL")]
+        public void Build_NotEqualNull_BecomesIsNotNull()
+        {
+            var root = new FilterCondition { FieldName = "Memo", Operator = ComparisonOperator.NotEqual, Value = null };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(root, null);
+            Assert.Equal("WHERE Memo IS NOT NULL", result.WhereClause);
+        }
+
+        [Fact]
+        [DisplayName("Build 不支援的 null 比較運算符應擲出 InvalidOperationException")]
+        public void Build_UnsupportedNullOperator_Throws()
+        {
+            var root = new FilterCondition { FieldName = "Age", Operator = ComparisonOperator.GreaterThan, Value = null };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            Assert.Throws<InvalidOperationException>(() => builder.Build(root, null));
+        }
+
+        [Fact]
+        [DisplayName("Build Between 缺第二值且 IgnoreIfNull=true 時應忽略條件")]
+        public void Build_BetweenMissingSecondValue_IgnoreIfNull_DropsCondition()
+        {
+            var root = new FilterCondition
+            {
+                FieldName = "Age",
+                Operator = ComparisonOperator.Between,
+                Value = 18,
+                SecondValue = null,
+                IgnoreIfNull = true
+            };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(root, null, includeWhereKeyword: false);
+            Assert.Equal(string.Empty, result.WhereClause);
+        }
+
+        [Fact]
+        [DisplayName("Build Between 缺第二值且未設 IgnoreIfNull 應擲例外")]
+        public void Build_BetweenMissingSecondValue_Throws()
+        {
+            var root = new FilterCondition
+            {
+                FieldName = "Age",
+                Operator = ComparisonOperator.Between,
+                Value = 18,
+                SecondValue = null
+            };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            Assert.Throws<InvalidOperationException>(() => builder.Build(root, null));
+        }
+
+        [Fact]
+        [DisplayName("Build Between 完整值應產生 BETWEEN 子句")]
+        public void Build_Between_BuildsBetweenClause()
+        {
+            var root = FilterCondition.Between("Age", 18, 60);
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            var result = builder.Build(root, null, includeWhereKeyword: false);
+            Assert.Equal("Age BETWEEN @p0 AND @p1", result.WhereClause);
+            Assert.Equal(18, result.Parameters!["@p0"]);
+            Assert.Equal(60, result.Parameters["@p1"]);
+        }
+
+        [Fact]
+        [DisplayName("Build IN 條件傳入非 enumerable 值應擲例外")]
+        public void Build_InWithNonEnumerable_Throws()
+        {
+            var root = new FilterCondition { FieldName = "Id", Operator = ComparisonOperator.In, Value = 1 };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            Assert.Throws<InvalidOperationException>(() => builder.Build(root, null));
+        }
+
+        [Fact]
+        [DisplayName("Build 空 FieldName 應擲出 InvalidOperationException")]
+        public void Build_EmptyFieldName_Throws()
+        {
+            var root = new FilterCondition { FieldName = "", Operator = ComparisonOperator.Equal, Value = 1 };
+            var builder = new WhereBuilder(DatabaseType.SQLServer);
+            Assert.Throws<InvalidOperationException>(() => builder.Build(root, null));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- 新增 **118 個純邏輯測試**（階段 1：13、階段 2：74、階段 3：31），提升 `Bee.Db` 在 CI 模式下的測試覆蓋率
- 所有新測試**不依賴真實資料庫**，可在 SonarCloud 完整執行；不新增任何 `[LocalOnlyFact]`
- Bee.Db.UnitTests 執行結果：**248 通過 / 22 略過**（`CI=true`）

## 涵蓋類別

| 類別 | 測試檔 |
|------|--------|
| `DbCommandSpec` | DbCommandSpecTests（補強） |
| `DbCommandResult` | DbCommandResultTests |
| `DbParameterSpec` / `DbParameterSpecCollection` | 對應 Tests |
| `DbConnectionScope` | DbConnectionScopeTests（自訂 `FakeDbConnection`） |
| `DefaultParameterCollector` / `FromBuilder` | 對應 Tests |
| `ILMapper<T>` | ILMapperTests（IL emit + DataTable.CreateDataReader） |
| `DbProviderManager` | DbProviderManagerTests |
| `SqlTableSchemaProvider`（靜態方法）| SqlTableSchemaProviderStaticTests |
| `SqlFormCommandBuilder` | SqlFormCommandBuilderTests |
| `DbAccess`（純邏輯防禦） | DbAccessExtraTests |
| `SelectCommandBuilder` | SelectCommandBuilderTests |
| `TableJoinCollection.FindRightAlias` | TableJoinCollectionTests |
| `DbAccessLogger.LogStart/LogEnd` | DbAccessLoggerTests（補強） |
| `DbFunc` / `WhereBuilder` / `TableSchemaComparer` 等 | 既有測試補強 |

## 計畫文件

- 計畫書：[docs/plans/plan-bee-db-test-coverage.md](../docs/plans/plan-bee-db-test-coverage.md) — 已標記 ✅ 已完成（2026-04-18）

## Test plan

- [x] CI 模式（`CI=true`）下 `dotnet test tests/Bee.Db.UnitTests` 全綠
- [x] 所有新測試與 Bee.Db.UnitTests 既有測試共存無衝突
- [ ] GitHub Actions `build-ci.yml` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)