### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-09 00:56

### DIFF
--- a/tests/Bee.Api.AspNetCore.UnitTests/ApiServiceControllerTests.cs
+++ b/tests/Bee.Api.AspNetCore.UnitTests/ApiServiceControllerTests.cs
@@ -2,6 +2,9 @@ using System.ComponentModel;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 
 namespace Bee.Api.AspNetCore.UnitTests
 {
@@ -12,6 +15,19 @@ namespace Bee.Api.AspNetCore.UnitTests
     public class ApiServiceControllerTests
     {
         private sealed class TestController : Controllers.ApiServiceController { }
+
+        private sealed class IsDevelopmentController : Controllers.ApiServiceController
+        {
+            public bool GetIsDevelopment() => IsDevelopment;
+        }
+
+        private sealed class TestHostEnvironment : IHostEnvironment
+        {
+            public string EnvironmentName { get; set; } = "Production";
+            public string ApplicationName { get; set; } = "Test";
+            public string ContentRootPath { get; set; } = "/";
+            public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+        }
 
         private static async Task<IActionResult> PostAsync(
             string contentType,
@@ -105,6 +121,36 @@ namespace Bee.Api.AspNetCore.UnitTests
 
             var obj = Assert.IsType<ObjectResult>(result);
             Assert.Equal(StatusCodes.Status401Unauthorized, obj.StatusCode);
+        }
+
+        [Fact]
+        [DisplayName("IsDevelopment 在 Development 環境下應回傳 true")]
+        public void IsDevelopment_DevelopmentEnvironment_ReturnsTrue()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IHostEnvironment>(new TestHostEnvironment { EnvironmentName = "Development" });
+            var context = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+            var controller = new IsDevelopmentController
+            {
+                ControllerContext = new ControllerContext { HttpContext = context }
+            };
+
+            Assert.True(controller.GetIsDevelopment());
+        }
+
+        [Fact]
+        [DisplayName("IsDevelopment 在 Production 環境下應回傳 false")]
+        public void IsDevelopment_ProductionEnvironment_ReturnsFalse()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IHostEnvironment>(new TestHostEnvironment { EnvironmentName = "Production" });
+            var context = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+            var controller = new IsDevelopmentController
+            {
+                ControllerContext = new ControllerContext { HttpContext = context }
+            };
+
+            Assert.False(controller.GetIsDevelopment());
         }
     }
 }

--- a/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
@@ -38,5 +38,33 @@ namespace Bee.Db.UnitTests
 
             Assert.False(upgraded);
         }
+
+        [Fact]
+        [DisplayName("TableSchemaBuilder 建構子傳入 null 應擲 ArgumentNullException")]
+        public void Constructor_NullId_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TableSchemaBuilder(null!));
+        }
+
+        [Fact]
+        [DisplayName("TableSchemaBuilder 建構子傳入空字串應擲 ArgumentException")]
+        public void Constructor_EmptyId_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TableSchemaBuilder(""));
+        }
+
+        [Fact]
+        [DisplayName("TableSchemaBuilder 建構子傳入空白字串應擲 ArgumentException")]
+        public void Constructor_WhitespaceId_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TableSchemaBuilder("   "));
+        }
+
+        [Fact]
+        [DisplayName("TableSchemaBuilder 建構子傳入未登錄的資料庫 ID 應擲 KeyNotFoundException")]
+        public void Constructor_UnknownId_ThrowsKeyNotFoundException()
+        {
+            Assert.Throws<KeyNotFoundException>(() => new TableSchemaBuilder("__nonexistent_db__"));
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | 89.4% | 2 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 76.0% | 4 |

### 無法處理

| 檔案 | 補強前覆蓋率 | 無法處理原因 |
|------|------------|------------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% | 未覆蓋路徑為 `LoadFromFile` 中的競速例外捕捉（`catch (IOException)` 於 `FileMode.CreateNew` 失敗時）與 `ReadAllTextShared` 的重試邏輯，需複雜並發測試環境才能觸發，純單元測試無法模擬 |
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` | 82.4% | 未覆蓋路徑為 `if (FormSchema == null) throw new ArgumentException(...)` — 實際上 `GetFormSchema` 找不到 ProgId 時直接拋出 `FileNotFoundException`，null check 分支為死碼，無法在不 mock `BackendInfo.DefineAccess` 的情況下觸發 |
| `src/Bee.Db/Providers/Oracle/OracleFormCommandBuilder.cs` | 82.4% | 同上 |

https://claude.ai/code/session_01TzC4RSDMxr8SWE5ZTykLt9

---
_Generated by [Claude Code](https://claude.ai/code/session_01TzC4RSDMxr8SWE5ZTykLt9)_