### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-04-24 00:30

### DIFF
--- a/tests/Bee.Business.UnitTests/SystemBusinessObjectDefineTests.cs
+++ b/tests/Bee.Business.UnitTests/SystemBusinessObjectDefineTests.cs
@@ -45,5 +45,22 @@ namespace Bee.Business.UnitTests
 
             Assert.False(string.IsNullOrWhiteSpace(result.Xml));
         }
+
+        [Fact]
+        [DisplayName("SaveDefine 本地呼叫 DbSchemaSettings 應成功執行 SaveDefineCore 路徑")]
+        public void SaveDefine_LocalCallDbSchemaSettings_Succeeds()
+        {
+            var bo = new SystemBusinessObject(Guid.Empty, isLocalCall: true);
+            var getResult = bo.GetDefine(new GetDefineArgs { DefineType = DefineType.DbSchemaSettings });
+            Assert.False(string.IsNullOrWhiteSpace(getResult.Xml));
+
+            var saveResult = bo.SaveDefine(new SaveDefineArgs
+            {
+                DefineType = DefineType.DbSchemaSettings,
+                Xml = getResult.Xml
+            });
+
+            Assert.NotNull(saveResult);
+        }
     }
 }

--- a/tests/Bee.Business.UnitTests/SystemBusinessObjectExtraTests.cs
+++ b/tests/Bee.Business.UnitTests/SystemBusinessObjectExtraTests.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using Bee.Business.System;
 using Bee.Business.UnitTests.Fakes;
 using Bee.Definition;
+using Bee.Tests.Shared;
 
 namespace Bee.Business.UnitTests
 {
@@ -135,6 +136,35 @@ namespace Bee.Business.UnitTests
 
             Assert.True(result.Parameters.Contains("Hello"));
             Assert.Contains("Hello system-level", result.Parameters.GetValue<string>("Hello"));
+        }
+
+        [DbFact]
+        [DisplayName("ExecFunc UpgradeTableSchema 應執行並在結果中包含 Upgraded 狀態")]
+        public void ExecFunc_UpgradeTableSchema_ReturnsUpgradedStatus()
+        {
+            var bo = new TestableSystemBusinessObject(Guid.Empty, _ => (false, string.Empty));
+            var args = new ExecFuncArgs("UpgradeTableSchema");
+            args.Parameters.Add("DatabaseId", "common");
+            args.Parameters.Add("DbName", "common");
+            args.Parameters.Add("TableName", "st_user");
+
+            var result = bo.ExecFunc(args);
+
+            Assert.True(result.Parameters.Contains("Upgraded"));
+        }
+
+        [DbFact]
+        [DisplayName("ExecFunc TestConnection 以有效資料庫設定應不拋出例外")]
+        public void ExecFunc_TestConnection_ValidDatabaseItem_Succeeds()
+        {
+            var bo = new TestableSystemBusinessObject(Guid.Empty, _ => (false, string.Empty));
+            var args = new ExecFuncArgs("TestConnection");
+            var dbItem = BackendInfo.DefineAccess.GetDatabaseSettings().Items!["common"];
+            args.Parameters.Add("DatabaseItem", dbItem);
+
+            var exception = Record.Exception(() => bo.ExecFunc(args));
+
+            Assert.Null(exception);
         }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| src/Bee.Business/System/SystemBusinessObject.cs | 89.8% | 1 |
| src/Bee.Business/System/SystemExecFuncHandler.cs | 35.3% | 2 |

### 補強說明

**SystemBusinessObject.cs**
- 新增 `SaveDefine_LocalCallDbSchemaSettings_Succeeds`：覆蓋 `SaveDefineCore` 私有方法的成功路徑（讀取 DbSchemaSettings XML → 反序列化 → 透過 DefineAccess 儲存），補強原本完全未執行的 `return SaveDefineCore(args)` 分支。

**SystemExecFuncHandler.cs**
- 新增 `ExecFunc_UpgradeTableSchema_ReturnsUpgradedStatus` (`[DbFact]`)：透過 `SystemBusinessObject.ExecFunc` 呼叫 `UpgradeTableSchema`，驗證對既有 `st_user` 資料表的 schema 升級結果回傳。
- 新增 `ExecFunc_TestConnection_ValidDatabaseItem_Succeeds` (`[DbFact]`)：以 "common" 資料庫設定呼叫 `TestConnection`，驗證連線測試不拋出例外。

### 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs | 未覆蓋的 34 行均在私有方法（ParsePrimaryKey/ParseIndexes/ParseDbField），需特定 DB schema 組合才能觸發，無法透過現有測試基礎設施補強 |
| src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs | 7 行未覆蓋集中於 HandleRequestAsync catch 區塊；JsonRpcExecutor.ExecuteAsyncCore 已有自己的 try-catch，該 catch 在正常執行流程中無法觸達 |
| src/Bee.Definition/Security/MasterKeyProvider.cs | 6 行未覆蓋為 ReadAllTextShared 的 IOException 重試迴圈與 CreateNew 競爭條件，需複雜多執行緒協調才能觸發 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBH27kB5jXaxtmZkGz71Uc)_