### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-04-22 08:46

### DIFF
--- a/tests/Bee.Api.Client.UnitTests/ApiConnectValidatorTests.cs
+++ b/tests/Bee.Api.Client.UnitTests/ApiConnectValidatorTests.cs
@@ -118,5 +118,22 @@ namespace Bee.Api.Client.UnitTests
                     Directory.Delete(tempDir, recursive: true);
             }
         }
+
+        [Fact]
+        [DisplayName("ApiConnectValidator.Validate URL 格式但不支援 Remote 時應拋 InvalidOperationException")]
+        public void Validate_RemoteUrl_RemoteNotSupported_ThrowsInvalidOperationException()
+        {
+            var original = ApiClientContext.SupportedConnectTypes;
+            try
+            {
+                ApiClientContext.SupportedConnectTypes = SupportedConnectTypes.Local;
+                Assert.Throws<InvalidOperationException>(
+                    () => ApiConnectValidator.Validate("http://example.com/api"));
+            }
+            finally
+            {
+                ApiClientContext.SupportedConnectTypes = original;
+            }
+        }
     }
 }

--- a/tests/Bee.Api.Client.UnitTests/RemoteDefineAccessTests.cs
+++ b/tests/Bee.Api.Client.UnitTests/RemoteDefineAccessTests.cs
@@ -2,6 +2,11 @@ using System.ComponentModel;
 using Bee.Api.Client.Connectors;
 using Bee.Api.Client.DefineAccess;
 using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Tests.Shared;
 
 namespace Bee.Api.Client.UnitTests
 {
@@ -9,6 +14,7 @@ namespace Bee.Api.Client.UnitTests
     /// 針對 <see cref="RemoteDefineAccess"/> 參數防護與不支援型別的純邏輯測試。
     /// 以 local <see cref="SystemApiConnector"/> 建構，但測試案例僅涵蓋在呼叫實際遠端之前就應拋出的錯誤路徑。
     /// </summary>
+    [Collection("Initialize")]
     public class RemoteDefineAccessTests
     {
         private static readonly string[] s_singleKey = { "onlyOne" };
@@ -86,6 +92,132 @@ namespace Bee.Api.Client.UnitTests
             var connector = new SystemApiConnector(Guid.NewGuid());
             var access = new RemoteDefineAccess(connector);
             Assert.NotNull(access);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetSystemSettings 本機連線應回傳系統設定")]
+        public void GetSystemSettings_LocalConnector_ReturnsSettings()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var settings = access.GetSystemSettings();
+
+            Assert.NotNull(settings);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetDatabaseSettings 本機連線應回傳資料庫設定")]
+        public void GetDatabaseSettings_LocalConnector_ReturnsSettings()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var settings = access.GetDatabaseSettings();
+
+            Assert.NotNull(settings);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetDbSchemaSettings 本機連線應回傳資料庫綱要設定")]
+        public void GetDbSchemaSettings_LocalConnector_ReturnsSettings()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var settings = access.GetDbSchemaSettings();
+
+            Assert.NotNull(settings);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetFormSchema 本機連線應回傳表單結構定義")]
+        public void GetFormSchema_LocalConnector_ReturnsFormSchema()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var schema = access.GetFormSchema("Employee");
+
+            Assert.NotNull(schema);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetTableSchema 本機連線應回傳資料表結構定義")]
+        public void GetTableSchema_LocalConnector_ReturnsTableSchema()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var schema = access.GetTableSchema("common", "st_user");
+
+            Assert.NotNull(schema);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetDefine 重複呼叫應使用快取回傳相同物件")]
+        public void GetDefine_SystemSettings_SecondCall_ReturnsCachedObject()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var result1 = access.GetSystemSettings();
+            var result2 = access.GetSystemSettings();
+
+            Assert.NotNull(result1);
+            Assert.Same(result1, result2);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetDefine SystemSettings 使用 GetDefine 公開方法應回傳系統設定")]
+        public void GetDefine_SystemSettings_ViaPublicMethod_ReturnsSettings()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var result = access.GetDefine(DefineType.SystemSettings);
+
+            Assert.NotNull(result);
+            Assert.IsType<SystemSettings>(result);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetDefine DatabaseSettings 使用 GetDefine 公開方法應回傳資料庫設定")]
+        public void GetDefine_DatabaseSettings_ViaPublicMethod_ReturnsSettings()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var result = access.GetDefine(DefineType.DatabaseSettings);
+
+            Assert.NotNull(result);
+            Assert.IsType<DatabaseSettings>(result);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetDefine FormSchema 含有效 key 使用 GetDefine 公開方法應回傳表單定義")]
+        public void GetDefine_FormSchema_ViaPublicMethod_ReturnsFormSchema()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var result = access.GetDefine(DefineType.FormSchema, new[] { "Employee" });
+
+            Assert.NotNull(result);
+            Assert.IsType<FormSchema>(result);
+        }
+
+        [Fact]
+        [DisplayName("RemoteDefineAccess.GetDefine TableSchema 含有效 keys 使用 GetDefine 公開方法應回傳資料表定義")]
+        public void GetDefine_TableSchema_ViaPublicMethod_ReturnsTableSchema()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            var access = new RemoteDefineAccess(connector);
+
+            var result = access.GetDefine(DefineType.TableSchema, new[] { "common", "st_user" });
+
+            Assert.NotNull(result);
+            Assert.IsType<TableSchema>(result);
         }
     }
 }

--- a/tests/Bee.Api.Client.UnitTests/SystemApiConnectorTests.cs
+++ b/tests/Bee.Api.Client.UnitTests/SystemApiConnectorTests.cs
@@ -74,5 +74,22 @@ namespace Bee.Api.Client.UnitTests
             await Assert.ThrowsAsync<ArgumentException>(async () =>
                 await connector.ExecuteAsync<object>(action!, new object(), PayloadFormat.Plain));
         }
+
+        [DbFact]
+        [DisplayName("SystemApiConnector.PingAsync 本機連線應成功回應")]
+        public async Task PingAsync_LocalConnector_Succeeds()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            await connector.PingAsync();
+        }
+
+        [DbFact]
+        [DisplayName("SystemApiConnector.Ping 同步本機連線應成功回應")]
+        public void Ping_LocalConnector_Succeeds()
+        {
+            var connector = new SystemApiConnector(Guid.NewGuid());
+            connector.Ping();
+        }
+
     }
 }

--- a/tests/Bee.Db.UnitTests/DbAccessExtraTests.cs
+++ b/tests/Bee.Db.UnitTests/DbAccessExtraTests.cs
@@ -178,5 +178,20 @@ namespace Bee.Db.UnitTests
             Assert.Contains("DatabaseType", text);
             Assert.Contains("Provider", text);
         }
+
+        [Fact]
+        [DisplayName("UpdateDataTable DataTable 為 null 應擲 ArgumentException")]
+        public void UpdateDataTable_NullDataTable_ThrowsArgumentException()
+        {
+            using var conn = new SqlConnection();
+            var dbAccess = new DbAccess(conn);
+            var spec = new DataTableUpdateSpec
+            {
+                DataTable = null!,
+                InsertCommand = new DbCommandSpec(DbCommandKind.NonQuery, "INSERT INTO t VALUES ({0})", "x")
+            };
+
+            Assert.Throws<ArgumentException>(() => dbAccess.UpdateDataTable(spec));
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/DbAccessStringMethodTests.cs
+++ b/tests/Bee.Db.UnitTests/DbAccessStringMethodTests.cs
@@ -1,0 +1,133 @@
+using System.ComponentModel;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests
+{
+    [Collection("Initialize")]
+    public class DbAccessStringMethodTests
+    {
+        [DbFact]
+        [DisplayName("ExecuteNonQuery 字串多載應回傳影響列數")]
+        public void ExecuteNonQuery_ValidSql_ReturnsRowsAffected()
+        {
+            var dbAccess = new DbAccess("common");
+            int affected = dbAccess.ExecuteNonQuery(
+                "UPDATE st_user SET note={1} WHERE sys_id={0}", "001", "test-string-overload");
+            Assert.True(affected >= 0);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteScalar 字串多載應回傳純量值")]
+        public void ExecuteScalar_ValidSql_ReturnsScalarValue()
+        {
+            var dbAccess = new DbAccess("common");
+            object? value = dbAccess.ExecuteScalar(
+                "SELECT COUNT(*) FROM st_user WHERE sys_id={0}", "001");
+            Assert.NotNull(value);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteDataTable 字串多載應回傳 DataTable")]
+        public void ExecuteDataTable_ValidSql_ReturnsDataTable()
+        {
+            var dbAccess = new DbAccess("common");
+            var table = dbAccess.ExecuteDataTable(
+                "SELECT sys_id FROM st_user WHERE sys_id={0}", "001");
+            Assert.NotNull(table);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteNonQueryAsync 非同步字串多載應回傳影響列數")]
+        public async Task ExecuteNonQueryAsync_ValidSql_ReturnsRowsAffected()
+        {
+            var dbAccess = new DbAccess("common");
+            int affected = await dbAccess.ExecuteNonQueryAsync(
+                "UPDATE st_user SET note={1} WHERE sys_id={0}", "001", "test-async-overload");
+            Assert.True(affected >= 0);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteScalarAsync 非同步字串多載應回傳純量值")]
+        public async Task ExecuteScalarAsync_ValidSql_ReturnsScalarValue()
+        {
+            var dbAccess = new DbAccess("common");
+            object? value = await dbAccess.ExecuteScalarAsync(
+                "SELECT COUNT(*) FROM st_user WHERE sys_id={0}", "001");
+            Assert.NotNull(value);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteDataTableAsync 非同步字串多載應回傳 DataTable")]
+        public async Task ExecuteDataTableAsync_ValidSql_ReturnsDataTable()
+        {
+            var dbAccess = new DbAccess("common");
+            var table = await dbAccess.ExecuteDataTableAsync(
+                "SELECT sys_id FROM st_user WHERE sys_id={0}", "001");
+            Assert.NotNull(table);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteBatch 未啟用交易應成功執行批次命令")]
+        public void ExecuteBatch_WithoutTransaction_Succeeds()
+        {
+            var batch = new DbBatchSpec { UseTransaction = false };
+            batch.Commands.Add(new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT COUNT(*) FROM st_user WHERE sys_id={0}", "001"));
+
+            var dbAccess = new DbAccess("common");
+            var result = dbAccess.ExecuteBatch(batch);
+
+            Assert.NotNull(result);
+            Assert.Single(result.Results);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteBatchAsync 未啟用交易應成功執行非同步批次命令")]
+        public async Task ExecuteBatchAsync_WithoutTransaction_Succeeds()
+        {
+            var batch = new DbBatchSpec { UseTransaction = false };
+            batch.Commands.Add(new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT COUNT(*) FROM st_user WHERE sys_id={0}", "001"));
+
+            var dbAccess = new DbAccess("common");
+            var result = await dbAccess.ExecuteBatchAsync(batch);
+
+            Assert.NotNull(result);
+            Assert.Single(result.Results);
+        }
+
+        [DbFact]
+        [DisplayName("Execute 含 DbTransaction 多載應成功執行命令")]
+        public void Execute_WithTransaction_NonQuery_Succeeds()
+        {
+            var dbAccess = new DbAccess("common");
+            using var conn = DbFunc.CreateConnection("common");
+            conn.Open();
+            using var tran = conn.BeginTransaction();
+
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery,
+                "UPDATE st_user SET note={1} WHERE sys_id={0}", "001", "tx-overload");
+            var result = dbAccess.Execute(spec, tran);
+            tran.Rollback();
+
+            Assert.NotNull(result);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteAsync 含 DbTransaction 多載應成功執行非同步命令")]
+        public async Task ExecuteAsync_WithTransaction_NonQuery_Succeeds()
+        {
+            var dbAccess = new DbAccess("common");
+            using var conn = DbFunc.CreateConnection("common");
+            await conn.OpenAsync();
+            await using var tran = await conn.BeginTransactionAsync();
+
+            var spec = new DbCommandSpec(DbCommandKind.NonQuery,
+                "UPDATE st_user SET note={1} WHERE sys_id={0}", "001", "tx-async-overload");
+            var result = await dbAccess.ExecuteAsync(spec, tran);
+            await tran.RollbackAsync();
+
+            Assert.NotNull(result);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlTableSchemaProviderTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlTableSchemaProviderTests.cs
@@ -15,5 +15,22 @@ namespace Bee.Db.UnitTests
             var dbTable = helper.GetTableSchema("st_user");
             Assert.NotNull(dbTable);
         }
+
+        [DbFact]
+        [DisplayName("SqlTableSchemaProvider 取得不存在資料表應回傳 null")]
+        public void GetTableSchema_NonExistentTable_ReturnsNull()
+        {
+            var helper = new SqlTableSchemaProvider("common");
+            var dbTable = helper.GetTableSchema("bee_nonexistent_table_xyz_99999");
+            Assert.Null(dbTable);
+        }
+
+        [DbFact]
+        [DisplayName("SqlTableSchemaProvider DatabaseId 應等於建構子傳入的值")]
+        public void Constructor_DatabaseId_IsSet()
+        {
+            var helper = new SqlTableSchemaProvider("common");
+            Assert.Equal("common", helper.DatabaseId);
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Api.Client/Connectors/SystemApiConnector.cs` | 19.4% | 2 |
| `src/Bee.Db/DbAccess.cs` | 74.1% | 10 |
| `src/Bee.Api.Client/DefineAccess/RemoteDefineAccess.cs` | 18.5% | 10 |
| `src/Bee.Api.Client/ApiConnectValidator.cs` | 25.5% | 1 |
| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | 74.6% | 2 |