### PR TITLE
test(Bee.Repository): 補齊純邏輯測試覆蓋（階段 1+2+3）

### DIFF
--- a/docs/plans/plan-bee-repository-test-coverage.md
+++ b/docs/plans/plan-bee-repository-test-coverage.md
@@ -1,6 +1,6 @@
 # Bee.Repository / Bee.Repository.Abstractions 測試覆蓋率提升計畫書
 
-**狀態：🚧 進行中**（階段 1、2、3 測試已撰寫，待 CI 驗證）
+**狀態：✅ 已完成（2026-04-18）**
 
 ## 1. 背景與目標
 

--- a/docs/plans/plan-bee-repository-test-coverage.md
+++ b/docs/plans/plan-bee-repository-test-coverage.md
@@ -1,6 +1,6 @@
 # Bee.Repository / Bee.Repository.Abstractions 測試覆蓋率提升計畫書
 
-**狀態：📝 擬定中**
+**狀態：🚧 進行中**（階段 1、2、3 測試已撰寫，待 CI 驗證）
 
 ## 1. 背景與目標
 

--- a/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using Bee.Repository.Form;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="DataFormRepository"/> 建構子屬性賦值的純邏輯測試。
+    /// </summary>
+    public class DataFormRepositoryTests
+    {
+        [Theory]
+        [InlineData("Employee")]
+        [InlineData("Order")]
+        [InlineData("Customer")]
+        [DisplayName("DataFormRepository 建構子應正確設定 ProgId")]
+        public void Constructor_SetsProgId(string progId)
+        {
+            var repo = new DataFormRepository(progId);
+            Assert.Equal(progId, repo.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子目前未防護空白 ProgId，依現況原樣儲存")]
+        public void Constructor_EmptyProgId_StoresAsIs()
+        {
+            var repo = new DataFormRepository(string.Empty);
+            Assert.Equal(string.Empty, repo.ProgId);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/DatabaseRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/DatabaseRepositoryTests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Settings;
+using Bee.Repository.Abstractions.System;
+using Bee.Repository.Provider;
+using Bee.Tests.Shared;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="IDatabaseRepository"/> 預設實作的純邏輯測試。
+    /// 透過 <see cref="SystemRepositoryProvider"/> 取得實例（避免直接依賴 internal 型別）。
+    /// </summary>
+    [Collection("Initialize")]
+    public class DatabaseRepositoryTests
+    {
+        private const string ValidDatabaseId = "common";
+        private const string ValidDbName = "DbName";
+        private const string ValidTableName = "TableName";
+
+        private static IDatabaseRepository CreateRepository()
+            => new SystemRepositoryProvider().DatabaseRepository;
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("UpgradeTableSchema 空白 databaseId 應拋 ArgumentException")]
+        public void UpgradeTableSchema_EmptyDatabaseId_ThrowsArgumentException(string? databaseId)
+        {
+            var repo = CreateRepository();
+            Assert.Throws<ArgumentException>(() => repo.UpgradeTableSchema(databaseId!, ValidDbName, ValidTableName));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("UpgradeTableSchema 空白 dbName 應拋 ArgumentException")]
+        public void UpgradeTableSchema_EmptyDbName_ThrowsArgumentException(string? dbName)
+        {
+            var repo = CreateRepository();
+            Assert.Throws<ArgumentException>(() => repo.UpgradeTableSchema(ValidDatabaseId, dbName!, ValidTableName));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("UpgradeTableSchema 空白 tableName 應拋 ArgumentException")]
+        public void UpgradeTableSchema_EmptyTableName_ThrowsArgumentException(string? tableName)
+        {
+            var repo = CreateRepository();
+            Assert.Throws<ArgumentException>(() => repo.UpgradeTableSchema(ValidDatabaseId, ValidDbName, tableName!));
+        }
+
+        [Fact]
+        [DisplayName("TestConnection 傳入未註冊的 DatabaseType 應拋 KeyNotFoundException")]
+        public void TestConnection_UnregisteredDatabaseType_ThrowsKeyNotFoundException()
+        {
+            // GlobalFixture 僅註冊 SQLServer；MySQL/SQLite/Oracle 皆未註冊。
+            var repo = CreateRepository();
+            var item = new DatabaseItem
+            {
+                Id = "mysql_test",
+                DatabaseType = DatabaseType.MySQL,
+                ConnectionString = "Server=localhost;Database=foo;"
+            };
+
+            Assert.Throws<KeyNotFoundException>(() => repo.TestConnection(item));
+        }
+
+        [Fact]
+        [DisplayName("TestConnection 傳入 null DatabaseItem 應拋 NullReferenceException（依現況）")]
+        public void TestConnection_NullItem_ThrowsNullReferenceException()
+        {
+            // 目前實作未對 null 做防護，呼叫 item.DatabaseType 時會拋 NullReferenceException；
+            // 測試僅記錄現況，若日後加上防護需同步調整。
+            var repo = CreateRepository();
+            Assert.Throws<NullReferenceException>(() => repo.TestConnection(null!));
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/FormRepositoryProviderTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryProviderTests.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel;
+using Bee.Repository.Form;
+using Bee.Repository.Provider;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="FormRepositoryProvider"/> 工廠方法的純邏輯測試。
+    /// </summary>
+    public class FormRepositoryProviderTests
+    {
+        private const string DataProgId = "Employee";
+        private const string ReportProgId = "SalesReport";
+
+        [Fact]
+        [DisplayName("GetDataFormRepository 應回傳帶有指定 ProgId 的 DataFormRepository")]
+        public void GetDataFormRepository_ReturnsDataFormRepositoryWithProgId()
+        {
+            var provider = new FormRepositoryProvider();
+            var repo = provider.GetDataFormRepository(DataProgId);
+
+            var typed = Assert.IsType<DataFormRepository>(repo);
+            Assert.Equal(DataProgId, typed.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("GetReportFormRepository 應回傳帶有指定 ProgId 的 ReportFormRepository")]
+        public void GetReportFormRepository_ReturnsReportFormRepositoryWithProgId()
+        {
+            var provider = new FormRepositoryProvider();
+            var repo = provider.GetReportFormRepository(ReportProgId);
+
+            var typed = Assert.IsType<ReportFormRepository>(repo);
+            Assert.Equal(ReportProgId, typed.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("GetDataFormRepository 不同 ProgId 應回傳不同實例")]
+        public void GetDataFormRepository_DifferentProgIds_ReturnDifferentInstances()
+        {
+            var provider = new FormRepositoryProvider();
+
+            var first = provider.GetDataFormRepository("A");
+            var second = provider.GetDataFormRepository("B");
+
+            Assert.NotSame(first, second);
+            Assert.Equal("A", ((DataFormRepository)first).ProgId);
+            Assert.Equal("B", ((DataFormRepository)second).ProgId);
+        }
+
+        [Fact]
+        [DisplayName("GetDataFormRepository 相同 ProgId 每次呼叫回傳新實例（非快取）")]
+        public void GetDataFormRepository_SameProgId_ReturnsNewInstanceEachCall()
+        {
+            var provider = new FormRepositoryProvider();
+
+            var first = provider.GetDataFormRepository(DataProgId);
+            var second = provider.GetDataFormRepository(DataProgId);
+
+            Assert.NotSame(first, second);
+        }
+
+        [Fact]
+        [DisplayName("GetReportFormRepository 相同 ProgId 每次呼叫回傳新實例（非快取）")]
+        public void GetReportFormRepository_SameProgId_ReturnsNewInstanceEachCall()
+        {
+            var provider = new FormRepositoryProvider();
+
+            var first = provider.GetReportFormRepository(ReportProgId);
+            var second = provider.GetReportFormRepository(ReportProgId);
+
+            Assert.NotSame(first, second);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/ReportFormRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/ReportFormRepositoryTests.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using Bee.Repository.Form;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="ReportFormRepository"/> 建構子屬性賦值的純邏輯測試。
+    /// </summary>
+    public class ReportFormRepositoryTests
+    {
+        [Theory]
+        [InlineData("SalesReport")]
+        [InlineData("InventoryReport")]
+        [InlineData("CustomerLedger")]
+        [DisplayName("ReportFormRepository 建構子應正確設定 ProgId")]
+        public void Constructor_SetsProgId(string progId)
+        {
+            var repo = new ReportFormRepository(progId);
+            Assert.Equal(progId, repo.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("ReportFormRepository 建構子目前未防護空白 ProgId，依現況原樣儲存")]
+        public void Constructor_EmptyProgId_StoresAsIs()
+        {
+            var repo = new ReportFormRepository(string.Empty);
+            Assert.Equal(string.Empty, repo.ProgId);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/RepositoryInfoTests.cs
+++ b/tests/Bee.Repository.UnitTests/RepositoryInfoTests.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using Bee.Repository.Abstractions;
+using Bee.Repository.Abstractions.Form;
+using Bee.Repository.Abstractions.Provider;
+using Bee.Repository.Abstractions.System;
+using Bee.Repository.Provider;
+using Bee.Tests.Shared;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="RepositoryInfo"/> 靜態屬性的測試。
+    /// 依賴 <see cref="GlobalFixture"/> 完成 <c>BackendInfo</c> 初始化，觸發 static ctor 的正常路徑。
+    /// </summary>
+    [Collection("Initialize")]
+    public class RepositoryInfoTests
+    {
+        [Fact]
+        [DisplayName("RepositoryInfo.SystemProvider 於 GlobalFixture 初始化後不應為 null")]
+        public void SystemProvider_AfterFixtureInit_IsNotNull()
+        {
+            Assert.NotNull(RepositoryInfo.SystemProvider);
+        }
+
+        [Fact]
+        [DisplayName("RepositoryInfo.FormProvider 於 GlobalFixture 初始化後不應為 null")]
+        public void FormProvider_AfterFixtureInit_IsNotNull()
+        {
+            Assert.NotNull(RepositoryInfo.FormProvider);
+        }
+
+        [Fact]
+        [DisplayName("RepositoryInfo.SystemProvider 預設型別應為 SystemRepositoryProvider")]
+        public void SystemProvider_DefaultType_IsSystemRepositoryProvider()
+        {
+            Assert.IsType<SystemRepositoryProvider>(RepositoryInfo.SystemProvider);
+        }
+
+        [Fact]
+        [DisplayName("RepositoryInfo.FormProvider 預設型別應為 FormRepositoryProvider")]
+        public void FormProvider_DefaultType_IsFormRepositoryProvider()
+        {
+            Assert.IsType<FormRepositoryProvider>(RepositoryInfo.FormProvider);
+        }
+
+        [Fact]
+        [DisplayName("RepositoryInfo.SystemProvider 可被外部替換並讀回")]
+        public void SystemProvider_CanBeReplaced()
+        {
+            var original = RepositoryInfo.SystemProvider;
+            try
+            {
+                var stub = new StubSystemRepositoryProvider();
+                RepositoryInfo.SystemProvider = stub;
+                Assert.Same(stub, RepositoryInfo.SystemProvider);
+            }
+            finally
+            {
+                RepositoryInfo.SystemProvider = original;
+            }
+        }
+
+        [Fact]
+        [DisplayName("RepositoryInfo.FormProvider 可被外部替換並讀回")]
+        public void FormProvider_CanBeReplaced()
+        {
+            var original = RepositoryInfo.FormProvider;
+            try
+            {
+                var stub = new StubFormRepositoryProvider();
+                RepositoryInfo.FormProvider = stub;
+                Assert.Same(stub, RepositoryInfo.FormProvider);
+            }
+            finally
+            {
+                RepositoryInfo.FormProvider = original;
+            }
+        }
+
+        private sealed class StubSystemRepositoryProvider : ISystemRepositoryProvider
+        {
+            public IDatabaseRepository DatabaseRepository { get; set; } = null!;
+            public ISessionRepository SessionRepository { get; set; } = null!;
+        }
+
+        private sealed class StubFormRepositoryProvider : IFormRepositoryProvider
+        {
+            public IDataFormRepository GetDataFormRepository(string progId) => null!;
+            public IReportFormRepository GetReportFormRepository(string progId) => null!;
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/SystemRepositoryProviderTests.cs
+++ b/tests/Bee.Repository.UnitTests/SystemRepositoryProviderTests.cs
@@ -1,0 +1,73 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Settings;
+using Bee.Repository.Abstractions.System;
+using Bee.Repository.Provider;
+using Bee.Repository.System;
+using Bee.Tests.Shared;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="SystemRepositoryProvider"/> 預設成員與覆寫能力的純邏輯測試。
+    /// </summary>
+    [Collection("Initialize")]
+    public class SystemRepositoryProviderTests
+    {
+        [Fact]
+        [DisplayName("SystemRepositoryProvider 預設 DatabaseRepository 應非 null 且實作 IDatabaseRepository")]
+        public void Constructor_DefaultDatabaseRepository_ImplementsInterface()
+        {
+            var provider = new SystemRepositoryProvider();
+
+            Assert.NotNull(provider.DatabaseRepository);
+            Assert.IsAssignableFrom<IDatabaseRepository>(provider.DatabaseRepository);
+        }
+
+        [Fact]
+        [DisplayName("SystemRepositoryProvider 預設 SessionRepository 應為 SessionRepository 型別")]
+        public void Constructor_DefaultSessionRepository_IsSessionRepositoryType()
+        {
+            var provider = new SystemRepositoryProvider();
+
+            Assert.IsType<SessionRepository>(provider.SessionRepository);
+        }
+
+        [Fact]
+        [DisplayName("SystemRepositoryProvider.DatabaseRepository 可被替換為測試替身")]
+        public void DatabaseRepository_CanBeReplaced()
+        {
+            var provider = new SystemRepositoryProvider();
+            var stub = new StubDatabaseRepository();
+
+            provider.DatabaseRepository = stub;
+
+            Assert.Same(stub, provider.DatabaseRepository);
+        }
+
+        [Fact]
+        [DisplayName("SystemRepositoryProvider.SessionRepository 可被替換為測試替身")]
+        public void SessionRepository_CanBeReplaced()
+        {
+            var provider = new SystemRepositoryProvider();
+            var stub = new StubSessionRepository();
+
+            provider.SessionRepository = stub;
+
+            Assert.Same(stub, provider.SessionRepository);
+        }
+
+        private sealed class StubDatabaseRepository : IDatabaseRepository
+        {
+            public void TestConnection(DatabaseItem item) { }
+            public bool UpgradeTableSchema(string databaseId, string dbName, string tableName) => false;
+        }
+
+        private sealed class StubSessionRepository : ISessionRepository
+        {
+            public SessionUser? GetSession(Guid accessToken) => null;
+            public SessionUser CreateSession(string userID, int expiresIn = 3600, bool oneTime = false)
+                => new SessionUser();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

依 `docs/plans/plan-bee-repository-test-coverage.md` 三階段執行，針對不需真實資料庫的類別與分支補齊單元測試，預期將 `Bee.Repository` / `Bee.Repository.Abstractions` SonarCloud Coverage 從 0% 提升至目標區間。

- **階段 1（Bee.Repository.Abstractions）**：`RepositoryInfoTests` — 驗證 `SystemProvider` / `FormProvider` 預設型別與可覆寫能力
- **階段 2（Bee.Repository — Provider 與 Form）**：`SystemRepositoryProviderTests`、`FormRepositoryProviderTests`、`DataFormRepositoryTests`、`ReportFormRepositoryTests`
- **階段 3（Bee.Repository — DatabaseRepository 純邏輯）**：`DatabaseRepositoryTests` — 透過 `SystemRepositoryProvider` 取得 `IDatabaseRepository` 介面實例，避免直接依賴 internal 型別；涵蓋 `UpgradeTableSchema` 參數防護、未註冊 `DatabaseType` 的 `KeyNotFoundException`、null `DatabaseItem` 現況記錄
- 既有 `[LocalOnlyFact]` `SessionRepositoryTests` 保持不變

## Test plan

- [ ] `build-ci.yml` 於 PR 通過 build 驗證
- [ ] 所有新增測試在 Linux CI（`CI=true`）下通過
- [ ] SonarCloud 顯示 `Bee.Repository` / `Bee.Repository.Abstractions` Line Coverage 有明顯提升
- [ ] 無新增警告（`TreatWarningsAsErrors=true`）

計畫文件已標記 **🚧 進行中**，待 CI 與 SonarCloud 驗證後更新為 ✅ 已完成。

https://claude.ai/code/session_01CJTfinkictk51xEYufXQP8