### PR TITLE
[AutoFix] SonarCloud Issues (6 issues) 2026-04-28 00:00

### DIFF
--- a/src/Bee.Db/Dml/InsertCommandBuilder.cs
+++ b/src/Bee.Db/Dml/InsertCommandBuilder.cs
@@ -37,8 +37,7 @@ namespace Bee.Db.Dml
         {
             if (string.IsNullOrWhiteSpace(tableName))
                 throw new ArgumentException("tableName cannot be null or whitespace.", nameof(tableName));
-            if (row == null)
-                throw new ArgumentNullException(nameof(row));
+            ArgumentNullException.ThrowIfNull(row);
 
             if (!_formSchema.Tables!.Contains(tableName))
                 throw new InvalidOperationException($"Cannot find the specified table: {tableName}");

--- a/src/Bee.Db/Dml/UpdateCommandBuilder.cs
+++ b/src/Bee.Db/Dml/UpdateCommandBuilder.cs
@@ -38,8 +38,7 @@ namespace Bee.Db.Dml
         {
             if (string.IsNullOrWhiteSpace(tableName))
                 throw new ArgumentException("tableName cannot be null or whitespace.", nameof(tableName));
-            if (row == null)
-                throw new ArgumentNullException(nameof(row));
+            ArgumentNullException.ThrowIfNull(row);
             if (row.RowState != DataRowState.Modified)
                 throw new InvalidOperationException(
                     $"BuildUpdate requires a row in Modified state; received {row.RowState}.");

--- a/src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs
+++ b/src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs
@@ -263,13 +263,13 @@ namespace Bee.Db.Providers.Sqlite
             var parts = facets.Split(',');
             if (parts.Length == 1)
             {
-                int.TryParse(parts[0].Trim(), out length);
-                int.TryParse(parts[0].Trim(), out precision);
+                _ = int.TryParse(parts[0].Trim(), out length);
+                _ = int.TryParse(parts[0].Trim(), out precision);
             }
             else if (parts.Length >= 2)
             {
-                int.TryParse(parts[0].Trim(), out precision);
-                int.TryParse(parts[1].Trim(), out scale);
+                _ = int.TryParse(parts[0].Trim(), out precision);
+                _ = int.TryParse(parts[1].Trim(), out scale);
             }
         }
 

--- a/src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs
+++ b/src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs
@@ -342,11 +342,9 @@ namespace Bee.Db.Providers.Sqlite
                 trimmed = trimmed.Substring(1, trimmed.Length - 2).Trim();
 
             // For string types, strip the surrounding single quotes and unescape doubled quotes.
-            if (dbType == FieldDbType.String || dbType == FieldDbType.Text)
-            {
-                if (trimmed.Length >= 2 && trimmed.StartsWith('\'') && trimmed.EndsWith('\''))
-                    trimmed = trimmed.Substring(1, trimmed.Length - 2).Replace("''", "'");
-            }
+            if ((dbType == FieldDbType.String || dbType == FieldDbType.Text) &&
+                trimmed.Length >= 2 && trimmed.StartsWith('\'') && trimmed.EndsWith('\''))
+                trimmed = trimmed.Substring(1, trimmed.Length - 2).Replace("''", "'");
 
             return StrFunc.IsEquals(originalDefault, trimmed) ? string.Empty : trimmed;
         }


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ3POm2gdxXKMPxsJeL_ | CA1806 | src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs | `_ = int.TryParse(...)` で戻り値を明示破棄（line 266） |
| AZ3POm2gdxXKMPxsJeMA | CA1806 | src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs | `_ = int.TryParse(...)` で戻り値を明示破棄（line 267） |
| AZ3POm2gdxXKMPxsJeMB | CA1806 | src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs | `_ = int.TryParse(...)` で戻り値を明示破棄（line 271） |
| AZ3POm2gdxXKMPxsJeMC | CA1806 | src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs | `_ = int.TryParse(...)` で戻り値を明示破棄（line 272） |
| AZ3POm2gdxXKMPxsJeL- | S1066 | src/Bee.Db/Providers/Sqlite/SqliteTableSchemaProvider.cs | ネストされた if を `&&` でマージ（line 345–348） |
| AZ3O-MXMVdAY-VS4XkDs | CA1510 | src/Bee.Db/Dml/UpdateCommandBuilder.cs | `ArgumentNullException.ThrowIfNull(row)` に置き換え |
| AZ3O-MaTVdAY-VS4XkDt | CA1510 | src/Bee.Db/Dml/InsertCommandBuilder.cs | `ArgumentNullException.ThrowIfNull(row)` に置き換え |

---
_Generated by [Claude Code](https://claude.ai/code/session_017hxTqoLp7rPhwNCBQpHWc7)_