### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-04-23 16:30

### DIFF
--- a/tests/Bee.Business.UnitTests/SystemBusinessObjectExtraTests.cs
+++ b/tests/Bee.Business.UnitTests/SystemBusinessObjectExtraTests.cs
@@ -122,5 +122,19 @@ namespace Bee.Business.UnitTests
             Assert.True(result.Parameters.Contains("Hello"));
             Assert.Contains("Hello system-level", result.Parameters.GetValue<string>("Hello"));
         }
+
+        [Fact]
+        [DisplayName("ExecFunc 已驗證呼叫 Hello 方法應回傳問候語（覆蓋 DoExecFunc 路徑）")]
+        public void ExecFunc_Hello_AuthenticatedCall_ReturnsGreeting()
+        {
+            // Hello 標註 Anonymous，Authenticated 呼叫者可存取（權限足夠），因此覆蓋 DoExecFunc 路徑
+            var bo = new TestableSystemBusinessObject(Guid.Empty, _ => (false, string.Empty));
+            var args = new ExecFuncArgs("Hello");
+
+            var result = bo.ExecFunc(args);
+
+            Assert.True(result.Parameters.Contains("Hello"));
+            Assert.Contains("Hello system-level", result.Parameters.GetValue<string>("Hello"));
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/DbAccessIsolationLevelTests.cs
+++ b/tests/Bee.Db.UnitTests/DbAccessIsolationLevelTests.cs
@@ -1,0 +1,108 @@
+using System.ComponentModel;
+using System.Data;
+using System.Globalization;
+using Bee.Base;
+using Bee.Definition;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests
+{
+    [Collection("Initialize")]
+    public class DbAccessIsolationLevelTests
+    {
+        [DbFact]
+        [DisplayName("ExecuteBatch 以指定 IsolationLevel 執行批次交易應成功")]
+        public void ExecuteBatch_WithIsolationLevel_Succeeds()
+        {
+            var batch = new DbBatchSpec
+            {
+                UseTransaction = true,
+                IsolationLevel = IsolationLevel.ReadCommitted
+            };
+            batch.Commands.Add(new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT COUNT(*) FROM st_user WHERE sys_id = {0}", "001"));
+
+            var dbAccess = new DbAccess("common");
+            var result = dbAccess.ExecuteBatch(batch);
+
+            Assert.NotNull(result);
+            Assert.Single(result.Results);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteBatchAsync 以指定 IsolationLevel 非同步執行批次交易應成功")]
+        public async Task ExecuteBatchAsync_WithIsolationLevel_Succeeds()
+        {
+            var batch = new DbBatchSpec
+            {
+                UseTransaction = true,
+                IsolationLevel = IsolationLevel.ReadCommitted
+            };
+            batch.Commands.Add(new DbCommandSpec(DbCommandKind.Scalar,
+                "SELECT COUNT(*) FROM st_user WHERE sys_id = {0}", "001"));
+
+            var dbAccess = new DbAccess("common");
+            var result = await dbAccess.ExecuteBatchAsync(batch);
+
+            Assert.NotNull(result);
+            Assert.Single(result.Results);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteBatch 批次中含 DataTable 命令應成功回傳資料表")]
+        public void ExecuteBatch_DataTableCommand_Succeeds()
+        {
+            var batch = new DbBatchSpec { UseTransaction = false };
+            batch.Commands.Add(new DbCommandSpec(DbCommandKind.DataTable,
+                "SELECT sys_id FROM st_user WHERE sys_id = {0}", "001"));
+
+            var dbAccess = new DbAccess("common");
+            var result = dbAccess.ExecuteBatch(batch);
+
+            Assert.NotNull(result);
+            Assert.Single(result.Results);
+            Assert.NotNull(result.Results[0].Table);
+        }
+
+        [DbFact]
+        [DisplayName("ExecuteBatchAsync 批次中含 DataTable 命令非同步應成功回傳資料表")]
+        public async Task ExecuteBatchAsync_DataTableCommand_Succeeds()
+        {
+            var batch = new DbBatchSpec { UseTransaction = false };
+            batch.Commands.Add(new DbCommandSpec(DbCommandKind.DataTable,
+                "SELECT sys_id FROM st_user WHERE sys_id = {0}", "001"));
+
+            var dbAccess = new DbAccess("common");
+            var result = await dbAccess.ExecuteBatchAsync(batch);
+
+            Assert.NotNull(result);
+            Assert.Single(result.Results);
+            Assert.NotNull(result.Results[0].Table);
+        }
+
+        [DbFact]
+        [DisplayName("UpdateDataTable 以指定 IsolationLevel 執行更新應成功")]
+        public void UpdateDataTable_WithIsolationLevel_Succeeds()
+        {
+            var dbAccess = new DbAccess("common");
+
+            var cmd = new DbCommandSpec(DbCommandKind.DataTable,
+                "SELECT * FROM st_user WHERE sys_id = {0}", "001");
+            var table = dbAccess.Execute(cmd).Table;
+            Assert.NotNull(table);
+            Assert.True(table.Rows.Count > 0, "st_user 中無 sys_id='001' 的資料");
+
+            int rnd = BaseFunc.RndInt(0, 100);
+            table.Rows[0]["note"] = rnd.ToString(CultureInfo.InvariantCulture);
+
+            var tableSchema = BackendInfo.DefineAccess.GetTableSchema("common", "st_user");
+            var builder = new TableSchemaCommandBuilder(tableSchema);
+            var updateSpec = builder.BuildUpdateSpec(table);
+            updateSpec.UseTransaction = true;
+            updateSpec.IsolationLevel = IsolationLevel.ReadCommitted;
+
+            int affected = dbAccess.UpdateDataTable(updateSpec);
+            Assert.True(affected > 0);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/DbAccess.cs` | 85.6% | 5 |
| `src/Bee.Business/System/SystemBusinessObject.cs` | 89.8% | 1 |

## 新增測試說明

### Bee.Db — `DbAccessIsolationLevelTests.cs`（新增）
- `ExecuteBatch_WithIsolationLevel_Succeeds` — `[DbFact]` 覆蓋 `ExecuteBatch` 的 `IsolationLevel` 分支
- `ExecuteBatchAsync_WithIsolationLevel_Succeeds` — `[DbFact]` 覆蓋 `ExecuteBatchAsync` 的 `IsolationLevel` 分支
- `ExecuteBatch_DataTableCommand_Succeeds` — `[DbFact]` 覆蓋 `ExecuteBatch` 中 `DataTable` 命令分支
- `ExecuteBatchAsync_DataTableCommand_Succeeds` — `[DbFact]` 覆蓋 `ExecuteBatchAsync` 中 `DataTable` 命令分支
- `UpdateDataTable_WithIsolationLevel_Succeeds` — `[DbFact]` 覆蓋 `BeginTransactionIfRequested` 的 `IsolationLevel` 分支

### Bee.Business — `SystemBusinessObjectExtraTests.cs`（修改）
- `ExecFunc_Hello_AuthenticatedCall_ReturnsGreeting` — `[Fact]` 覆蓋 `SystemBusinessObject.DoExecFunc` 已驗證路徑，同時間接覆蓋 `SystemExecFuncHandler` 建構函式

## 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | 34 個未覆蓋行均在私有 DB 方法（`ParseIndexes` 迴圈主體、`ParseDbField` 的 AutoIncrement/Decimal 分支），需要具備特定 schema（含非 PK 索引、Identity 欄位、Decimal 欄位）的 DB 資料表，無法在不知道確切測試 DB schema 的情況下補強 |
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | 7 個未覆蓋行為 `HandleRequestAsync` 的 `catch` 區塊與 `IsDevelopment` 屬性，僅在 `JsonRpcExecutor.ExecuteAsync` 拋出未捕獲例外時才可到達；`ExecuteAsyncCore` 已內建全面的例外處理，正常運作下 catch 區塊實際上是死碼 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01WaDtAAwD5nUKkSH9rxxXc4)_