### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-04-24 08:55

### DIFF
--- a/tests/Bee.Business.UnitTests/SystemBusinessObjectDefineTests.cs
+++ b/tests/Bee.Business.UnitTests/SystemBusinessObjectDefineTests.cs
@@ -45,5 +45,17 @@ namespace Bee.Business.UnitTests
 
             Assert.False(string.IsNullOrWhiteSpace(result.Xml));
         }
+
+        [Fact]
+        [DisplayName("SaveDefine 本地呼叫 SystemSettings 應成功執行並回傳結果")]
+        public void SaveDefine_LocalCall_SystemSettings_ReturnsResult()
+        {
+            var bo = new SystemBusinessObject(Guid.Empty, isLocalCall: true);
+            var xml = bo.GetDefine(new GetDefineArgs { DefineType = DefineType.SystemSettings }).Xml;
+
+            var result = bo.SaveDefine(new SaveDefineArgs { DefineType = DefineType.SystemSettings, Xml = xml });
+
+            Assert.NotNull(result);
+        }
     }
 }

--- a/tests/Bee.Business.UnitTests/SystemBusinessObjectExtraTests.cs
+++ b/tests/Bee.Business.UnitTests/SystemBusinessObjectExtraTests.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using Bee.Business.System;
 using Bee.Business.UnitTests.Fakes;
 using Bee.Definition;
+using Bee.Tests.Shared;
 
 namespace Bee.Business.UnitTests
 {
@@ -135,6 +136,37 @@ namespace Bee.Business.UnitTests
 
             Assert.True(result.Parameters.Contains("Hello"));
             Assert.Contains("Hello system-level", result.Parameters.GetValue<string>("Hello"));
+        }
+
+        [DbFact]
+        [DisplayName("ExecFunc(TestConnection) 傳入有效資料庫設定應不拋出例外")]
+        public void ExecFunc_TestConnection_ValidDatabaseItem_Succeeds()
+        {
+            var dbSettings = BackendInfo.DefineAccess.GetDatabaseSettings();
+            var dbItem = dbSettings.Items?.FirstOrDefault(x => x.Id == "common");
+            Assert.NotNull(dbItem);
+
+            var bo = new TestableSystemBusinessObject(Guid.Empty, _ => (false, string.Empty));
+            var args = new ExecFuncArgs("TestConnection");
+            args.Parameters.Add("DatabaseItem", dbItem);
+
+            var exception = Record.Exception(() => bo.ExecFunc(args));
+            Assert.Null(exception);
+        }
+
+        [DbFact]
+        [DisplayName("ExecFunc(UpgradeTableSchema) 傳入已知資料表應回傳含 Upgraded 的結果")]
+        public void ExecFunc_UpgradeTableSchema_ExistingTable_HasUpgradedResult()
+        {
+            var bo = new TestableSystemBusinessObject(Guid.Empty, _ => (false, string.Empty));
+            var args = new ExecFuncArgs("UpgradeTableSchema");
+            args.Parameters.Add("DatabaseId", "common");
+            args.Parameters.Add("DbName", "common");
+            args.Parameters.Add("TableName", "st_user");
+
+            var result = bo.ExecFunc(args);
+
+            Assert.True(result.Parameters.Contains("Upgraded"));
         }
     }
 }

--- a/tests/Bee.Db.UnitTests/SqlTableSchemaProviderTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlTableSchemaProviderTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Bee.Base.Data;
 using Bee.Db.Providers.SqlServer;
 using Bee.Tests.Shared;
 
@@ -31,6 +32,50 @@ namespace Bee.Db.UnitTests
         {
             var helper = new SqlTableSchemaProvider("common");
             Assert.Equal("common", helper.DatabaseId);
+        }
+
+        [DbFact]
+        [DisplayName("GetTableSchema st_user 應包含主索引與非主索引（涵蓋 ParsePrimaryKey / ParseIndexes）")]
+        public void GetTableSchema_StUser_HasPrimaryKeyAndNonPrimaryIndexes()
+        {
+            var provider = new SqlTableSchemaProvider("common");
+
+            var schema = provider.GetTableSchema("st_user");
+
+            Assert.NotNull(schema);
+            Assert.NotNull(schema!.Indexes);
+            Assert.True(schema.Indexes!.Count >= 3);
+            Assert.True(schema.Indexes.Any(x => x.PrimaryKey));
+            Assert.True(schema.Indexes.Any(x => !x.PrimaryKey));
+        }
+
+        [DbFact]
+        [DisplayName("GetTableSchema st_user String 欄位 sys_id 長度應為 20（NVARCHAR 長度除以 2）")]
+        public void GetTableSchema_StUser_StringFieldHasCorrectLength()
+        {
+            var provider = new SqlTableSchemaProvider("common");
+
+            var schema = provider.GetTableSchema("st_user");
+
+            Assert.NotNull(schema);
+            var sysIdField = schema!.Fields!.FirstOrDefault(x => x.FieldName == "sys_id");
+            Assert.NotNull(sysIdField);
+            Assert.Equal(FieldDbType.String, sysIdField!.DbType);
+            Assert.Equal(20, sysIdField.Length);
+        }
+
+        [DbFact]
+        [DisplayName("GetTableSchema st_user AutoIncrement 欄位 sys_no 型別應為 AutoIncrement")]
+        public void GetTableSchema_StUser_AutoIncrementFieldIsRecognized()
+        {
+            var provider = new SqlTableSchemaProvider("common");
+
+            var schema = provider.GetTableSchema("st_user");
+
+            Assert.NotNull(schema);
+            var sysNoField = schema!.Fields!.FirstOrDefault(x => x.FieldName == "sys_no");
+            Assert.NotNull(sysNoField);
+            Assert.Equal(FieldDbType.AutoIncrement, sysNoField!.DbType);
         }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs | 75.4% | 3 |
| src/Bee.Business/System/SystemExecFuncHandler.cs | 35.3% | 2 |
| src/Bee.Business/System/SystemBusinessObject.cs | 89.8% | 1 |

### 補強說明

**SqlTableSchemaProvider** (34 uncovered lines — DB dependent)
- 新增 `GetTableSchema_StUser_HasPrimaryKeyAndNonPrimaryIndexes`：涵蓋 `ParsePrimaryKey` 及 `ParseIndexes` 私有靜態方法
- 新增 `GetTableSchema_StUser_StringFieldHasCorrectLength`：涵蓋 `ParseDbField` 中 NVARCHAR 長度除以 2 的分支
- 新增 `GetTableSchema_StUser_AutoIncrementFieldIsRecognized`：涵蓋 `ParseDbField` AutoIncrement 型別識別分支

**SystemExecFuncHandler** (11 uncovered lines — DB dependent, internal class tested via ExecFunc)
- 新增 `ExecFunc_TestConnection_ValidDatabaseItem_Succeeds`：透過 SystemBusinessObject 呼叫 TestConnection
- 新增 `ExecFunc_UpgradeTableSchema_ExistingTable_HasUpgradedResult`：透過 SystemBusinessObject 呼叫 UpgradeTableSchema

**SystemBusinessObject** (9 uncovered lines)
- 新增 `SaveDefine_LocalCall_SystemSettings_ReturnsResult`：涵蓋 `SaveDefineCore` 本地呼叫成功路徑（lines 201–210, 224）

### 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs | `HandleRequestAsync` catch block（lines 146–152）需要 `JsonRpcExecutor.ExecuteAsync` 拋出例外，但 executor 內部已完整捕捉所有例外並回傳 error response，無法在外部觸發 |
| src/Bee.Definition/Security/MasterKeyProvider.cs | `ReadAllTextShared` 重試路徑及 `catch (IOException)` race condition 路徑需模擬並發檔案存取，難以在單元測試中觸發 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjrSRc5Bpw5AJH5rMpbCrM)_