### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-09 16:53

### DIFF
--- a/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
@@ -97,5 +97,29 @@ namespace Bee.Db.UnitTests
 
             Assert.Contains("DELETE FROM `tb_foo`", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("ProgID 建構子使用有效 ProgId 應成功載入 FormSchema")]
+        public void Constructor_ValidProgId_LoadsFormSchema()
+        {
+            var exception = Record.Exception(() => new MySqlFormCommandBuilder("Employee"));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("ProgID 建構子 GetFormSchema 回傳 null 應擲 ArgumentException")]
+        public void Constructor_ProgId_WhenGetFormSchemaReturnsNull_ThrowsArgumentException()
+        {
+            var original = BackendInfo.DefineAccess;
+            BackendInfo.DefineAccess = new NullFormSchemaAccess();
+            try
+            {
+                Assert.Throws<ArgumentException>(() => new MySqlFormCommandBuilder("any"));
+            }
+            finally
+            {
+                BackendInfo.DefineAccess = original;
+            }
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/NullFormSchemaAccess.cs
+++ b/tests/Bee.Db.UnitTests/NullFormSchemaAccess.cs
@@ -1,0 +1,33 @@
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 測試用的 IDefineAccess 實作，GetFormSchema 永遠回傳 null，
+    /// 用於覆蓋 FormCommandBuilder 建構子的 null 防禦分支。
+    /// </summary>
+    internal sealed class NullFormSchemaAccess : IDefineAccess
+    {
+        public FormSchema GetFormSchema(string progId) => null!;
+        public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+        public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+        public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+        public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+        public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+        public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+        public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+        public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+        public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+        public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+        public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+        public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+        public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+        public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+        public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+    }
+}

--- a/tests/Bee.Db.UnitTests/OracleFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleFormCommandBuilderTests.cs
@@ -115,5 +115,29 @@ namespace Bee.Db.UnitTests
             // 透過 DatabaseType.Oracle.GetParameterPrefix() 注入，純語法測試不涵蓋。
             Assert.Contains("{0}", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("ProgID 建構子使用有效 ProgId 應成功載入 FormSchema")]
+        public void Constructor_ValidProgId_LoadsFormSchema()
+        {
+            var exception = Record.Exception(() => new OracleFormCommandBuilder("Employee"));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("ProgID 建構子 GetFormSchema 回傳 null 應擲 ArgumentException")]
+        public void Constructor_ProgId_WhenGetFormSchemaReturnsNull_ThrowsArgumentException()
+        {
+            var original = BackendInfo.DefineAccess;
+            BackendInfo.DefineAccess = new NullFormSchemaAccess();
+            try
+            {
+                Assert.Throws<ArgumentException>(() => new OracleFormCommandBuilder("any"));
+            }
+            finally
+            {
+                BackendInfo.DefineAccess = original;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` | 82.4% | 2 |
| `src/Bee.Db/Providers/Oracle/OracleFormCommandBuilder.cs` | 82.4% | 2 |

### 補強說明

兩個檔案的 3 個未覆蓋行均位於 progId 建構子：

```csharp
FormSchema = BackendInfo.DefineAccess.GetFormSchema(progId);  // 從未完整執行到賦值
if (FormSchema == null)                                         // 從未到達
    throw new ArgumentException(...);                           // 從未到達
```

根因：`LocalDefineAccess.GetFormSchema` 對不存在的 ProgId 直接拋出 `FileNotFoundException`，賦值前即中斷，導致後兩行永遠不被執行。

新增測試：
- `Constructor_ValidProgId_LoadsFormSchema`：以測試夾具中的有效 ProgId（`Employee`）呼叫建構子，確認賦值路徑完整執行
- `Constructor_ProgId_WhenGetFormSchemaReturnsNull_ThrowsArgumentException`：透過 `NullFormSchemaAccess` stub 讓 `GetFormSchema` 回傳 null，覆蓋 null 檢查與 `ArgumentException` 拋出路徑

### 無法處理（3 筆）

| 檔案 | 覆蓋率 | 原因 |
|------|--------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | 89.4% | `HandleRequestAsync` catch 路徑：`JsonRpcExecutor.ExecuteAsync()` 內建 try-catch 永遠回傳 `JsonRpcResponse`，外層 catch block 實際上為死碼，純單元測試無法觸發 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% | `LoadFromFile` 競爭條件 catch 與 `ReadAllTextShared` 重試路徑：需模擬並發檔案存取，純單元測試難以可靠重現 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 76.0% | `GetCommandText` 的 StringBuilder 迴圈路徑（`plan.IsEmpty` 為 false 時）：需要目標資料表與定義存在 schema drift，在自動化測試中難以安全建立此狀態 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01RAH2RrGPPk4i6EawDvbJF5)_