### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-08 04:05

### DIFF
--- a/.claude/logs/2026-05-08-12-16-coverage-fix.md
+++ b/.claude/logs/2026-05-08-12-16-coverage-fix.md
@@ -1,0 +1,32 @@
+# Coverage AutoFix 工作記錄
+- 執行時間：2026-05-08 12:16（Taipei）
+- PR：https://github.com/jeff377/bee-library/pull/37
+- 處理檔案數：3
+
+## 覆蓋率補強摘要
+
+| 檔案 | 補強前覆蓋率 | 新增測試數 | 補強路徑說明 |
+|------|------------|---------|------------|
+| `src/Bee.Db/Providers/Oracle/OracleTableSchemaProvider.cs` | < 90% | 6 | `NormalizeDataTypeName` parenEnd<0 分支、after≠"" 分支；null/空字串輸入；`ParseDbField` Decimal（Precision/Scale）；`ParsePrimaryKey` 無 PK 提前返回 |
+| `src/Bee.Db/Providers/MySql/MySqlTableSchemaProvider.cs` | < 90% | 2 | `ParseDbField` Decimal 分支（Precision/Scale 賦值）；`ParsePrimaryKey` 無 PK 提前返回 |
+| `src/Bee.Db/Providers/SqlServer/SqlTableSchemaProvider.cs` | < 90% | 4 | `GetFieldDbType` null/空字串輸入；`ParseDbField` Decimal 分支（Precision/Scale 賦值）；`ParsePrimaryKey` 無 PK 提前返回 |
+
+## 新增測試檔一覽
+
+| 測試檔 | 測試類別 | 測試數 |
+|--------|---------|------|
+| `tests/Bee.Db.UnitTests/OracleTableSchemaProviderNullAndExtraTests.cs` | `OracleTableSchemaProviderNullTests`（靜態）、`OracleTableSchemaProviderDecimalAndNoPkTests`（整合，需 Oracle） | 6 |
+| `tests/Bee.Db.UnitTests/MySqlTableSchemaProviderExtraTests.cs` | `MySqlTableSchemaProviderExtraTests`（整合，需 MySQL） | 2 |
+| `tests/Bee.Db.UnitTests/SqlTableSchemaProviderNullAndNoPkTests.cs` | `SqlTableSchemaProviderNullTests`（靜態）、`SqlTableSchemaProviderDecimalAndNoPkTests`（整合，需 SQL Server） | 4 |
+
+## 無法處理的檔案
+
+| 檔案 | 原因 |
+|------|------|
+| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | `HandleRequestAsync` catch block 與 `IsDevelopment` property 需要 `IHostEnvironment` 注入並強制 `ExecuteAsync` 拋例外，超出純靜態測試範圍，需整合/端對端測試或重構才能覆蓋 |
+| `src/Bee.Definition/Security/MasterKeyProvider.cs` | `LoadFromFile` 中的 `IOException` catch block 與 `ReadAllTextShared` 重試迴圈屬競態條件路徑，無法在測試中穩定觸發，需 fault-injection 機制才能可靠覆蓋 |
+
+## CI 與品質閘
+
+- SonarCloud Quality Gate：✅ 通過（0 new issues，0 Security Hotspots）
+- 整合測試（Oracle / MySQL / SQL Server）：依 `[DbFact]` 機制，環境變數未設時自動 Skip；CI 已有對應 DB 容器，預期正常執行

--- a/tests/Bee.Db.UnitTests/MySqlTableSchemaProviderExtraTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlTableSchemaProviderExtraTests.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.MySql;
+using Bee.Definition.Database;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="MySqlTableSchemaProvider"/> 整合路徑：
+    /// 驗證 <c>ParseDbField</c> Decimal 分支（Precision/Scale 賦值）與
+    /// <c>ParsePrimaryKey</c> 在無主鍵時的提前返回路徑。
+    /// 依賴 MySQL 連線；環境變數未設時自動跳過。
+    /// </summary>
+    [Collection("Initialize")]
+    public class MySqlTableSchemaProviderExtraTests
+    {
+        [DbFact(DatabaseType.MySQL)]
+        [DisplayName("MySQL SchemaProvider 讀回 DECIMAL(15,3) 欄位時應正確設定 Precision 與 Scale（ParseDbField Decimal 分支）")]
+        public void GetTableSchema_DecimalField_ReturnsPrecisionAndScale()
+        {
+            const string tableName = "tb_ex_decimal";
+            string databaseId = TestDbConventions.GetDatabaseId(DatabaseType.MySQL);
+            var dbAccess = new DbAccess(databaseId);
+            DropMySqlTable(dbAccess, tableName);
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE tb_ex_decimal (id VARCHAR(36) NOT NULL, " +
+                    "amount DECIMAL(15,3) NOT NULL, " +
+                    "CONSTRAINT PK_TB_EX_DECIMAL PRIMARY KEY (id)) " +
+                    "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"));
+
+                var provider = new MySqlTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Fields!.Contains("amount"));
+                var field = schema.Fields["amount"];
+                Assert.Equal(FieldDbType.Decimal, field.DbType);
+                Assert.Equal(15, field.Precision);
+                Assert.Equal(3, field.Scale);
+            }
+            finally
+            {
+                DropMySqlTable(dbAccess, tableName);
+            }
+        }
+
+        [DbFact(DatabaseType.MySQL)]
+        [DisplayName("MySQL SchemaProvider 讀取只有唯一索引（無 PK）的資料表時 ParsePrimaryKey 應提前返回且唯一索引仍正確解析")]
+        public void GetTableSchema_TableWithUniqueIndexNoPk_ParsePrimaryKeyReturnsEarlyAndIndexPresent()
+        {
+            const string tableName = "tb_ex_nopk";
+            string databaseId = TestDbConventions.GetDatabaseId(DatabaseType.MySQL);
+            var dbAccess = new DbAccess(databaseId);
+            DropMySqlTable(dbAccess, tableName);
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE tb_ex_nopk (code VARCHAR(20) NOT NULL) " +
+                    "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"));
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE UNIQUE INDEX UX_TB_EX_NOPK ON tb_ex_nopk (code)"));
+
+                var provider = new MySqlTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Fields!.Contains("code"));
+                Assert.NotEmpty(schema.Indexes!);
+                Assert.DoesNotContain(schema.Indexes!, idx => idx.PrimaryKey);
+            }
+            finally
+            {
+                DropMySqlTable(dbAccess, tableName);
+            }
+        }
+
+        private static void DropMySqlTable(DbAccess dbAccess, string tableName)
+        {
+            dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                "DROP TABLE IF EXISTS " + tableName));
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/OracleTableSchemaProviderNullAndExtraTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleTableSchemaProviderNullAndExtraTests.cs
@@ -1,0 +1,135 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.Oracle;
+using Bee.Tests.Shared;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="OracleTableSchemaProvider"/> NormalizeDataTypeName 邊界路徑：
+    /// null/empty 輸入、括號後有後綴文字、只有左括號無右括號。
+    /// </summary>
+    public class OracleTableSchemaProviderNullTests
+    {
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType null 輸入應回傳 Unknown")]
+        public void GetFieldDbType_NullDataType_ReturnsUnknown()
+        {
+            Assert.Equal(FieldDbType.Unknown, OracleTableSchemaProvider.GetFieldDbType(null!, 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType 空字串輸入應回傳 Unknown")]
+        public void GetFieldDbType_EmptyDataType_ReturnsUnknown()
+        {
+            Assert.Equal(FieldDbType.Unknown, OracleTableSchemaProvider.GetFieldDbType(string.Empty, 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType TIMESTAMP(6) WITH TIME ZONE 應回傳 Unknown（NormalizeDataTypeName 括號後有後綴文字的 after 分支）")]
+        public void GetFieldDbType_TimestampWithTimeZoneQualifier_ReturnsUnknown()
+        {
+            // NormalizeDataTypeName("TIMESTAMP(6) WITH TIME ZONE"):
+            // lower="timestamp(6) with time zone", parenStart=9, parenEnd=11
+            // before="timestamp", after=" with time zone" → result="timestamp with time zone"
+            // → 不在 switch → Unknown
+            Assert.Equal(FieldDbType.Unknown,
+                OracleTableSchemaProvider.GetFieldDbType("TIMESTAMP(6) WITH TIME ZONE", 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("Oracle GetFieldDbType 只有左括號無右括號時應回傳 Unknown（NormalizeDataTypeName parenEnd<0 分支）")]
+        public void GetFieldDbType_TypeWithOpenParenNoCloseParen_ReturnsUnknown()
+        {
+            // NormalizeDataTypeName("FLOAT("):
+            // lower="float(", parenStart=5, parenEnd=lower.IndexOf(')', 5)=-1
+            // → if (parenEnd < 0) return lower; → returns "float(" → switch default → Unknown
+            Assert.Equal(FieldDbType.Unknown,
+                OracleTableSchemaProvider.GetFieldDbType("FLOAT(", 0, 0, 0));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="OracleTableSchemaProvider"/> 整合測試：
+    /// 驗證 <c>ParseDbField</c> Decimal 分支（Precision/Scale 賦值）與
+    /// <c>ParsePrimaryKey</c> 在無主鍵時的提前返回路徑。
+    /// 依賴 Oracle 連線；環境變數未設時自動跳過。
+    /// </summary>
+    [Collection("Initialize")]
+    public class OracleTableSchemaProviderDecimalAndNoPkTests
+    {
+        [DbFact(DatabaseType.Oracle)]
+        [DisplayName("Oracle SchemaProvider 讀回 NUMBER(15,3) 欄位時應正確設定 Precision 與 Scale（ParseDbField Decimal 分支）")]
+        public void GetTableSchema_DecimalField_ReturnsPrecisionAndScale()
+        {
+            const string tableName = "tb_ex_decimal";
+            string databaseId = TestDbConventions.GetDatabaseId(DatabaseType.Oracle);
+            var dbAccess = new DbAccess(databaseId);
+            DropOracleTable(dbAccess, tableName);
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE \"TB_EX_DECIMAL\" " +
+                    "(\"id\" RAW(16) NOT NULL, \"amount\" NUMBER(15,3) NOT NULL, " +
+                    "CONSTRAINT \"PK_TB_EX_DECIMAL\" PRIMARY KEY (\"id\"))"));
+
+                var provider = new OracleTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Fields!.Contains("amount"));
+                var field = schema.Fields["amount"];
+                Assert.Equal(FieldDbType.Decimal, field.DbType);
+                Assert.Equal(15, field.Precision);
+                Assert.Equal(3, field.Scale);
+            }
+            finally
+            {
+                DropOracleTable(dbAccess, tableName);
+            }
+        }
+
+        [DbFact(DatabaseType.Oracle)]
+        [DisplayName("Oracle SchemaProvider 讀取只有唯一索引（無 PK）的資料表時 ParsePrimaryKey 應提前返回且唯一索引仍正確解析")]
+        public void GetTableSchema_TableWithUniqueIndexNoPk_ParsePrimaryKeyReturnsEarlyAndIndexPresent()
+        {
+            const string tableName = "tb_ex_nopk";
+            string databaseId = TestDbConventions.GetDatabaseId(DatabaseType.Oracle);
+            var dbAccess = new DbAccess(databaseId);
+            DropOracleTable(dbAccess, tableName);
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE \"TB_EX_NOPK\" (\"code\" VARCHAR2(20 CHAR) NOT NULL)"));
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE UNIQUE INDEX \"UX_TB_EX_NOPK\" ON \"TB_EX_NOPK\" (\"code\")"));
+
+                var provider = new OracleTableSchemaProvider(databaseId);
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Fields!.Contains("code"));
+                Assert.NotEmpty(schema.Indexes!);
+                Assert.DoesNotContain(schema.Indexes!, idx => idx.PrimaryKey);
+            }
+            finally
+            {
+                DropOracleTable(dbAccess, tableName);
+            }
+        }
+
+        private static void DropOracleTable(DbAccess dbAccess, string tableName)
+        {
+            string storageName = tableName.ToUpperInvariant();
+            string ddl =
+                "BEGIN " +
+                "  EXECUTE IMMEDIATE 'DROP TABLE \"" + storageName + "\" CASCADE CONSTRAINTS'; " +
+                "EXCEPTION WHEN OTHERS THEN IF SQLCODE != -942 THEN RAISE; END IF; " +
+                "END;";
+            dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery, ddl));
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/SqlTableSchemaProviderNullAndNoPkTests.cs
+++ b/tests/Bee.Db.UnitTests/SqlTableSchemaProviderNullAndNoPkTests.cs
@@ -1,0 +1,105 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Db.Providers.SqlServer;
+using Bee.Definition.Database;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補充 <see cref="SqlTableSchemaProvider"/> NormalizeDataTypeName 邊界路徑：
+    /// null/empty 輸入。
+    /// </summary>
+    public class SqlTableSchemaProviderNullTests
+    {
+        [Fact]
+        [DisplayName("SQL Server GetFieldDbType null 輸入應回傳 Unknown")]
+        public void GetFieldDbType_NullDataType_ReturnsUnknown()
+        {
+            Assert.Equal(FieldDbType.Unknown, SqlTableSchemaProvider.GetFieldDbType(null!, 0, 0, 0));
+        }
+
+        [Fact]
+        [DisplayName("SQL Server GetFieldDbType 空字串輸入應回傳 Unknown")]
+        public void GetFieldDbType_EmptyDataType_ReturnsUnknown()
+        {
+            Assert.Equal(FieldDbType.Unknown, SqlTableSchemaProvider.GetFieldDbType(string.Empty, 0, 0, 0));
+        }
+    }
+
+    /// <summary>
+    /// <see cref="SqlTableSchemaProvider"/> 整合測試：
+    /// 驗證 <c>ParseDbField</c> Decimal 分支（Precision/Scale 賦值）與
+    /// <c>ParsePrimaryKey</c> 在無主鍵時的提前返回路徑。
+    /// 依賴 SQL Server 連線；環境變數未設時自動跳過。
+    /// </summary>
+    [Collection("Initialize")]
+    public class SqlTableSchemaProviderDecimalAndNoPkTests
+    {
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("SQL Server SchemaProvider 讀回 DECIMAL(15,3) 欄位時應正確設定 Precision 與 Scale（ParseDbField Decimal 分支）")]
+        public void GetTableSchema_DecimalField_ReturnsPrecisionAndScale()
+        {
+            const string tableName = "tb_ex_decimal";
+            var dbAccess = new DbAccess("common_sqlserver");
+            DropSqlTable(dbAccess, tableName);
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE [tb_ex_decimal] " +
+                    "([id] UNIQUEIDENTIFIER NOT NULL, [amount] DECIMAL(15,3) NOT NULL, " +
+                    "CONSTRAINT [PK_TB_EX_DECIMAL] PRIMARY KEY ([id]))"));
+
+                var provider = new SqlTableSchemaProvider("common_sqlserver");
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Fields!.Contains("amount"));
+                var field = schema.Fields["amount"];
+                Assert.Equal(FieldDbType.Decimal, field.DbType);
+                Assert.Equal(15, field.Precision);
+                Assert.Equal(3, field.Scale);
+            }
+            finally
+            {
+                DropSqlTable(dbAccess, tableName);
+            }
+        }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("SQL Server SchemaProvider 讀取只有唯一索引（無 PK）的資料表時 ParsePrimaryKey 應提前返回且唯一索引仍正確解析")]
+        public void GetTableSchema_TableWithUniqueIndexNoPk_ParsePrimaryKeyReturnsEarlyAndIndexPresent()
+        {
+            const string tableName = "tb_ex_nopk";
+            var dbAccess = new DbAccess("common_sqlserver");
+            DropSqlTable(dbAccess, tableName);
+
+            try
+            {
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE TABLE [tb_ex_nopk] ([code] NVARCHAR(20) NOT NULL)"));
+                dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    "CREATE UNIQUE INDEX [UX_TB_EX_NOPK] ON [tb_ex_nopk] ([code])"));
+
+                var provider = new SqlTableSchemaProvider("common_sqlserver");
+                var schema = provider.GetTableSchema(tableName);
+
+                Assert.NotNull(schema);
+                Assert.True(schema!.Fields!.Contains("code"));
+                Assert.NotEmpty(schema.Indexes!);
+                Assert.DoesNotContain(schema.Indexes!, idx => idx.PrimaryKey);
+            }
+            finally
+            {
+                DropSqlTable(dbAccess, tableName);
+            }
+        }
+
+        private static void DropSqlTable(DbAccess dbAccess, string tableName)
+        {
+            dbAccess.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                "IF OBJECT_ID(N'[" + tableName + "]', N'U') IS NOT NULL DROP TABLE [" + tableName + "]"));
+        }
+    }
+}


### PR DESCRIPTION
## 摘要

針對 SonarCloud 回報覆蓋率不足（< 90%）的 `Bee.Db` 模組，補充三個新測試檔，涵蓋靜態方法邊界路徑與整合測試分支：

### 新增檔案

| 檔案 | 測試類型 | 涵蓋路徑 |
|------|---------|---------|
| `OracleTableSchemaProviderNullAndExtraTests.cs` | 靜態 + 整合（Oracle） | `NormalizeDataTypeName` `parenEnd<0` 與 `after≠""` 分支；`ParseDbField` Decimal；`ParsePrimaryKey` 無 PK 提前返回 |
| `MySqlTableSchemaProviderExtraTests.cs` | 整合（MySQL） | `ParseDbField` Decimal 分支（Precision/Scale 賦值）；`ParsePrimaryKey` 無 PK 提前返回 |
| `SqlTableSchemaProviderNullAndNoPkTests.cs` | 靜態 + 整合（SQL Server） | `GetFieldDbType` null/空字串輸入；`ParseDbField` Decimal；`ParsePrimaryKey` 無 PK 提前返回 |

### 無法處理（需重構才能覆蓋）

- `Bee.Api.AspNetCore/Controllers/ApiServiceController.cs`：`HandleRequestAsync` catch block 與 `IsDevelopment` property — 需要 `IHostEnvironment` 注入並強制 `ExecuteAsync` 拋例外，超出純測試範圍。
- `Bee.Definition/Security/MasterKeyProvider.cs`：`LoadFromFile` 中的 `IOException` catch block 與 `ReadAllTextShared` 重試迴圈 — 屬競態條件路徑，無法在測試中穩定觸發。

## 測試計畫

- [ ] 靜態測試（無 DB 依賴）：`OracleTableSchemaProviderNullTests`、`SqlTableSchemaProviderNullTests` — 直接執行即可驗證
- [ ] Oracle 整合測試：需設定 `BEE_TEST_CONNSTR_ORACLE` 環境變數（CI 已有 Oracle 23ai Free 容器）
- [ ] MySQL 整合測試：需設定 `BEE_TEST_CONNSTR_MYSQL` 環境變數（CI 已有 MySQL 8.0 容器）
- [ ] SQL Server 整合測試：需設定 `BEE_TEST_CONNSTR_SQLSERVER` 環境變數（CI 已有 SQL Server 2022 容器）
- [ ] 環境變數未設定時，所有 `[DbFact]` 測試自動 Skip，不影響 CI 通過

https://claude.ai/code/session_011Q2jYxvDw5bWX2d5DcFjzb

---
_Generated by [Claude Code](https://claude.ai/code/session_011Q2jYxvDw5bWX2d5DcFjzb)_