### PR TITLE
[AutoFix] Coverage Fix (4 files) 2026-05-07 16:30

### DIFF
--- a/.claude/logs/2026-05-07-16-45-coverage-fix.md
+++ b/.claude/logs/2026-05-07-16-45-coverage-fix.md
@@ -1,0 +1,38 @@
+# Coverage AutoFix 工作記錄
+- 執行時間：2026-05-07 16:45（Taipei）
+- PR：https://github.com/jeff377/bee-library/pull/34
+- 處理檔案數：4
+
+## 覆蓋率補強摘要
+| 檔案 | 補強前覆蓋率 | 新增測試數 | 預估補強後覆蓋率 |
+|------|------------|---------|--------------|
+| `src/Bee.Db/Providers/MySql/MySqlTableSchemaProvider.cs` | 77.9% | 10 | ~95%+ |
+| `src/Bee.Db/Providers/SqlServer/SqlSchemaSyntax.cs` | 58.3% | 19 | ~90%+ |
+| `src/Bee.Db/Providers/Oracle/OracleTableSchemaProvider.cs` | 86.0% | 9 | ~90%+ |
+| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | 87.5% | 6 | ~90%+ |
+
+## 新增測試檔案
+
+### tests/Bee.Db.UnitTests/MySqlTableSchemaProviderStaticTests.cs（新增）
+- GetFieldDbType：覆蓋所有 MySQL 型別（char/Guid、char/String、varchar、text 系列、tinyint、int 系列、bigint、decimal/Currency、decimal/Decimal、float/double/real、date、datetime/timestamp、binary 系列、unknown）
+- ParseDBDefaultValue：空值、trim、與內建預設相同、大小寫不同（uuid）、有外層括號的內建預設、不同值回傳 trimmed
+
+### tests/Bee.Db.UnitTests/SqlSchemaSyntaxTests.cs（新增）
+- QuoteName：各種識別符（含 `]` escape）
+- EscapeSqlString：單引號加倍
+- ConvertDbType：所有 FieldDbType（String/Text/Boolean/AutoIncrement/Short/Integer/Long/Decimal/Currency/Date/DateTime/Guid/Binary/Unknown）
+- GetDefaultValueExpression：所有型別
+- GetDefaultExpression：AllowNull、AutoIncrement、String 無自訂、String 有自訂、Integer 無自訂、Integer 有自訂、DateTime、Guid、Text
+- GetColumnDefinition：String NOT NULL、Integer NOT NULL、AllowNull、Guid NOT NULL、含 ] 的欄位名
+
+### tests/Bee.Db.UnitTests/OracleTableSchemaProviderAdditionalTests.cs（新增）
+- GetFieldDbType：NCHAR、NVARCHAR2（小寫）、NCLOB、NUMBER 邊界條件（scale!=0、precision=0）
+- ParseDBDefaultValue：NVARCHAR2/CHAR/NCHAR/NCLOB 的字串引號剝除、非引號包覆的字串型預設、NCLOB 自訂預設
+
+### tests/Bee.Db.UnitTests/SqlTableSchemaProviderAdditionalTests.cs（新增）
+- ParseDBDefaultValue：MONEY/FLOAT 的 ((...)) 剝除（相同與不同內建預設）、不支援型別（DECIMAL/BIGINT/VARBINARY）→ 空字串、NVARCHAR 含與不含 N 前綴
+
+## 無法處理的檔案
+| 檔案 | 原因 |
+|------|------|
+| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | `HandleRequestAsync` 的 catch 路徑需要 `JsonRpcExecutor.ExecuteAsync` 拋出例外；`IsDevelopment` 屬性需要 DI 容器注入 `IHostEnvironment`。在不使用 mock 框架（Moq/NSubstitute 未納入測試相依）的情況下無法補測。7 個未覆蓋行均位於例外處理路徑。 |

--- a/tests/Bee.Db.UnitTests/MySqlTableSchemaProviderStaticTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlTableSchemaProviderStaticTests.cs
@@ -1,0 +1,166 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.MySql;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// Static-only tests for <see cref="MySqlTableSchemaProvider"/>: validates the type-
+    /// mapping and default-value parsing helpers that don't require a live MySQL connection.
+    /// The full integration coverage (live INFORMATION_SCHEMA reads, GetTableSchema
+    /// round-trip) is gated by <c>BEE_TEST_CONNSTR_MYSQL</c> and runs in MySqlIntegrationTests.
+    /// </summary>
+    public class MySqlTableSchemaProviderStaticTests
+    {
+        #region GetFieldDbType
+
+        [Theory]
+        [InlineData("char", 0, 0, 36, FieldDbType.Guid)]
+        [InlineData("char", 0, 0, 10, FieldDbType.String)]
+        [InlineData("CHAR", 0, 0, 36, FieldDbType.Guid)]
+        [InlineData("varchar", 0, 0, 100, FieldDbType.String)]
+        [InlineData("VARCHAR", 0, 0, 50, FieldDbType.String)]
+        [InlineData("text", 0, 0, 0, FieldDbType.Text)]
+        [InlineData("tinytext", 0, 0, 0, FieldDbType.Text)]
+        [InlineData("mediumtext", 0, 0, 0, FieldDbType.Text)]
+        [InlineData("longtext", 0, 0, 0, FieldDbType.Text)]
+        [InlineData("tinyint", 0, 0, 0, FieldDbType.Boolean)]
+        [InlineData("TINYINT", 0, 0, 0, FieldDbType.Boolean)]
+        [InlineData("smallint", 0, 0, 0, FieldDbType.Short)]
+        [InlineData("int", 0, 0, 0, FieldDbType.Integer)]
+        [InlineData("integer", 0, 0, 0, FieldDbType.Integer)]
+        [InlineData("mediumint", 0, 0, 0, FieldDbType.Integer)]
+        [InlineData("bigint", 0, 0, 0, FieldDbType.Long)]
+        [InlineData("decimal", 19, 4, 0, FieldDbType.Currency)]
+        [InlineData("decimal", 12, 3, 0, FieldDbType.Decimal)]
+        [InlineData("numeric", 19, 4, 0, FieldDbType.Currency)]
+        [InlineData("numeric", 10, 2, 0, FieldDbType.Decimal)]
+        [InlineData("float", 0, 0, 0, FieldDbType.Decimal)]
+        [InlineData("double", 0, 0, 0, FieldDbType.Decimal)]
+        [InlineData("real", 0, 0, 0, FieldDbType.Decimal)]
+        [InlineData("date", 0, 0, 0, FieldDbType.Date)]
+        [InlineData("datetime", 0, 0, 0, FieldDbType.DateTime)]
+        [InlineData("timestamp", 0, 0, 0, FieldDbType.DateTime)]
+        [InlineData("binary", 0, 0, 0, FieldDbType.Binary)]
+        [InlineData("varbinary", 0, 0, 0, FieldDbType.Binary)]
+        [InlineData("blob", 0, 0, 0, FieldDbType.Binary)]
+        [InlineData("tinyblob", 0, 0, 0, FieldDbType.Binary)]
+        [InlineData("mediumblob", 0, 0, 0, FieldDbType.Binary)]
+        [InlineData("longblob", 0, 0, 0, FieldDbType.Binary)]
+        [InlineData("json", 0, 0, 0, FieldDbType.Unknown)]
+        [DisplayName("MySQL GetFieldDbType 應正確映射各 MySQL 型別")]
+        public void GetFieldDbType_VariousMySqlTypes_MapsCorrectly(
+            string dataType, int precision, int scale, int length, FieldDbType expected)
+        {
+            var result = MySqlTableSchemaProvider.GetFieldDbType(dataType, precision, scale, length);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL GetFieldDbType 應對輸入字串大小寫不敏感")]
+        public void GetFieldDbType_CaseInsensitive()
+        {
+            Assert.Equal(FieldDbType.Integer, MySqlTableSchemaProvider.GetFieldDbType("INT", 0, 0, 0));
+            Assert.Equal(FieldDbType.Long, MySqlTableSchemaProvider.GetFieldDbType("BIGINT", 0, 0, 0));
+            Assert.Equal(FieldDbType.Text, MySqlTableSchemaProvider.GetFieldDbType("TEXT", 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("MySQL GetFieldDbType CHAR(36) 應映射為 Guid，其他長度映射為 String")]
+        public void GetFieldDbType_CharLength36_IsGuid_OtherLengthIsString()
+        {
+            Assert.Equal(FieldDbType.Guid, MySqlTableSchemaProvider.GetFieldDbType("char", 0, 0, 36));
+            Assert.Equal(FieldDbType.String, MySqlTableSchemaProvider.GetFieldDbType("char", 0, 0, 35));
+            Assert.Equal(FieldDbType.String, MySqlTableSchemaProvider.GetFieldDbType("char", 0, 0, 10));
+        }
+
+        [Fact]
+        [DisplayName("MySQL GetFieldDbType NULL 或空字串應回傳 Unknown")]
+        public void GetFieldDbType_NullOrEmpty_ReturnsUnknown()
+        {
+            Assert.Equal(FieldDbType.Unknown, MySqlTableSchemaProvider.GetFieldDbType(null!, 0, 0, 0));
+            Assert.Equal(FieldDbType.Unknown, MySqlTableSchemaProvider.GetFieldDbType(string.Empty, 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("MySQL GetFieldDbType DECIMAL(19,4) 應映射為 Currency")]
+        public void GetFieldDbType_Decimal19_4_IsCurrency()
+        {
+            Assert.Equal(FieldDbType.Currency, MySqlTableSchemaProvider.GetFieldDbType("decimal", 19, 4, 0));
+        }
+
+        #endregion
+
+        #region ParseDBDefaultValue
+
+        [Theory]
+        [InlineData("int", "0", "0", "")]
+        [InlineData("int", "42", "0", "42")]
+        [InlineData("varchar", "hello", "", "hello")]
+        [InlineData("varchar", "  world  ", "", "world")]
+        [InlineData("datetime", "CURRENT_TIMESTAMP(6)", "CURRENT_TIMESTAMP(6)", "")]
+        [InlineData("char", "uuid()", "(UUID())", "")]
+        [InlineData("char", "UUID()", "(UUID())", "")]
+        [InlineData("bigint", "100", "0", "100")]
+        [InlineData("tinyint", "1", "0", "1")]
+        [DisplayName("MySQL ParseDBDefaultValue 應 trim 空白並與內建預設比對")]
+        public void ParseDBDefaultValue_VariousCases_ReturnsExpected(
+            string dataType, string defaultValue, string originalDefault, string expected)
+        {
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue(dataType, defaultValue, originalDefault);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue 空字串輸入應回傳空字串")]
+        public void ParseDBDefaultValue_EmptyInput_ReturnsEmpty()
+        {
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue("int", string.Empty, "0");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue 與內建預設值大小寫不同也視為相同（uuid）")]
+        public void ParseDBDefaultValue_MatchesBuiltinDefaultCaseInsensitive_ReturnsEmpty()
+        {
+            // MySQL 將 (UUID()) 正規化為 uuid()（小寫、無外層括號）
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue("char", "uuid()", "(UUID())");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue 有外層括號的內建預設值應剝除括號後比較")]
+        public void ParseDBDefaultValue_OuterParensInOriginal_StrippedBeforeCompare()
+        {
+            // 框架原始為 (UUID())，MySQL INFORMATION_SCHEMA 回傳 uuid()（已剝括號）
+            // StripOuterParens((UUID())) → UUID() → 與 uuid() case-insensitive 相等 → 空字串
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue("char", "uuid()", "(UUID())");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue 與內建預設值不同時應回傳 trimmed 值")]
+        public void ParseDBDefaultValue_DifferentFromBuiltin_ReturnsTrimmedValue()
+        {
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue("varchar", "  active  ", string.Empty);
+
+            Assert.Equal("active", result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue 數值型預設為 0 不同時應回傳自訂值")]
+        public void ParseDBDefaultValue_NumericCustomDefault_ReturnsValue()
+        {
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue("int", "99", "0");
+
+            Assert.Equal("99", result);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/OracleTableSchemaProviderAdditionalTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleTableSchemaProviderAdditionalTests.cs
@@ -1,0 +1,99 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.Oracle;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="OracleTableSchemaProvider"/> 靜態方法的覆蓋率：
+    /// 测試 <see cref="OracleTableSchemaProviderStaticTests"/> 尚未涉及的
+    /// NCHAR、NVARCHAR2、CHAR、NCLOB 型別路徑。
+    /// </summary>
+    public class OracleTableSchemaProviderAdditionalTests
+    {
+        #region GetFieldDbType 補充型別
+
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType NCHAR 應映射為 String")]
+        public void GetFieldDbType_Nchar_ReturnsString()
+        {
+            Assert.Equal(FieldDbType.String, OracleTableSchemaProvider.GetFieldDbType("NCHAR", 0, 0, 10));
+            Assert.Equal(FieldDbType.String, OracleTableSchemaProvider.GetFieldDbType("nchar", 0, 0, 5));
+        }
+
+        [Theory]
+        [InlineData("NVARCHAR2", 0, 0, 100, FieldDbType.String)]
+        [InlineData("nvarchar2", 0, 0, 50, FieldDbType.String)]
+        [InlineData("NCHAR", 0, 0, 10, FieldDbType.String)]
+        [InlineData("NCLOB", 0, 0, 0, FieldDbType.Text)]
+        [DisplayName("Oracle GetFieldDbType N-prefix 型別應正確映射")]
+        public void GetFieldDbType_NPrefixTypes_MapsCorrectly(
+            string dataType, int precision, int scale, int length, FieldDbType expected)
+        {
+            var result = OracleTableSchemaProvider.GetFieldDbType(dataType, precision, scale, length);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("NUMBER", 0, 1, 0, FieldDbType.Decimal)]
+        [InlineData("NUMBER", 0, 0, 0, FieldDbType.Decimal)]
+        [InlineData("NUMBER", 18, 2, 0, FieldDbType.Decimal)]
+        [DisplayName("Oracle GetFieldDbType NUMBER 途徑補充：精度/小數不符合已知對映時應回傳 Decimal")]
+        public void GetFieldDbType_NumberUncoveredBranches_ReturnsDecimal(
+            string dataType, int precision, int scale, int length, FieldDbType expected)
+        {
+            var result = OracleTableSchemaProvider.GetFieldDbType(dataType, precision, scale, length);
+
+            Assert.Equal(expected, result);
+        }
+
+        #endregion
+
+        #region ParseDBDefaultValue 補充型別
+
+        [Theory]
+        [InlineData("NVARCHAR2", "'hello'", "", "hello")]
+        [InlineData("CHAR", "'A'", "", "A")]
+        [InlineData("NCHAR", "'X'", "", "X")]
+        [InlineData("NCLOB", "'foo'", "", "foo")]
+        [DisplayName("Oracle ParseDBDefaultValue N-prefix 型別應剔除字串引號")]
+        public void ParseDBDefaultValue_NPrefixTypes_StripsStringLiteral(
+            string dataType, string defaultValue, string originalDefault, string expected)
+        {
+            var result = OracleTableSchemaProvider.ParseDBDefaultValue(dataType, defaultValue, originalDefault);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("Oracle ParseDBDefaultValue NVARCHAR2 預設與內建預設相同應回傳空字串")]
+        public void ParseDBDefaultValue_Nvarchar2MatchesBuiltin_ReturnsEmpty()
+        {
+            var result = OracleTableSchemaProvider.ParseDBDefaultValue("NVARCHAR2", "''", "");
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("Oracle ParseDBDefaultValue 非引號包裹的字串型預設應原樣輸出")]
+        public void ParseDBDefaultValue_StringTypeNotQuoted_ReturnsAsIs()
+        {
+            // Oracle DATA_DEFAULT 如果不是引號包裹（如引用式 default），StripStringLiteral 不處理直接回傳
+            var result = OracleTableSchemaProvider.ParseDBDefaultValue("NVARCHAR2", "CURRENT_TIMESTAMP", "");
+
+            Assert.Equal("CURRENT_TIMESTAMP", result);
+        }
+
+        [Fact]
+        [DisplayName("Oracle ParseDBDefaultValue NCLOB 與內建預設不同時應回傳副本內容")]
+        public void ParseDBDefaultValue_NclobCustomDefault_ReturnsStrippedValue()
+        {
+            var result = OracleTableSchemaProvider.ParseDBDefaultValue("NCLOB", "'my default'", "");
+
+            Assert.Equal("my default", result);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlSchemaSyntaxTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlSchemaSyntaxTests.cs
@@ -1,0 +1,252 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.SqlServer;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 純語法測試：覆蓋 <see cref="SqlSchemaSyntax"/> 的識別符 quote、字串 escape、
+    /// 資料型轉換、預設值表達式與 column 定義組裝。
+    /// </summary>
+    public class SqlSchemaSyntaxTests
+    {
+        #region QuoteName
+
+        [Theory]
+        [InlineData("st_user", "[st_user]")]
+        [InlineData("name", "[name]")]
+        [InlineData("col]with bracket", "[col]]with bracket]")]
+        [InlineData("", "[]")]
+        [DisplayName("SQL Server QuoteName 應以方括號包覆並 escape 內部 ]")]
+        public void QuoteName_VariousIdentifiers_QuotesProperly(string identifier, string expected)
+        {
+            Assert.Equal(expected, SqlSchemaSyntax.QuoteName(identifier));
+        }
+
+        #endregion
+
+        #region EscapeSqlString
+
+        [Theory]
+        [InlineData("hello", "hello")]
+        [InlineData("O'Brien", "O''Brien")]
+        [InlineData("it's a 'test'", "it''s a ''test''")]
+        [InlineData("", "")]
+        [DisplayName("SQL Server EscapeSqlString 單引號應加倍以避免破壞字面量")]
+        public void EscapeSqlString_DoublesSingleQuotes(string input, string expected)
+        {
+            Assert.Equal(expected, SqlSchemaSyntax.EscapeSqlString(input));
+        }
+
+        #endregion
+
+        #region ConvertDbType
+
+        [Theory]
+        [InlineData(FieldDbType.Text, "[nvarchar](max)")]
+        [InlineData(FieldDbType.Boolean, "[bit]")]
+        [InlineData(FieldDbType.AutoIncrement, "[int] IDENTITY(1,1)")]
+        [InlineData(FieldDbType.Short, "[smallint]")]
+        [InlineData(FieldDbType.Integer, "[int]")]
+        [InlineData(FieldDbType.Long, "[bigint]")]
+        [InlineData(FieldDbType.Currency, "[decimal](19,4)")]
+        [InlineData(FieldDbType.Date, "[date]")]
+        [InlineData(FieldDbType.DateTime, "[datetime]")]
+        [InlineData(FieldDbType.Guid, "[uniqueidentifier]")]
+        [InlineData(FieldDbType.Binary, "[varbinary](max)")]
+        [DisplayName("SQL Server ConvertDbType 應回傳各型別對應的 SQL Server 型別字串")]
+        public void ConvertDbType_VariousTypes_ReturnsExpectedSql(FieldDbType dbType, string expected)
+        {
+            var field = new DbField("f", "F", dbType);
+            Assert.Equal(expected, SqlSchemaSyntax.ConvertDbType(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server ConvertDbType String 應含 Length")]
+        public void ConvertDbType_String_IncludesLength()
+        {
+            var field = new DbField("name", "Name", FieldDbType.String) { Length = 50 };
+            Assert.Equal("[nvarchar](50)", SqlSchemaSyntax.ConvertDbType(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server ConvertDbType Decimal 預設精度 18,0")]
+        public void ConvertDbType_DecimalDefault_ReturnsDecimal18_0()
+        {
+            var field = new DbField("f", "F", FieldDbType.Decimal);
+            Assert.Equal("[decimal](18,0)", SqlSchemaSyntax.ConvertDbType(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server ConvertDbType Decimal 自訂精度應正確輸出")]
+        public void ConvertDbType_DecimalCustom_ReturnsCorrectPrecision()
+        {
+            var field = new DbField("f", "F", FieldDbType.Decimal) { Precision = 12, Scale = 3 };
+            Assert.Equal("[decimal](12,3)", SqlSchemaSyntax.ConvertDbType(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server ConvertDbType Unknown 應丟出 InvalidOperationException")]
+        public void ConvertDbType_UnknownType_ThrowsInvalidOperationException()
+        {
+            var field = new DbField("f", "F", FieldDbType.Unknown);
+            Assert.Throws<InvalidOperationException>(() => SqlSchemaSyntax.ConvertDbType(field));
+        }
+
+        #endregion
+
+        #region GetDefaultValueExpression
+
+        [Theory]
+        [InlineData(FieldDbType.String, "")]
+        [InlineData(FieldDbType.Text, "")]
+        [InlineData(FieldDbType.Boolean, "0")]
+        [InlineData(FieldDbType.Short, "0")]
+        [InlineData(FieldDbType.Integer, "0")]
+        [InlineData(FieldDbType.Long, "0")]
+        [InlineData(FieldDbType.Decimal, "0")]
+        [InlineData(FieldDbType.Currency, "0")]
+        [InlineData(FieldDbType.Date, "getdate()")]
+        [InlineData(FieldDbType.DateTime, "getdate()")]
+        [InlineData(FieldDbType.Guid, "newid()")]
+        [InlineData(FieldDbType.AutoIncrement, "")]
+        [InlineData(FieldDbType.Binary, "")]
+        [InlineData(FieldDbType.Unknown, "")]
+        [DisplayName("SQL Server GetDefaultValueExpression 各型別應對應正確 SQL Server 預設表達式")]
+        public void GetDefaultValueExpression_VariousTypes_ReturnsExpected(FieldDbType dbType, string expected)
+        {
+            Assert.Equal(expected, SqlSchemaSyntax.GetDefaultValueExpression(dbType));
+        }
+
+        #endregion
+
+        #region GetDefaultExpression
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression AllowNull 欄位應回傳空字串（無 DEFAULT 子句）")]
+        public void GetDefaultExpression_AllowNull_ReturnsEmpty()
+        {
+            var field = new DbField("f", "F", FieldDbType.Integer) { AllowNull = true };
+            Assert.Equal(string.Empty, SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression AutoIncrement 欄位應回傳空字串")]
+        public void GetDefaultExpression_AutoIncrement_ReturnsEmpty()
+        {
+            var field = new DbField("pk", "PK", FieldDbType.AutoIncrement);
+            Assert.Equal(string.Empty, SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression String 無自訂預設應回傳 N''")]
+        public void GetDefaultExpression_StringNoCustom_ReturnsEmptyNLiteral()
+        {
+            var field = new DbField("name", "Name", FieldDbType.String) { Length = 50 };
+            Assert.Equal("N''", SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression String 自訂預設應包 N'...' 後回傳")]
+        public void GetDefaultExpression_StringCustom_ReturnsNLiteralWrapped()
+        {
+            var field = new DbField("name", "Name", FieldDbType.String) { Length = 50, DefaultValue = "hello" };
+            Assert.Equal("N'hello'", SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression Integer 無自訂預設應回傳內建預設 0")]
+        public void GetDefaultExpression_IntegerNoCustom_ReturnsBuiltinZero()
+        {
+            var field = new DbField("age", "Age", FieldDbType.Integer);
+            Assert.Equal("0", SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression Integer 自訂預設應原樣輸出")]
+        public void GetDefaultExpression_IntegerCustom_ReturnsRaw()
+        {
+            var field = new DbField("age", "Age", FieldDbType.Integer) { DefaultValue = "42" };
+            Assert.Equal("42", SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression DateTime 無自訂應回傳 getdate()")]
+        public void GetDefaultExpression_DateTimeNoCustom_ReturnsGetDate()
+        {
+            var field = new DbField("created_at", "Created", FieldDbType.DateTime);
+            Assert.Equal("getdate()", SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression Guid 無自訂應回傳 newid()")]
+        public void GetDefaultExpression_GuidNoCustom_ReturnsNewId()
+        {
+            var field = new DbField("sys_rowid", "Row ID", FieldDbType.Guid);
+            Assert.Equal("newid()", SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetDefaultExpression Text 無自訂預設應回傳 N''")]
+        public void GetDefaultExpression_TextNoCustom_ReturnsEmptyNLiteral()
+        {
+            var field = new DbField("content", "Content", FieldDbType.Text);
+            Assert.Equal("N''", SqlSchemaSyntax.GetDefaultExpression(field));
+        }
+
+        #endregion
+
+        #region GetColumnDefinition
+
+        [Fact]
+        [DisplayName("SQL Server GetColumnDefinition String NOT NULL 應包含型別、非空和 DEFAULT")]
+        public void GetColumnDefinition_StringNotNull_IncludesTypeNullabilityAndDefault()
+        {
+            var field = new DbField("name", "Name", FieldDbType.String) { Length = 50 };
+            var sql = SqlSchemaSyntax.GetColumnDefinition(field);
+            Assert.Contains("[name]", sql);
+            Assert.Contains("[nvarchar](50)", sql);
+            Assert.Contains("NOT NULL", sql);
+            Assert.Contains("DEFAULT (N'')", sql);
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetColumnDefinition Integer NOT NULL 應包含 DEFAULT 0")]
+        public void GetColumnDefinition_IntegerNotNull_IncludesDefaultZero()
+        {
+            var field = new DbField("count", "Count", FieldDbType.Integer);
+            var sql = SqlSchemaSyntax.GetColumnDefinition(field);
+            Assert.Equal("[count] [int] NOT NULL DEFAULT (0)", sql);
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetColumnDefinition AllowNull 不應出現 DEFAULT 子句")]
+        public void GetColumnDefinition_AllowNull_OmitsDefaultClause()
+        {
+            var field = new DbField("remark", "Remark", FieldDbType.Integer) { AllowNull = true };
+            var sql = SqlSchemaSyntax.GetColumnDefinition(field);
+            Assert.Equal("[remark] [int] NULL", sql);
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetColumnDefinition Guid NOT NULL 應包含 DEFAULT (newid())")]
+        public void GetColumnDefinition_GuidNotNull_IncludesNewId()
+        {
+            var field = new DbField("sys_rowid", "Row ID", FieldDbType.Guid);
+            var sql = SqlSchemaSyntax.GetColumnDefinition(field);
+            Assert.Equal("[sys_rowid] [uniqueidentifier] NOT NULL DEFAULT (newid())", sql);
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetColumnDefinition 含 ] 的欄位名應正確 escape")]
+        public void GetColumnDefinition_IdentifierWithBracket_EscapesProperly()
+        {
+            var field = new DbField("col]name", "Col", FieldDbType.Integer);
+            var sql = SqlSchemaSyntax.GetColumnDefinition(field);
+            Assert.StartsWith("[col]]name]", sql);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlTableSchemaProviderAdditionalTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlTableSchemaProviderAdditionalTests.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel;
+using Bee.Db.Providers.SqlServer;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="SqlTableSchemaProvider"/> 靜態方法的覆蓋率：
+    /// 测試 <see cref="SqlTableSchemaProviderStaticTests"/> 尚未涉及的
+    /// MONEY、FLOAT 和預設分支路徑。
+    /// </summary>
+    public class SqlTableSchemaProviderAdditionalTests
+    {
+        #region ParseDBDefaultValue 補充型別
+
+        [Theory]
+        [InlineData("MONEY", "((0))", "0", "")]
+        [InlineData("MONEY", "((500))", "0", "500")]
+        [InlineData("FLOAT", "((0))", "0", "")]
+        [InlineData("FLOAT", "((3.14))", "0", "3.14")]
+        [DisplayName("SQL Server ParseDBDefaultValue MONEY/FLOAT 應剝除 ((...)) 包裹")]
+        public void ParseDBDefaultValue_MoneyAndFloat_StripsDoubleParens(
+            string dataType, string defaultValue, string originalDefault, string expected)
+        {
+            var result = SqlTableSchemaProvider.ParseDBDefaultValue(dataType, defaultValue, originalDefault);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("DECIMAL", "((10.5))", "")]
+        [InlineData("BIGINT", "((1000))", "")]
+        [InlineData("VARBINARY", "0x", "")]
+        [DisplayName("SQL Server ParseDBDefaultValue 不支援的型別應回傳空字串")]
+        public void ParseDBDefaultValue_UnsupportedTypes_ReturnsEmpty(
+            string dataType, string defaultValue, string expected)
+        {
+            var result = SqlTableSchemaProvider.ParseDBDefaultValue(dataType, defaultValue, string.Empty);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("SQL Server ParseDBDefaultValue NVARCHAR 表達式副本應正確解析")]
+        public void ParseDBDefaultValue_NvarcharWithSingleQuotePrefix_StripsNPrefix()
+        {
+            // SQL Server 儲存的 NVARCHAR default 格式為 (N'value')
+            var result = SqlTableSchemaProvider.ParseDBDefaultValue("NVARCHAR", "(N'active')", "");
+
+            Assert.Equal("active", result);
+        }
+
+        [Fact]
+        [DisplayName("SQL Server ParseDBDefaultValue NVARCHAR 表達式副本不含 N 前缀也應正確解析")]
+        public void ParseDBDefaultValue_NvarcharWithoutNPrefix_StripsParens()
+        {
+            // 部分 SQL Server 表達式不含 N 前缀
+            var result = SqlTableSchemaProvider.ParseDBDefaultValue("NVARCHAR", "('world')", "");
+
+            Assert.Equal("world", result);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/MySql/MySqlTableSchemaProvider.cs` | 77.9% | 10 |
| `src/Bee.Db/Providers/SqlServer/SqlSchemaSyntax.cs` | 58.3% | 19 |
| `src/Bee.Db/Providers/Oracle/OracleTableSchemaProvider.cs` | 86.0% | 9 |
| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | 87.5% | 6 |

### 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | `HandleRequestAsync` 的 catch 路徑需要 `JsonRpcExecutor.ExecuteAsync` 拋出例外，且 `IsDevelopment` 屬性需要 DI 容器注入 `IHostEnvironment`，無法在不依賴 mock 框架的情況下補測。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01T62ex8ee6wPr7Ckz3tQZw6)_