### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-08 12:30

### DIFF
--- a/tests/Bee.Db.UnitTests/PgFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/PgFormCommandBuilderTests.cs
@@ -85,5 +85,20 @@ namespace Bee.Db.UnitTests
 
             Assert.Contains("DELETE FROM \"tb_foo\"", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("BuildSelect 應委派至 PostgreSQL 方言並產生 SELECT 語句")]
+        public void BuildSelect_DelegatesToPostgreSqlDialect()
+        {
+            var schema = new FormSchema("X", "X");
+            var table = schema.Tables!.Add("Foo", "Foo");
+            table.DbTableName = "tb_foo";
+            table.Fields!.AddStringField("name", "Name", 50);
+
+            var builder = new PgFormCommandBuilder(schema);
+            var spec = builder.BuildSelect("Foo", "");
+
+            Assert.Contains("\"tb_foo\"", spec.CommandText);
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/UpgradePlanTests.cs
+++ b/tests/Bee.Db.UnitTests/UpgradePlanTests.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using Bee.Db.Schema;
+
+namespace Bee.Db.UnitTests
+{
+    public class UpgradePlanTests
+    {
+        private static readonly string[] s_createTableSql = { "CREATE TABLE t1 (id INT)" };
+        private static readonly string[] s_createIndexSql = { "CREATE INDEX idx ON t1(id)", "CREATE INDEX idx2 ON t1(id)" };
+        private static readonly string[] s_narrowingWarning = { "Narrowing change" };
+
+        [Fact]
+        [DisplayName("AllStatements 多個 stage 時應依序產出所有 SQL 語句")]
+        public void AllStatements_MultipleStages_YieldsAllInOrder()
+        {
+            var stage1 = new UpgradeStage(UpgradeStageKind.CreateTable, s_createTableSql);
+            var stage2 = new UpgradeStage(UpgradeStageKind.CreateIndexes, s_createIndexSql);
+            UpgradeStage[] stages = { stage1, stage2 };
+            var plan = new UpgradePlan(UpgradeExecutionMode.Create, stages);
+
+            var statements = plan.AllStatements.ToList();
+
+            Assert.Equal(3, statements.Count);
+            Assert.Equal(s_createTableSql[0], statements[0]);
+        }
+
+        [Fact]
+        [DisplayName("AllStatements stage 無語句時應回傳空集合")]
+        public void AllStatements_NoStages_ReturnsEmpty()
+        {
+            var plan = new UpgradePlan(UpgradeExecutionMode.NoChange);
+
+            Assert.Empty(plan.AllStatements);
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 warnings 應正確儲存警告清單")]
+        public void Constructor_WithWarnings_StoresWarnings()
+        {
+            var plan = new UpgradePlan(UpgradeExecutionMode.Alter, null, s_narrowingWarning);
+
+            Assert.Single(plan.Warnings);
+            Assert.Equal("Narrowing change", plan.Warnings[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/PostgreSql/PgFormCommandBuilder.cs` | 70.6% | 1 |
| `src/Bee.Db/Schema/UpgradePlan.cs` | 69.2% | 3 |

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` (89.4%) | `HandleRequestAsync` catch block 需 `JsonRpcExecutor.ExecuteAsync` 在其自身 try/catch 外拋出例外，現有架構下無法透過純單元測試觸發；補強須依賴 DI 注入或重構 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` (87.8%) | 未覆蓋行集中在 `LoadFromFile` 競態 IOException 分支與 `ReadAllTextShared` 重試迴圈，需並行實際檔案鎖定才能觸發 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` (76.0%) | `GetCommandText` 非空路徑（`foreach (var sql in plan.AllStatements)` 迴圈體）只在 DB schema 與定義不同步時才執行，需啟動 DB 並製造 schema 差異，無法以純單元測試覆蓋 |

---
_Generated by [Claude Code](https://claude.ai/code/session_0121WHn2QEYSmuBny9B3kLMX)_