### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-09 08:45

### DIFF
--- a/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
@@ -97,5 +97,13 @@ namespace Bee.Db.UnitTests
 
             Assert.Contains("DELETE FROM `tb_foo`", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("ProgID 建構子有效 ProgID 應成功建立實例")]
+        public void Constructor_ValidProgId_Succeeds()
+        {
+            var exception = Record.Exception(() => new MySqlFormCommandBuilder("Department"));
+            Assert.Null(exception);
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/OracleFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleFormCommandBuilderTests.cs
@@ -115,5 +115,13 @@ namespace Bee.Db.UnitTests
             // 透過 DatabaseType.Oracle.GetParameterPrefix() 注入，純語法測試不涵蓋。
             Assert.Contains("{0}", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("ProgID 建構子有效 ProgID 應成功建立實例")]
+        public void Constructor_ValidProgId_Succeeds()
+        {
+            var exception = Record.Exception(() => new OracleFormCommandBuilder("Department"));
+            Assert.Null(exception);
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
@@ -38,5 +38,15 @@ namespace Bee.Db.UnitTests
 
             Assert.False(upgraded);
         }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("GetCommandText 資料表不存在時應回傳非空 SQL 字串")]
+        public void GetCommandText_TableNotExists_ReturnsNonEmptySql()
+        {
+            var builder = new TableSchemaBuilder("common_sqlserver");
+            // ft_department 定義存在但 DB 中未建立，差異非空
+            string sql = builder.GetCommandText("common", "ft_department");
+            Assert.False(string.IsNullOrWhiteSpace(sql));
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 76.0% | 1 |
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` | 82.4% | 1 |
| `src/Bee.Db/Providers/Oracle/OracleFormCommandBuilder.cs` | 82.4% | 1 |

### 測試說明

**`TableSchemaBuilder`** — `GetCommandText_TableNotExists_ReturnsNonEmptySql`
補強 `GetCommandText` 的非空計畫路徑（lines 90–97）。使用 `ft_department`（定義存在於 `tests/Define/TableSchema/common/` 但 DB 中未建立），觸發 CREATE TABLE 計畫，驗證回傳非空 SQL。標記 `[DbFact(DatabaseType.SQLServer)]`，無 SQL Server 連線時自動略過。

**`MySqlFormCommandBuilder`** — `Constructor_ValidProgId_Succeeds`
補強 progId 字串建構子的成功路徑（line 30），使用有效 ProgID `"Department"`（`tests/Define/FormSchema/Department.FormSchema.xml` 存在），驗證建構子可成功返回而不拋出例外。

**`OracleFormCommandBuilder`** — `Constructor_ValidProgId_Succeeds`
同 MySQL，補強 progId 建構子成功路徑。

---

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | `HandleRequestAsync` 的 catch block（7 行）僅在 `JsonRpcExecutor.ExecuteAsync` 拋出例外時觸發，但 `ExecuteAsyncCore` 本身有 try-catch 攔截所有例外，純單元測試無法觸發此路徑；`IsDevelopment` getter 僅在 catch block 中調用，因此同樣無法覆蓋。需重構 src/ 注入 executor 才能測試。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 個未覆蓋行均為 I/O 競爭路徑：`LoadFromFile` 的 `FileMode.CreateNew` IOException catch（多進程競爭才觸發）、`ReadAllTextShared` 的 IOException 重試迴圈（需要並發 I/O 衝突環境），純單元測試無法可靠重現。 |

https://claude.ai/code/session_01VNiCooHyczaUaWH8U2sMZf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNiCooHyczaUaWH8U2sMZf)_