### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-04-23 08:30

### DIFF
--- a/tests/Bee.Business.UnitTests/CacheDataSourceProviderTests.cs
+++ b/tests/Bee.Business.UnitTests/CacheDataSourceProviderTests.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using Bee.Business.Provider;
+using Bee.Tests.Shared;
+
+namespace Bee.Business.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheDataSourceProvider"/> 覆蓋率補強測試。
+    /// </summary>
+    [Collection("Initialize")]
+    public class CacheDataSourceProviderTests
+    {
+        [DbFact]
+        [DisplayName("GetSessionUser 傳入不存在的 AccessToken 應回傳 null")]
+        public void GetSessionUser_UnknownToken_ReturnsNull()
+        {
+            var provider = new CacheDataSourceProvider();
+
+            var result = provider.GetSessionUser(Guid.NewGuid());
+
+            Assert.Null(result);
+        }
+    }
+}

--- a/tests/Bee.Business.UnitTests/SystemBusinessObjectCoverageTests.cs
+++ b/tests/Bee.Business.UnitTests/SystemBusinessObjectCoverageTests.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using Bee.Business.System;
+using Bee.Definition;
+
+namespace Bee.Business.UnitTests
+{
+    /// <summary>
+    /// <see cref="SystemBusinessObject"/> 覆蓋率補強測試：
+    /// 涵蓋 DoExecFunc 委派路徑與 SaveDefineCore 內部流程。
+    /// </summary>
+    [Collection("Initialize")]
+    public class SystemBusinessObjectCoverageTests
+    {
+        private static readonly string[] s_departmentKeys = { "Department" };
+
+        [Fact]
+        [DisplayName("ExecFunc 呼叫不存在的方法應拋 MissingMethodException（覆蓋 DoExecFunc 委派路徑）")]
+        public void ExecFunc_UnknownMethod_ThrowsMissingMethodException()
+        {
+            var bo = new SystemBusinessObject(Guid.Empty);
+            var args = new ExecFuncArgs("NoSuchMethodInHandler");
+
+            Assert.Throws<MissingMethodException>(() => bo.ExecFunc(args));
+        }
+
+        [Fact]
+        [DisplayName("SaveDefine 非敏感型別傳入空 XML 應拋 InvalidOperationException（SaveDefineCore null 路徑）")]
+        public void SaveDefine_NonSensitiveType_EmptyXml_ThrowsInvalidOperation()
+        {
+            // Empty xml → SerializeFunc.XmlToObject returns null → InvalidOperationException in SaveDefineCore
+            var bo = new SystemBusinessObject(Guid.Empty, isLocalCall: false);
+            var args = new SaveDefineArgs { DefineType = DefineType.FormSchema, Xml = string.Empty };
+
+            Assert.Throws<InvalidOperationException>(() => bo.SaveDefine(args));
+        }
+
+        [Fact]
+        [DisplayName("SaveDefine 本地呼叫傳入有效 XML 應成功完成存檔（SaveDefineCore 成功路徑）")]
+        public void SaveDefine_LocalCall_ValidXml_Succeeds()
+        {
+            var bo = new SystemBusinessObject(Guid.Empty, isLocalCall: true);
+
+            // Retrieve valid FormSchema XML via GetDefine
+            var getResult = bo.GetDefine(new GetDefineArgs
+            {
+                DefineType = DefineType.FormSchema,
+                Keys = s_departmentKeys
+            });
+
+            // Round-trip save: write back the same content
+            var result = bo.SaveDefine(new SaveDefineArgs
+            {
+                DefineType = DefineType.FormSchema,
+                Xml = getResult.Xml,
+                Keys = s_departmentKeys
+            });
+
+            Assert.NotNull(result);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/DatabaseRepositoryDbTests.cs
+++ b/tests/Bee.Repository.UnitTests/DatabaseRepositoryDbTests.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel;
+using Bee.Repository.Abstractions.System;
+using Bee.Repository.Provider;
+using Bee.Tests.Shared;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// <see cref="IDatabaseRepository"/> 需要資料庫的補強測試：
+    /// 涵蓋 <see cref="IDatabaseRepository.UpgradeTableSchema"/> 正常執行路徑。
+    /// </summary>
+    [Collection("Initialize")]
+    public class DatabaseRepositoryDbTests
+    {
+        private static IDatabaseRepository CreateRepository()
+            => new SystemRepositoryProvider().DatabaseRepository;
+
+        [DbFact]
+        [DisplayName("UpgradeTableSchema 傳入有效參數應正常執行並回傳布林結果")]
+        public void UpgradeTableSchema_ValidArgs_DoesNotThrow()
+        {
+            var repo = CreateRepository();
+
+            var ex = Record.Exception(() => repo.UpgradeTableSchema("common", "common", "st_user"));
+
+            Assert.Null(ex);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Business/System/SystemBusinessObject.cs` | 89.8% | 3 |
| `src/Bee.Business/Provider/CacheDataSourceProvider.cs` | 50.0% | 1 |
| `src/Bee.Repository/System/DatabaseRepository.cs` | 80.0% | 1 |

### 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 剩餘 6 行位於 `LoadFromFile` 的 IOException race-condition catch（concurrent CreateNew 失敗）與 `ReadAllTextShared` 的 retry 迴圈（transient IOException），需要模擬並行檔案鎖定才能觸發，無法在一般單元測試中覆蓋。 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面宣告，無可執行程式碼，SonarCloud 標記的 2 行為介面定義行，無法透過測試覆蓋。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01FG1VBGucDg6YbFZWo31Lr5)_