### PR TITLE
fix(security): 處理 SonarCloud security hotspots

### DIFF
--- a/.claude/rules/sonarcloud.md
+++ b/.claude/rules/sonarcloud.md
@@ -147,6 +147,54 @@ string.Join(", ", new[] { "a", "b", "c" });
 |------|------|
 | **S2701** | `Assert.True`／`Assert.False` 的第一參數不應為字面值（如 `Assert.True(true)`），應為被測表達式 |
 
+## 13. Regex（ReDoS 防護）
+
+| 規則 | 原則 |
+|------|------|
+| **S6444** | `Regex.IsMatch`／`Regex.Replace`／`new Regex(...)` 一律傳入 `TimeSpan.FromSeconds(1)` timeout，即使 pattern 為編譯期常數或已用 `Regex.Escape()` 轉義 |
+
+```csharp
+// ✅ 正確：明確指定 timeout
+Regex.IsMatch(input, pattern, RegexOptions.None, TimeSpan.FromSeconds(1));
+Regex.Replace(s, Regex.Escape(search), replacement, options, TimeSpan.FromSeconds(1));
+new Regex(pattern, RegexOptions.Compiled, TimeSpan.FromSeconds(1));
+
+// ❌ 禁止：未傳 timeout
+Regex.IsMatch(input, pattern);
+new Regex(pattern, RegexOptions.Compiled);
+```
+
+## 14. GitHub Actions 工作流
+
+| 規則 | 原則 |
+|------|------|
+| **S7636** | secrets 不直接在 `run:` block 展開；改以 step-level `env:` 注入後引用環境變數，避免遭 log 洩漏 |
+| **S7637** | 第三方 actions 一律 pin 至完整 commit SHA；版本 tag 以行尾註解保留可讀性 |
+
+```yaml
+# ✅ 正確：secrets 用 env:，action pin commit SHA
+- name: Push to NuGet
+  env:
+    NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+  run: dotnet nuget push ... --api-key "$env:NUGET_API_KEY"
+
+- uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+# ❌ 禁止：secrets 直接在 run 展開、action 只 pin 主版本
+- name: Push to NuGet
+  run: dotnet nuget push ... --api-key ${{ secrets.NUGET_API_KEY }}
+
+- uses: actions/checkout@v4
+```
+
+取得 SHA 的方法：`gh api repos/<org>/<name>/git/ref/tags/<tag> --jq .object.sha`
+
+## 15. 序列化
+
+| 規則 | 原則 |
+|------|------|
+| **S5766** | `[Serializable]` marker 類別之建構子若**未**實作 `(SerializationInfo, StreamingContext)`、屬性皆為原始型別、不經 `BinaryFormatter` 反序列化，則非實際反序列化入口，於 Sonar UI 標記 **Safe** 並說明理由即可，不必改程式 |
+
 ---
 
 ## 不納入之規則

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -26,23 +26,23 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       with:
         dotnet-version: 10.0.x
 
     - name: Setup Java (for SonarScanner)
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
       with:
         distribution: zulu
         java-version: '17'
 
     - name: Cache SonarCloud packages
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
       with:
         path: ~\.sonar\cache
         key: ${{ runner.os }}-sonar

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
       with:
         dotnet-version: 10.0.x
 
@@ -62,10 +62,12 @@ jobs:
         dotnet pack src/Bee.Repository/Bee.Repository.csproj --configuration Release --output ./nupkgs --no-build /p:Version=$ver
 
     - name: Push to NuGet
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
       run: |
         $ErrorActionPreference = 'Stop'
         Get-ChildItem -Path ./nupkgs -Filter *.nupkg | ForEach-Object {
-          dotnet nuget push $_.FullName --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push $_.FullName --api-key "$env:NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
           if ($LASTEXITCODE -ne 0) { throw "Failed to push $($_.Name)" }
         }
 
@@ -81,7 +83,7 @@ jobs:
         echo "VERSION=${TAG#v}" >> $GITHUB_OUTPUT
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
       with:
         tag_name: ${{ github.ref_name }}
         name: Release ${{ github.ref_name }}

--- a/docs/plans/plan-sonarcloud-hotspots.md
+++ b/docs/plans/plan-sonarcloud-hotspots.md
@@ -1,0 +1,117 @@
+# 計畫：處理 SonarCloud Security Hotspots
+
+**狀態：🚧 進行中**
+
+## 背景
+
+SonarCloud 對 `jeff377_bee-library` 目前揭露 **9 個 security hotspots**（1 個已 REVIEWED/SAFE，8 個 TO_REVIEW）。本次一次性清理，避免 hotspot 堆積淹沒新掃描的訊號，並強化 GitHub Actions 供應鏈。
+
+預期結果：
+
+- 所有 8 個 TO_REVIEW hotspot 變更為 REVIEWED（SAFE 或 FIXED）。
+- `nuget-publish.yml` 的 secrets 以 step-level `env:` 注入。
+- 兩個 workflow 的第三方 actions 全部 pin 至完整 commit SHA。
+- 4 個 Regex 呼叫加上 `TimeSpan.FromSeconds(1)`，從根源消除 S6444。
+- `.claude/rules/sonarcloud.md` 新增本次規則（S6444 / S5766 / S7636 / S7637）。
+
+---
+
+## Hotspot 清冊與處置
+
+| # | 位置 | 規則 | 類別 | 處置 |
+|---|------|------|------|------|
+| 1 | `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs:32` | S5693 | DoS | ✅ 已 SAFE（`[RequestSizeLimit(10MB)]` 已生效）— 不動 |
+| 2 | `src/Bee.Base/FileFunc.cs:170` | S6444 | ReDoS | 🔧 加 timeout |
+| 3 | `src/Bee.Base/StrFunc.cs:160`（`Replace`） | S6444 | ReDoS | 🔧 加 timeout |
+| 4 | `src/Bee.Base/StrFunc.cs:515`（`Like`） | S6444 | ReDoS | 🔧 加 timeout（風險最高，手動改通配符） |
+| 5 | `src/Bee.Db/DbCommandSpec.cs:24`（`PlaceholderRegex`） | S6444 | ReDoS | 🔧 `new Regex` 加 timeout |
+| 6 | `src/Bee.Base/ApiException.cs:29`（建構子） | S5766 | object-injection | 🏷️ Sonar UI 標記 SAFE |
+| 7 | `src/Bee.Definition/SortField.cs:25`（建構子） | S5766 | object-injection | 🏷️ Sonar UI 標記 SAFE |
+| 8 | `.github/workflows/nuget-publish.yml:68` | S7636 | secrets 展開 | 🔧 改用 step-level `env:` |
+| 9 | `.github/workflows/nuget-publish.yml:84` | S7637 | 未 pin SHA | 🔧 Pin 全部第三方 actions 至 commit SHA |
+
+---
+
+## 實作步驟
+
+### Step 1 — 為 4 個 Regex 呼叫加上 `TimeSpan.FromSeconds(1)`
+
+- `src/Bee.Base/FileFunc.cs:170` — `Regex.IsMatch(input, pattern, RegexOptions.None, TimeSpan.FromSeconds(1))`
+- `src/Bee.Base/StrFunc.cs:160` — `Regex.Replace(..., oOptions, TimeSpan.FromSeconds(1))`
+- `src/Bee.Base/StrFunc.cs:515` — `Regex.IsMatch(source, regexPattern, options, TimeSpan.FromSeconds(1))`
+- `src/Bee.Db/DbCommandSpec.cs:24` — `new Regex(..., RegexOptions.Compiled, TimeSpan.FromSeconds(1))`
+
+4 個呼叫點散落兩個套件、數量不多，決定**就地寫 `TimeSpan.FromSeconds(1)` 不抽共用常數**（避免為 DRY 新增跨套件 API surface）。
+
+### Step 2 — 修 `.github/workflows/nuget-publish.yml:68`（secrets env 注入）
+
+```yaml
+- name: Push to NuGet
+  env:
+    NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+  run: |
+    $ErrorActionPreference = 'Stop'
+    Get-ChildItem -Path ./nupkgs -Filter *.nupkg | ForEach-Object {
+      dotnet nuget push $_.FullName --api-key "$env:NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+      if ($LASTEXITCODE -ne 0) { throw "Failed to push $($_.Name)" }
+    }
+```
+
+### Step 3 — Pin 所有第三方 actions 到 commit SHA
+
+共 6 處（兩個 workflow）：
+
+`nuget-publish.yml`：`actions/checkout@v4`、`actions/setup-dotnet@v4`、`softprops/action-gh-release@v2`
+`build-ci.yml`：`actions/checkout@v4`、`actions/setup-dotnet@v4`、`actions/setup-java@v4`、`actions/cache@v4`
+
+取 SHA：
+```bash
+gh api repos/actions/checkout/git/ref/tags/v4 --jq .object.sha
+gh api repos/actions/setup-dotnet/git/ref/tags/v4 --jq .object.sha
+gh api repos/actions/setup-java/git/ref/tags/v4 --jq .object.sha
+gh api repos/actions/cache/git/ref/tags/v4 --jq .object.sha
+gh api repos/softprops/action-gh-release/git/ref/tags/v2 --jq .object.sha
+```
+
+格式：`uses: <org>/<name>@<full-sha>  # <tag>`
+
+### Step 4 — 更新 `.claude/rules/sonarcloud.md`
+
+在「11. Reflection 與 Assembly」後新增章節：
+
+- **§13 Regex（ReDoS 防護）**：S6444 — 所有 Regex 呼叫傳入 `TimeSpan.FromSeconds(1)`
+- **§14 GitHub Actions 工作流**：S7636、S7637
+- **§15 序列化**：S5766 — marker `[Serializable]` 無 `ISerializable` 時可 Sonar UI 標 SAFE
+
+### Step 5 — 驗證
+
+```bash
+dotnet build --configuration Release
+dotnet test --configuration Release --settings .runsettings
+```
+
+### Step 6 — Commit、push、建立 PR
+
+分支：`claude/sonarcloud-hotspots`，建 PR 後 `subscribe_pr_activity` 訂閱。
+
+### Step 7 — PR 合併後（使用者操作）
+
+進 SonarCloud UI 把 2 個 `[Serializable]` hotspot 標 SAFE：
+
+- `ApiException.cs:29` — 理由：非反序列化建構子；`ApiException(Exception, bool)` 僅從既有 `Exception` 複製字串與布林，類別未實作 `ISerializable`、無 `(SerializationInfo, StreamingContext)` 建構子，不經 BinaryFormatter。
+- `SortField.cs:25` — 理由：非反序列化建構子；`SortField(string, SortDirection)` 建構子已驗證 `fieldName` 非空，類別僅透過 MessagePack 序列化（型別安全框架），未實作 `ISerializable`。
+
+---
+
+## 影響檔案
+
+**修改**：
+- `src/Bee.Base/FileFunc.cs`
+- `src/Bee.Base/StrFunc.cs`
+- `src/Bee.Db/DbCommandSpec.cs`
+- `.github/workflows/nuget-publish.yml`
+- `.github/workflows/build-ci.yml`
+- `.claude/rules/sonarcloud.md`
+
+**新增**：
+- `docs/plans/plan-sonarcloud-hotspots.md`（本檔）

--- a/src/Bee.Base/FileFunc.cs
+++ b/src/Bee.Base/FileFunc.cs
@@ -167,7 +167,7 @@ namespace Bee.Base
         {
             // Check whether it is a Windows path or UNC network path
             string pattern = @"^([a-zA-Z]:\\|\\\\)";
-            return Regex.IsMatch(input, pattern);
+            return Regex.IsMatch(input, pattern, RegexOptions.None, TimeSpan.FromSeconds(1));
         }
 
         /// <summary>

--- a/src/Bee.Base/StrFunc.cs
+++ b/src/Bee.Base/StrFunc.cs
@@ -157,7 +157,7 @@ namespace Bee.Base
             if (IsEmpty(s)) { return string.Empty; }
 
             oOptions = (ignoreCase) ? RegexOptions.IgnoreCase : RegexOptions.None;
-            return Regex.Replace(s, Regex.Escape(search), replacement, oOptions);
+            return Regex.Replace(s, Regex.Escape(search), replacement, oOptions, TimeSpan.FromSeconds(1));
         }
 
         /// <summary>
@@ -512,7 +512,7 @@ namespace Bee.Base
             if (compareOption.HasFlag(CompareOptions.IgnoreCase))
                 options |= RegexOptions.IgnoreCase;
 
-            return Regex.IsMatch(source, regexPattern, options);
+            return Regex.IsMatch(source, regexPattern, options, TimeSpan.FromSeconds(1));
         }
 
         /// <summary>

--- a/src/Bee.Db/DbCommandSpec.cs
+++ b/src/Bee.Db/DbCommandSpec.cs
@@ -21,7 +21,7 @@ namespace Bee.Db
         private int _commandTimeout = DefaultTimeout;
         // Pre-compiled placeholder regex: {key}; supports {{key}} as an escape (outputs {key})
         private static readonly Regex PlaceholderRegex =
-            new Regex(@"\{(?<key>[^\}]+)\}|\{\{(?<escaped>[^\}]+)\}\}", RegexOptions.Compiled);
+            new Regex(@"\{(?<key>[^\}]+)\}|\{\{(?<escaped>[^\}]+)\}\}", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         /// <summary>
         /// Initializes a new empty instance of <see cref="DbCommandSpec"/>.


### PR DESCRIPTION
## Summary

一次清理 SonarCloud 在 `jeff377_bee-library` 上揭露的 9 個 security hotspots：7 個改程式、2 個待合併後於 Sonar UI 標 SAFE。

### 改程式（本 PR 覆蓋）
- **Regex S6444（ReDoS）**：4 個呼叫點加 `TimeSpan.FromSeconds(1)`
  - `src/Bee.Base/FileFunc.cs:170`（`IsLocalPath`）
  - `src/Bee.Base/StrFunc.cs:160`（`Replace`）
  - `src/Bee.Base/StrFunc.cs:515`（`Like`，手動改通配符後含 `.*` 量詞，風險最高）
  - `src/Bee.Db/DbCommandSpec.cs:24`（`PlaceholderRegex`）
- **GitHub Actions S7636（secrets 展開）**：`nuget-publish.yml` push step 改為 step-level `env:` 注入
- **GitHub Actions S7637（未 pin SHA）**：兩個 workflow 共 6 處第三方 action 全部 pin 至 full commit SHA，tag 放行尾註解
  - `actions/checkout@34e11487…` (v4.3.1)
  - `actions/setup-dotnet@67a3573c…` (v4.3.1)
  - `actions/setup-java@c1e32368…` (v4.8.0)
  - `actions/cache@00578528…` (v4.3.0)
  - `softprops/action-gh-release@3bb12739…` (v2.6.2)

### 待合併後 Sonar UI 手動標 SAFE（使用者執行）
- `src/Bee.Base/ApiException.cs:29` — 非反序列化建構子（未實作 `ISerializable`，參數來自既有 `Exception`）
- `src/Bee.Definition/SortField.cs:25` — 非反序列化建構子（MessagePack 不走此建構子，且建構子已驗證 `fieldName` 非空）

### 規則文件
- `.claude/rules/sonarcloud.md` 新增 §13（S6444）、§14（S7636/S7637）、§15（S5766），未來撰寫新程式碼直接迴避

### 既已 SAFE，不動
- `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs:32` — S5693，`[RequestSizeLimit(10MB)]` 已生效

## Test plan

- [x] 本機 `dotnet build Bee.Library.slnx -c Release` 綠（0 警告 0 錯誤）
- [x] 本機 `dotnet test` — Regex 相關測試（`IsLocalPath`、`StrFunc`）16 個全過
- [x] 既有的 MacOS 平台相依失敗（`IsPathRooted` for Windows `C:\...`）非本 PR 造成，已比對 main 前後一致
- [ ] PR CI（`build-ci.yml`）通過
- [ ] 合併後 SonarCloud 下一輪掃描：hotspot 從 9 降到 2（2 個 Serializable 再於 UI 標 SAFE 歸零）

## 實作計畫

`docs/plans/plan-sonarcloud-hotspots.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)