### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-04-24 16:46

### DIFF
--- a/tests/Bee.Business.UnitTests/CacheDataSourceProviderTests.cs
+++ b/tests/Bee.Business.UnitTests/CacheDataSourceProviderTests.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using Bee.Business.Provider;
+using Bee.Tests.Shared;
+
+namespace Bee.Business.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheDataSourceProvider"/> 測試。
+    /// </summary>
+    [Collection("Initialize")]
+    public class CacheDataSourceProviderTests
+    {
+        [DbFact]
+        [DisplayName("GetSessionUser 傳入不存在的 Token 應回傳 null")]
+        public void GetSessionUser_UnknownToken_ReturnsNull()
+        {
+            var provider = new CacheDataSourceProvider();
+
+            var result = provider.GetSessionUser(Guid.NewGuid());
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("CacheDataSourceProvider 建構子應正常初始化")]
+        public void Constructor_Default_CreatesInstance()
+        {
+            var exception = Record.Exception(() => new CacheDataSourceProvider());
+
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Business/Provider/CacheDataSourceProvider.cs` | 50.0% | 2 |

## 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | 34 個未覆蓋行全在 private DB 相依方法（ParsePrimaryKey、ParseIndexes、ParseDbField）中；static 公開方法已有完整測試。 |
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | 7 個未覆蓋行在 HandleRequestAsync 的 catch block 及 IsDevelopment 屬性，屬於死碼—JsonRpcExecutor.ExecuteAsync 內部 catch 所有例外並以回應回傳，永遠不會向上拋出。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 個未覆蓋行在 LoadFromFile 的 IOException catch block 及 ReadAllTextShared 的重試迴圈，屬競爭條件路徑，無法在單元測試中可靠重現。 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面檔案，無可執行程式碼；0% 覆蓋率為 SonarCloud 計數工具的統計工件。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7VNeiTHYud9n59DjGMyfR)_