### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-05-08 16:42

### DIFF
--- a/tests/Bee.Definition.UnitTests/Layouts/LayoutColumnCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Layouts/LayoutColumnCollectionTests.cs
@@ -22,14 +22,15 @@ namespace Bee.Definition.UnitTests.Layouts
         }
 
         [Fact]
-        [DisplayName("Add 應將新欄位加入集合，Count 增加為 1")]
-        public void Add_ValidParams_IncreasesCollectionCount()
+        [DisplayName("Add 應將欄位加入集合中，可由索引取出")]
+        public void Add_ValidParams_ColumnIsAddedToCollection()
         {
             var collection = new LayoutColumnCollection();
 
-            collection.Add("Name", "姓名", ControlType.TextEdit);
+            var column = collection.Add("Name", "姓名", ControlType.TextEdit);
 
-            Assert.Equal(1, collection.Count);
+            Assert.Single(collection);
+            Assert.Same(column, collection[0]);
         }
 
         [Fact]
@@ -38,10 +39,12 @@ namespace Bee.Definition.UnitTests.Layouts
         {
             var collection = new LayoutColumnCollection();
 
-            collection.Add("Field1", "欄位1", ControlType.TextEdit);
-            collection.Add("Field2", "欄位2", ControlType.CheckEdit);
+            var col1 = collection.Add("Field1", "欄位1", ControlType.TextEdit);
+            var col2 = collection.Add("Field2", "欄位2", ControlType.CheckEdit);
 
             Assert.Equal(2, collection.Count);
+            Assert.Same(col1, collection[0]);
+            Assert.Same(col2, collection[1]);
         }
     }
 }

--- a/tests/Bee.Definition.UnitTests/Layouts/LayoutColumnCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Layouts/LayoutColumnCollectionTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Bee.Definition.Layouts;
+
+namespace Bee.Definition.UnitTests.Layouts
+{
+    /// <summary>
+    /// LayoutColumnCollection 單元測試。
+    /// </summary>
+    public class LayoutColumnCollectionTests
+    {
+        [Fact]
+        [DisplayName("Add 應建立並回傳具正確屬性的 LayoutColumn")]
+        public void Add_ValidParams_ReturnsColumnWithCorrectProperties()
+        {
+            var collection = new LayoutColumnCollection();
+
+            var column = collection.Add("Amount", "金額", ControlType.TextEdit);
+
+            Assert.Equal("Amount", column.FieldName);
+            Assert.Equal("金額", column.Caption);
+            Assert.Equal(ControlType.TextEdit, column.ControlType);
+        }
+
+        [Fact]
+        [DisplayName("Add 應將新欄位加入集合，Count 增加為 1")]
+        public void Add_ValidParams_IncreasesCollectionCount()
+        {
+            var collection = new LayoutColumnCollection();
+
+            collection.Add("Name", "姓名", ControlType.TextEdit);
+
+            Assert.Equal(1, collection.Count);
+        }
+
+        [Fact]
+        [DisplayName("Add 多次呼叫應依序加入全部欄位")]
+        public void Add_MultipleCalls_AddsAllColumns()
+        {
+            var collection = new LayoutColumnCollection();
+
+            collection.Add("Field1", "欄位1", ControlType.TextEdit);
+            collection.Add("Field2", "欄位2", ControlType.CheckEdit);
+
+            Assert.Equal(2, collection.Count);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Layouts/LayoutColumnCollection.cs` | 0.0% | 3 |

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` (89.4%) | `HandleRequestAsync` catch block 為防禦性程式碼，`JsonRpcExecutor.ExecuteAsync` 已有自己的 catch-all，無法從外部觸發 500 例外路徑 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` (87.8%) | 未覆蓋行為為 `ReadAllTextShared` 的 IOException 重試邏輯及 `LoadFromFile` 的 race condition catch，需多執行緒環境或 OS 層 file lock 才能觸發，無法在單元測試中確定性重現 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` (76.0%) | `GetCommandText` 非空路徑需 schema drift（DB 與 form definition 不同步），現有 fixture 均已同步；在不修改共用 `tests/Define/` XML 或全域靜態狀態的前提下無法補測 |
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` (82.4%) | `Constructor(string progId)` 的 null check 路徑為防禦性程式碼：`FileDefineStorage.GetFormSchema` 對不存在的 progId 拋出 `FileNotFoundException` 而非回傳 null，需替換全域靜態 `BackendInfo.DefineAccess` 才能觸發，在 single-host 測試模式下有 race 風險 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8ExfvA7aCvLbswRJnhAsd)_