### PR TITLE
[AutoFix] SonarCloud Issues (4 issues) 2026-05-02 00:00

### DIFF
--- a/src/Bee.Api.Core/JsonRpc/ApiPayload.cs
+++ b/src/Bee.Api.Core/JsonRpc/ApiPayload.cs
@@ -28,7 +28,7 @@ namespace Bee.Api.Core.JsonRpc
             SerializeState = serializeState;
             if (Value is IObjectSerialize objectSerialize)
             {
-                objectSerialize?.SetSerializeState(serializeState);
+                objectSerialize.SetSerializeState(serializeState);
             }
         }
 

--- a/src/Bee.Api.Core/JsonRpc/JsonRpcResponse.cs
+++ b/src/Bee.Api.Core/JsonRpc/JsonRpcResponse.cs
@@ -43,7 +43,7 @@ namespace Bee.Api.Core.JsonRpc
         public virtual void SetSerializeState(SerializeState serializeState)
         {
             SerializeState = serializeState;
-            if (Result != null) Result?.SetSerializeState(serializeState);
+            if (Result != null) Result.SetSerializeState(serializeState);
         }
 
         #endregion

--- a/src/Bee.Api.Core/Messages/ApiMessageBase.cs
+++ b/src/Bee.Api.Core/Messages/ApiMessageBase.cs
@@ -28,7 +28,7 @@ namespace Bee.Api.Core.Messages
         public virtual void SetSerializeState(SerializeState serializeState)
         {
             SerializeState = serializeState;
-            if (_parameters != null) _parameters?.SetSerializeState(serializeState);
+            if (_parameters != null) _parameters.SetSerializeState(serializeState);
         }
 
         #endregion

--- a/src/Bee.Base/StringUtilities.cs
+++ b/src/Bee.Base/StringUtilities.cs
@@ -98,9 +98,9 @@ namespace Bee.Base
         public static bool Contains(string? s, string value, bool ignoreCase = true)
         {
             if (s is null) return false;
-            return s.IndexOf(value, ignoreCase
+            return s.Contains(value, ignoreCase
                 ? StringComparison.CurrentCultureIgnoreCase
-                : StringComparison.CurrentCulture) >= 0;
+                : StringComparison.CurrentCulture);
         }
 
         /// <summary>


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ3kPRM07SRIkvbA0-h0 | csharpsquid:S2589 | src/Bee.Api.Core/Messages/ApiMessageBase.cs | 移除 `_parameters?.SetSerializeState` 的多餘 null 條件運算子；`if (_parameters != null)` 已確認非 null |
| AZ3kPRNG7SRIkvbA0-h1 | csharpsquid:S2589 | src/Bee.Api.Core/JsonRpc/JsonRpcResponse.cs | 移除 `Result?.SetSerializeState` 的多餘 null 條件運算子；`if (Result != null)` 已確認非 null |
| AZ3kPRNV7SRIkvbA0-h2 | csharpsquid:S2589 | src/Bee.Api.Core/JsonRpc/ApiPayload.cs | 移除 `objectSerialize?.SetSerializeState` 的多餘 null 條件運算子；pattern matching 已保證非 null |
| AZ3kPRHd7SRIkvbA0-hz | external_roslyn:CA2249 | src/Bee.Base/StringUtilities.cs | 以 `string.Contains(value, comparison)` 取代 `string.IndexOf(...) >= 0`，語意更清晰 |

https://claude.ai/code/session_01TwkTJGS9f8ysKtv2HLexQT

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwkTJGS9f8ysKtv2HLexQT)_