### PR TITLE
[AutoFix] SonarCloud Issues (5 issues) 2026-04-25 08:00

### DIFF
--- a/src/Bee.Db/Providers/SqlServer/SqlTableAlterCommandBuilder.cs
+++ b/src/Bee.Db/Providers/SqlServer/SqlTableAlterCommandBuilder.cs
@@ -77,7 +77,7 @@ namespace Bee.Db.Providers.SqlServer
             return $"EXEC sp_rename N'{sourceLiteral}', N'{targetLiteral}', N'COLUMN';";
         }
 
-        private static IReadOnlyList<string> BuildAlterFieldStatements(string tableName, DbField oldField, DbField newField)
+        private static List<string> BuildAlterFieldStatements(string tableName, DbField oldField, DbField newField)
         {
             var statements = new List<string>();
             bool columnSpecChanged = HasColumnSpecChanged(oldField, newField);

--- a/src/Bee.Db/Providers/SqlServer/SqlTableRebuildCommandBuilder.cs
+++ b/src/Bee.Db/Providers/SqlServer/SqlTableRebuildCommandBuilder.cs
@@ -109,10 +109,10 @@ namespace Bee.Db.Providers.SqlServer
         {
             var sb = new StringBuilder();
             // Rename indexes (including PK) so they follow the table.
-            foreach (var index in schema.Indexes!)
+            foreach (var indexName in schema.Indexes!.Select(index => index.Name))
             {
-                string oldIndexName = StrFunc.Format(index.Name, oldTable);
-                string newIndexName = StrFunc.Format(index.Name, newTable);
+                string oldIndexName = StrFunc.Format(indexName, oldTable);
+                string newIndexName = StrFunc.Format(indexName, newTable);
                 string oldQualified = SqlSchemaHelper.EscapeSqlString($"dbo.{oldTable}.{oldIndexName}");
                 string escapedNew = SqlSchemaHelper.EscapeSqlString(newIndexName);
                 sb.Append(CultureInfo.InvariantCulture, $"EXEC sp_rename N'{oldQualified}', N'{escapedNew}', N'INDEX';\n");

--- a/src/Bee.Db/Providers/SqlServer/SqlTableRebuildCommandBuilder.cs
+++ b/src/Bee.Db/Providers/SqlServer/SqlTableRebuildCommandBuilder.cs
@@ -68,11 +68,8 @@ namespace Bee.Db.Providers.SqlServer
             var cloned = diff.DefineTable.Clone();
             if (diff.RealTable != null)
             {
-                foreach (var realField in diff.RealTable.Fields!)
-                {
-                    if (!cloned.Fields!.Contains(realField.FieldName))
-                        cloned.Fields!.Add(realField.Clone());
-                }
+                foreach (var realField in diff.RealTable.Fields!.Where(f => !cloned.Fields!.Contains(f.FieldName)))
+                    cloned.Fields!.Add(realField.Clone());
             }
             return cloned;
         }

--- a/src/Bee.Db/Schema/TableUpgradeOrchestrator.cs
+++ b/src/Bee.Db/Schema/TableUpgradeOrchestrator.cs
@@ -49,7 +49,7 @@ namespace Bee.Db.Schema
         /// <param name="options">Upgrade options; null uses <see cref="UpgradeOptions.Default"/>.</param>
         public UpgradePlan Plan(TableSchemaDiff diff, UpgradeOptions? options = null)
         {
-            if (diff == null) throw new ArgumentNullException(nameof(diff));
+            ArgumentNullException.ThrowIfNull(diff);
             options ??= UpgradeOptions.Default;
 
             if (diff.IsNewTable)
@@ -87,7 +87,7 @@ namespace Bee.Db.Schema
         /// <param name="databaseId">The database identifier to open connections for.</param>
         public static bool Execute(UpgradePlan plan, string databaseId)
         {
-            if (plan == null) throw new ArgumentNullException(nameof(plan));
+            ArgumentNullException.ThrowIfNull(plan);
             BaseFunc.EnsureNotNullOrWhiteSpace((databaseId, nameof(databaseId)));
 
             if (plan.IsEmpty) return false;


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ3AXeZIpz1wVSI8ht6n | csharpsquid:S3267 | `src/Bee.Db/Providers/SqlServer/SqlTableRebuildCommandBuilder.cs` | 將含 `if` 的 `foreach` 改用 `.Where()` LINQ 方法簡化 |
| AZ3Ae9_wvr48Boa4b5xh | csharpsquid:S3267 | `src/Bee.Db/Providers/SqlServer/SqlTableRebuildCommandBuilder.cs` | 將 `foreach (var index in schema.Indexes!)` 改用 `.Select(index => index.Name)` 簡化 |
| AZ3AXebKpz1wVSI8ht6o | external_roslyn:CA1510 | `src/Bee.Db/Schema/TableUpgradeOrchestrator.cs` | 以 `ArgumentNullException.ThrowIfNull(diff)` 取代手動 null 檢查 |
| AZ3AXebKpz1wVSI8ht6p | external_roslyn:CA1510 | `src/Bee.Db/Schema/TableUpgradeOrchestrator.cs` | 以 `ArgumentNullException.ThrowIfNull(plan)` 取代手動 null 檢查 |
| AZ3AN2fvEjNYTa-xxcwx | external_roslyn:CA1859 | `src/Bee.Db/Providers/SqlServer/SqlTableAlterCommandBuilder.cs` | 將 `BuildAlterFieldStatements` 回傳型別由 `IReadOnlyList<string>` 改為 `List<string>` 以提升效能 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqyJbBbmVJdW5zQ1CdLzmF)_