### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-10 00:30

### DIFF
--- a/tests/Bee.Db.UnitTests/PgFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/PgFormCommandBuilderTests.cs
@@ -26,6 +26,14 @@ namespace Bee.Db.UnitTests
         }
 
         [Fact]
+        [DisplayName("ProgID 建構子指定有效 FormSchema ID 應成功建立")]
+        public void Constructor_ValidProgId_CreatesSuccessfully()
+        {
+            var exception = Record.Exception(() => new PgFormCommandBuilder("Employee"));
+            Assert.Null(exception);
+        }
+
+        [Fact]
         [DisplayName("BuildInsert 應委派至 PostgreSQL 方言並產生 INSERT 語句")]
         public void BuildInsert_DelegatesToPostgreSqlDialect()
         {

--- a/tests/Bee.Db.UnitTests/SqliteFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/SqliteFormCommandBuilderTests.cs
@@ -36,6 +36,14 @@ namespace Bee.Db.UnitTests
         }
 
         [Fact]
+        [DisplayName("ProgID 建構子指定有效 FormSchema ID 應成功建立")]
+        public void Constructor_ValidProgId_CreatesSuccessfully()
+        {
+            var exception = Record.Exception(() => new SqliteFormCommandBuilder("Employee"));
+            Assert.Null(exception);
+        }
+
+        [Fact]
         [DisplayName("BuildSelect 應委派至 SQLite 方言並產生 SELECT 語句")]
         public void BuildSelect_DelegatesToSqliteDialect()
         {

--- a/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
@@ -38,5 +38,23 @@ namespace Bee.Db.UnitTests
 
             Assert.False(upgraded);
         }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("TableSchemaBuilder GetCommandText 指定未存在於 DB 的資料表應回傳非空 SQL")]
+        public void GetCommandText_NewTable_SqlServer_ReturnsNonEmptyScript()
+        {
+            var builder = new TableSchemaBuilder("common_sqlserver");
+            string sql = builder.GetCommandText("common", "ft_project");
+            Assert.NotEmpty(sql);
+        }
+
+        [DbFact(DatabaseType.PostgreSQL)]
+        [DisplayName("TableSchemaBuilder GetCommandText PostgreSQL 指定未存在於 DB 的資料表應回傳非空 SQL")]
+        public void GetCommandText_NewTable_PostgreSql_ReturnsNonEmptyScript()
+        {
+            var builder = new TableSchemaBuilder("common_postgresql");
+            string sql = builder.GetCommandText("common", "ft_project");
+            Assert.NotEmpty(sql);
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 76.0% | 2 |
| `src/Bee.Db/Providers/Sqlite/SqliteFormCommandBuilder.cs` | 82.4% | 1 |
| `src/Bee.Db/Providers/PostgreSql/PgFormCommandBuilder.cs` | 82.4% | 1 |

### 補強說明

**TableSchemaBuilder** — 新增 `[DbFact(SQLServer)]` 與 `[DbFact(PostgreSQL)]` 測試，使用已定義於 XML（`tests/Define/TableSchema/common/ft_project.TableSchema.xml`）但未在測試 DB 建立的資料表 `ft_project`，觸發 `GetCommandText` 非空計畫路徑（lines 90–97），涵蓋 `StringBuilder` 組裝、空行過濾、`AppendLine` 等 6 個未覆蓋行。

**SqliteFormCommandBuilder / PgFormCommandBuilder** — 新增以有效 `progID`（`"Employee"`）呼叫建構子的測試，覆蓋 `GetFormSchema` 成功回傳後的賦值行與 null 檢查分支；`throw new ArgumentException` 行（null 永不出現）為防禦性死碼，無法觸發，列入無法處理。

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | `HandleRequestAsync` catch block 與 `IsDevelopment` 僅在 `executor.ExecuteAsync` 拋出時才執行；但 `JsonRpcExecutor.ExecuteAsyncCore` 內部已完整攔截所有 exception，永不向上拋出，導致這 7 行為結構性死碼。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋行位於 `LoadFromFile` 的 `catch (IOException)`（FileMode.CreateNew 競爭條件）與 `ReadAllTextShared` 的重試邏輯；需 OS 層級並發操控，無法在單元測試中可靠重現。 |

https://claude.ai/code/session_012bBf3UCrkabghKuKRASAxR

---
_Generated by [Claude Code](https://claude.ai/code/session_012bBf3UCrkabghKuKRASAxR)_