### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-08 08:30

### DIFF
--- a/.claude/logs/2026-05-08-08-48-coverage-fix.md
+++ b/.claude/logs/2026-05-08-08-48-coverage-fix.md
@@ -1,0 +1,22 @@
+# Coverage AutoFix 工作記錄
+- 執行時間：2026-05-08 08:48（Taipei）
+- PR：https://github.com/jeff377/bee-library/pull/36
+- 處理檔案數：3
+
+## 覆蓋率補強摘要
+| 檔案 | 補強前覆蓋率 | 新增測試數 | 預估補強後覆蓋率 |
+|------|------------|---------|--------------|
+| `src/Bee.Db/Providers/Oracle/OracleTableSchemaProvider.cs` | 86.5% | 7 | ~90% |
+| `src/Bee.Db/Providers/MySql/MySqlTableSchemaProvider.cs` | 85.2% | 5 | ~88% |
+| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | 87.5% | 4 | ~90% |
+
+### 補強內容說明
+- **OracleTableSchemaProvider**：補充 `NormalizeDataTypeName` 的 `parenEnd < 0` 分支（惡意型別名 `TIMESTAMP(6`）、括號後剩餘文字分支（`TIMESTAMP(6) WITH TIME ZONE`）、null 輸入、`ParseDBDefaultValue` 中 `LONG`/`BLOB` 走 default 分支；整合測試補非主鍵索引（覆蓋 `ParseIndexes` 迴圈主體）與無主鍵資料表（覆蓋 `ParsePrimaryKey` 提早返回）。
+- **MySqlTableSchemaProvider**：補充 `StripOuterParens` 的不完整括號分支（原始值開括號但無閉括號、單字元、兩字元 `()`）；整合測試補非主鍵索引與無主鍵資料表。
+- **SqlTableSchemaProvider**：補充 `GetFieldDbType` null 輸入→Unknown；整合測試補非主鍵索引（`ParseIndexes` 迴圈主體）、無主鍵資料表（`ParsePrimaryKey` 提早返回）、`NVARCHAR(MAX)` 欄位映射為 Text 型別。
+
+## 無法處理的檔案
+| 檔案 | 原因 |
+|------|------|
+| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | `HandleRequestAsync` 的 catch 區塊（7 行）無法觸達：`JsonRpcExecutor.ExecuteAsync` 已在內部攔截所有例外並回傳 error response，不向外拋出；`IsDevelopment` 僅在 catch 中呼叫，亦無法涵蓋。 |
+| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 條未涵蓋行均為競爭條件 / 重試路徑（`LoadFromFile` 中 `FileMode.CreateNew` 的 `IOException` catch、`ReadAllTextShared` 的重試迴圈 `Thread.Sleep`+`attempt++`），需多執行緒並發才能觸發，不適合常規單元測試。 |

--- a/tests/Bee.Db.UnitTests/MySqlTableSchemaProviderEdgeCaseTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlTableSchemaProviderEdgeCaseTests.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.MySql;
+using Bee.Tests.Shared;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="MySqlTableSchemaProvider"/> 尚未涵蓋的靜態分支與
+    /// 需要活 MySQL 連線的 ParseIndexes 路徑（非主鍵索引）。
+    /// </summary>
+    [Collection("Initialize")]
+    public class MySqlTableSchemaProviderEdgeCaseTests
+    {
+        #region ParseDBDefaultValue 邊緣案例
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue originalDefault 有開括號但無閉括號時 StripOuterParens 應原樣保留")]
+        public void ParseDBDefaultValue_OriginalWithUnclosedParen_NotStripped()
+        {
+            // StripOuterParens("(CURRENT_TIMESTAMP") → value[last] = 'P' ≠ ')' → 不剝除，回傳原字串
+            // "(CURRENT_TIMESTAMP" ≠ "CURRENT_TIMESTAMP" → 回傳 trimmed = "CURRENT_TIMESTAMP"
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue(
+                "datetime", "CURRENT_TIMESTAMP", "(CURRENT_TIMESTAMP");
+            Assert.Equal("CURRENT_TIMESTAMP", result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue originalDefault 為單字元時 StripOuterParens 長度不足應原樣保留")]
+        public void ParseDBDefaultValue_OriginalSingleChar_NotStripped()
+        {
+            // StripOuterParens("(") → length = 1 < 2 → 不剝除，回傳 "("
+            // "(" ≠ "0" → 回傳 trimmed "0"
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue("int", "0", "(");
+            Assert.Equal("0", result);
+        }
+
+        [Fact]
+        [DisplayName("MySQL ParseDBDefaultValue originalDefault 為兩字元 () 時 StripOuterParens 剝除後為空字串")]
+        public void ParseDBDefaultValue_OriginalEmptyParens_StrippedToEmpty()
+        {
+            // StripOuterParens("()") → length=2, starts '(', ends ')' → returns ""
+            // "" == "0" is false (case-insensitive) → returns trimmed = "0"
+            var result = MySqlTableSchemaProvider.ParseDBDefaultValue("int", "0", "()");
+            Assert.Equal("0", result);
+        }
+
+        #endregion
+
+        #region 整合測試（需 MySQL 連線）
+
+        [DbFact(DatabaseType.MySQL)]
+        [DisplayName("MySQL SchemaProvider 應正確讀取包含非主鍵索引的資料表結構（覆蓋 ParseIndexes 迴圈主體）")]
+        public void SchemaProvider_TableWithNonPkIndex_ParseIndexesLoopBodyCovered()
+        {
+            const string tableName = "tb_idx_edge";
+            var databaseId = TestDbConventions.GetDatabaseId(DatabaseType.MySQL);
+            var dbAccess = new DbAccess(databaseId);
+
+            dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                $"DROP TABLE IF EXISTS `{tableName}`"));
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"CREATE TABLE `{tableName}` (" +
+                    "`sys_rowid` CHAR(36) NOT NULL," +
+                    "`code` VARCHAR(20) NOT NULL," +
+                    "PRIMARY KEY (`sys_rowid`)," +
+                    "UNIQUE KEY `IX_tb_idx_edge_code` (`code`)" +
+                    ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"));
+
+                var provider = new MySqlTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Indexes!.Count >= 2, "應有 PK + 至少一個非主鍵唯一索引");
+                Assert.True(schema.Indexes.Any(idx => idx.PrimaryKey), "應有主鍵索引");
+                Assert.True(schema.Indexes.Any(idx => !idx.PrimaryKey && idx.Unique), "應有非主鍵唯一索引");
+            }
+            finally
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"DROP TABLE IF EXISTS `{tableName}`"));
+            }
+        }
+
+        [DbFact(DatabaseType.MySQL)]
+        [DisplayName("MySQL SchemaProvider 讀取無主鍵資料表時 ParsePrimaryKey 應提早返回")]
+        public void SchemaProvider_TableWithNoPrimaryKey_ParsePrimaryKeyEarlyReturn()
+        {
+            const string tableName = "tb_nopk_edge";
+            var databaseId = TestDbConventions.GetDatabaseId(DatabaseType.MySQL);
+            var dbAccess = new DbAccess(databaseId);
+
+            dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                $"DROP TABLE IF EXISTS `{tableName}`"));
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"CREATE TABLE `{tableName}` (" +
+                    "`code` VARCHAR(20) NOT NULL" +
+                    ") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"));
+
+                var provider = new MySqlTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.False(schema!.Indexes!.Any(idx => idx.PrimaryKey), "無主鍵資料表不應有主鍵索引");
+            }
+            finally
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"DROP TABLE IF EXISTS `{tableName}`"));
+            }
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/OracleTableSchemaProviderEdgeCaseTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleTableSchemaProviderEdgeCaseTests.cs
@@ -1,0 +1,146 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.Oracle;
+using Bee.Tests.Shared;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="OracleTableSchemaProvider"/> 尚未涵蓋的靜態分支與
+    /// 需要活 Oracle 連線的 ParseIndexes / ParsePrimaryKey 路徑。
+    /// </summary>
+    [Collection("Initialize")]
+    public class OracleTableSchemaProviderEdgeCaseTests
+    {
+        #region GetFieldDbType 邊緣案例
+
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType null 輸入應回傳 Unknown")]
+        public void GetFieldDbType_NullInput_ReturnsUnknown()
+        {
+            Assert.Equal(FieldDbType.Unknown, OracleTableSchemaProvider.GetFieldDbType(null!, 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType 型別名稱有開括號但無閉括號時 NormalizeDataTypeName 應原樣保留並回傳 Unknown")]
+        public void GetFieldDbType_MalformedTypeWithUnclosedParen_ReturnsUnknown()
+        {
+            // NormalizeDataTypeName: parenStart=9, parenEnd=-1 → if (parenEnd < 0) return lower
+            // "timestamp(6" 不符合 switch 任何 case → Unknown
+            Assert.Equal(FieldDbType.Unknown, OracleTableSchemaProvider.GetFieldDbType("TIMESTAMP(6", 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType TIMESTAMP WITH TIME ZONE 應回傳 Unknown（括號後剩餘文字保留）")]
+        public void GetFieldDbType_TimestampWithTimeZone_ReturnsUnknown()
+        {
+            // NormalizeDataTypeName("TIMESTAMP(6) WITH TIME ZONE"):
+            // before="timestamp", after=" with time zone" → "timestamp with time zone"
+            // 不符合 "timestamp" case → Unknown
+            Assert.Equal(FieldDbType.Unknown, OracleTableSchemaProvider.GetFieldDbType("TIMESTAMP(6) WITH TIME ZONE", 0, 0, 0));
+        }
+
+        #endregion
+
+        #region ParseDBDefaultValue 邊緣案例
+
+        [Fact]
+        [DisplayName("Oracle ParseDBDefaultValue LONG 型別應走 default 分支並回傳 trimmed 值")]
+        public void ParseDBDefaultValue_LongType_ReturnsTrimmedValue()
+        {
+            // "LONG" → NormalizeDataTypeName → "long"
+            // "long" 不在字串型別 switch（僅含 varchar2/nvarchar2/char/nchar/clob/nclob）→ default: normalized = trimmed
+            var result = OracleTableSchemaProvider.ParseDBDefaultValue("LONG", "  my_default  ", "");
+            Assert.Equal("my_default", result);
+        }
+
+        [Fact]
+        [DisplayName("Oracle ParseDBDefaultValue BLOB 型別應走 default 分支並回傳 trimmed 值")]
+        public void ParseDBDefaultValue_BlobType_ReturnsTrimmedValue()
+        {
+            // "BLOB" 不在字串型別 switch → default: normalized = trimmed
+            var result = OracleTableSchemaProvider.ParseDBDefaultValue("BLOB", "  hexvalue  ", "");
+            Assert.Equal("hexvalue", result);
+        }
+
+        #endregion
+
+        #region 整合測試（需 Oracle 連線）
+
+        [DbFact(DatabaseType.Oracle)]
+        [DisplayName("Oracle SchemaProvider 應正確讀取包含非主鍵索引的資料表結構（覆蓋 ParseIndexes 迴圈主體）")]
+        public void SchemaProvider_TableWithNonPkIndex_ParseIndexesLoopBodyCovered()
+        {
+            const string tableName = "tb_idx_edge";
+            var databaseId = TestDbConventions.GetDatabaseId(DatabaseType.Oracle);
+            var dbAccess = new DbAccess(databaseId);
+
+            DropTable(dbAccess, tableName);
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE \"TB_IDX_EDGE\" (" +
+                    "\"SYS_ROWID\" RAW(16) NOT NULL," +
+                    "\"CODE\" VARCHAR2(20 CHAR) NOT NULL," +
+                    "CONSTRAINT \"PK_TB_IDX_EDGE\" PRIMARY KEY (\"SYS_ROWID\")" +
+                    ")"));
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE UNIQUE INDEX \"IX_TB_IDX_EDGE_CODE\" ON \"TB_IDX_EDGE\" (\"CODE\")"));
+
+                var provider = new OracleTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Indexes!.Count >= 2, "應有 PK + 至少一個非主鍵唯一索引");
+                Assert.True(schema.Indexes.Any(idx => idx.PrimaryKey), "應有主鍵索引");
+                Assert.True(schema.Indexes.Any(idx => !idx.PrimaryKey && idx.Unique), "應有非主鍵唯一索引");
+            }
+            finally
+            {
+                DropTable(dbAccess, tableName);
+            }
+        }
+
+        [DbFact(DatabaseType.Oracle)]
+        [DisplayName("Oracle SchemaProvider 讀取無主鍵資料表時 ParsePrimaryKey 應提早返回")]
+        public void SchemaProvider_TableWithNoPrimaryKey_ParsePrimaryKeyEarlyReturn()
+        {
+            const string tableName = "tb_nopk_edge";
+            var databaseId = TestDbConventions.GetDatabaseId(DatabaseType.Oracle);
+            var dbAccess = new DbAccess(databaseId);
+
+            DropTable(dbAccess, tableName);
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE \"TB_NOPK_EDGE\" (" +
+                    "\"CODE\" VARCHAR2(20 CHAR) NOT NULL" +
+                    ")"));
+
+                var provider = new OracleTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.False(schema!.Indexes!.Any(idx => idx.PrimaryKey), "無主鍵資料表不應有主鍵索引");
+            }
+            finally
+            {
+                DropTable(dbAccess, tableName);
+            }
+        }
+
+        private static void DropTable(DbAccess dbAccess, string tableName)
+        {
+            string storageName = tableName.ToUpperInvariant();
+            string ddl =
+                "BEGIN " +
+                "  EXECUTE IMMEDIATE 'DROP TABLE \"" + storageName + "\" CASCADE CONSTRAINTS'; " +
+                "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; " +
+                "END;";
+            dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery, ddl));
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlTableSchemaProviderIndexTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlTableSchemaProviderIndexTests.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel;
+using Bee.Db.Providers.SqlServer;
+using Bee.Tests.Shared;
+using Bee.Definition.Database;
+using Bee.Base.Data;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="SqlTableSchemaProvider"/> 需要活 SQL Server 連線的 ParseIndexes 與
+    /// ParsePrimaryKey 未涵蓋路徑，以及 GetFieldDbType null 輸入邊緣案例。
+    /// </summary>
+    [Collection("Initialize")]
+    public class SqlTableSchemaProviderIndexTests
+    {
+        #region GetFieldDbType 邊緣案例
+
+        [Fact]
+        [DisplayName("SQL Server GetFieldDbType null 輸入應回傳 Unknown")]
+        public void GetFieldDbType_NullInput_ReturnsUnknown()
+        {
+            Assert.Equal(FieldDbType.Unknown, SqlTableSchemaProvider.GetFieldDbType(null!, 0, 0, 0));
+        }
+
+        #endregion
+
+        #region 整合測試（需 SQL Server 連線）
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("SQL Server SchemaProvider 應正確讀取包含非主鍵索引的資料表結構（覆蓋 ParseIndexes 迴圈主體）")]
+        public void GetTableSchema_TableWithNonPkIndex_ParseIndexesLoopBodyCovered()
+        {
+            string tableName = $"bee_idx_edge_{Guid.NewGuid():N}";
+            var dbAccess = new DbAccess("common_sqlserver");
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"CREATE TABLE [{tableName}] (" +
+                    "[sys_rowid] UNIQUEIDENTIFIER NOT NULL," +
+                    "[code] NVARCHAR(20) NOT NULL," +
+                    "CONSTRAINT [PK_{tableName}] PRIMARY KEY ([sys_rowid])" +
+                    ");"));
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"CREATE UNIQUE INDEX [IX_{tableName}_code] ON [{tableName}] ([code]);"));
+
+                var provider = new SqlTableSchemaProvider("common_sqlserver");
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Indexes!.Count >= 2, "應有 PK + 至少一個非主鍵唯一索引");
+                Assert.True(schema.Indexes.Any(idx => idx.PrimaryKey), "應有主鍵索引");
+                Assert.True(schema.Indexes.Any(idx => !idx.PrimaryKey && idx.Unique), "應有非主鍵唯一索引");
+            }
+            finally
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"IF OBJECT_ID(N'[{tableName}]', N'U') IS NOT NULL DROP TABLE [{tableName}];"));
+            }
+        }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("SQL Server SchemaProvider 讀取無主鍵資料表時 ParsePrimaryKey 應提早返回")]
+        public void GetTableSchema_TableWithNoPrimaryKey_ParsePrimaryKeyEarlyReturn()
+        {
+            string tableName = $"bee_nopk_edge_{Guid.NewGuid():N}";
+            var dbAccess = new DbAccess("common_sqlserver");
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"CREATE TABLE [{tableName}] ([code] NVARCHAR(20) NOT NULL);"));
+
+                var provider = new SqlTableSchemaProvider("common_sqlserver");
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.False(schema!.Indexes!.Any(idx => idx.PrimaryKey), "無主鍵資料表不應有主鍵索引");
+            }
+            finally
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"IF OBJECT_ID(N'[{tableName}]', N'U') IS NOT NULL DROP TABLE [{tableName}];"));
+            }
+        }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("SQL Server SchemaProvider NVARCHAR(MAX) 欄位應映射為 Text 型別")]
+        public void GetTableSchema_NvarcharMaxColumn_MapsToTextType()
+        {
+            string tableName = $"bee_nvarmax_{Guid.NewGuid():N}";
+            var dbAccess = new DbAccess("common_sqlserver");
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"CREATE TABLE [{tableName}] ([content] NVARCHAR(MAX) NULL);"));
+
+                var provider = new SqlTableSchemaProvider("common_sqlserver");
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Fields!.Contains("content"), "應包含 content 欄位");
+                Assert.Equal(FieldDbType.Text, schema.Fields["content"].DbType);
+            }
+            finally
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"IF OBJECT_ID(N'[{tableName}]', N'U') IS NOT NULL DROP TABLE [{tableName}];"));
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/Oracle/OracleTableSchemaProvider.cs` | 86.5% | 7 |
| `src/Bee.Db/Providers/MySql/MySqlTableSchemaProvider.cs` | 85.2% | 5 |
| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | 87.5% | 4 |

### 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | `HandleRequestAsync` 的 catch 區塊無法觸達：`JsonRpcExecutor.ExecuteAsync` 在內部攔截所有例外並回傳 error response，不向外拋出；`IsDevelopment` 僅在 catch 中呼叫，亦無法覆蓋。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 條未涵蓋行均為競爭條件 / 重試路徑（`LoadFromFile` 中 `FileMode.CreateNew` 的 `IOException` catch、`ReadAllTextShared` 的重試迴圈），需多執行緒並發才能觸發，不適合常規單元測試。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01JC6qw1dSysqHxPHFPPqGE5)_