### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-10 08:49

### DIFF
--- a/tests/Bee.Api.AspNetCore.UnitTests/ApiServiceControllerIsDevelopmentTests.cs
+++ b/tests/Bee.Api.AspNetCore.UnitTests/ApiServiceControllerIsDevelopmentTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
 
@@ -21,6 +20,14 @@ namespace Bee.Api.AspNetCore.UnitTests
             public IFileProvider ContentRootFileProvider { get; set; } = null!;
         }
 
+        private sealed class FakeServiceProvider : IServiceProvider
+        {
+            private readonly IHostEnvironment _env;
+            public FakeServiceProvider(IHostEnvironment env) => _env = env;
+            public object? GetService(Type serviceType) =>
+                serviceType == typeof(IHostEnvironment) ? _env : null;
+        }
+
         private sealed class TestableController : Controllers.ApiServiceController
         {
             public bool GetIsDevelopment() => IsDevelopment;
@@ -28,9 +35,8 @@ namespace Bee.Api.AspNetCore.UnitTests
 
         private static TestableController CreateController(string environmentName)
         {
-            var services = new ServiceCollection();
-            services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment { EnvironmentName = environmentName });
-            var context = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+            var env = new FakeHostEnvironment { EnvironmentName = environmentName };
+            var context = new DefaultHttpContext { RequestServices = new FakeServiceProvider(env) };
             return new TestableController { ControllerContext = new ControllerContext { HttpContext = context } };
         }
 

--- a/tests/Bee.Api.AspNetCore.UnitTests/ApiServiceControllerIsDevelopmentTests.cs
+++ b/tests/Bee.Api.AspNetCore.UnitTests/ApiServiceControllerIsDevelopmentTests.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace Bee.Api.AspNetCore.UnitTests
+{
+    /// <summary>
+    /// 測試 <see cref="Controllers.ApiServiceController.IsDevelopment"/> 屬性。
+    /// </summary>
+    [Collection("Initialize")]
+    public class ApiServiceControllerIsDevelopmentTests
+    {
+        private sealed class FakeHostEnvironment : IHostEnvironment
+        {
+            public required string EnvironmentName { get; set; }
+            public string ApplicationName { get; set; } = string.Empty;
+            public string ContentRootPath { get; set; } = string.Empty;
+            public IFileProvider ContentRootFileProvider { get; set; } = null!;
+        }
+
+        private sealed class TestableController : Controllers.ApiServiceController
+        {
+            public bool GetIsDevelopment() => IsDevelopment;
+        }
+
+        private static TestableController CreateController(string environmentName)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment { EnvironmentName = environmentName });
+            var context = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+            return new TestableController { ControllerContext = new ControllerContext { HttpContext = context } };
+        }
+
+        [Fact]
+        [DisplayName("IsDevelopment 在 Development 環境應回傳 true")]
+        public void IsDevelopment_DevelopmentEnvironment_ReturnsTrue()
+        {
+            var controller = CreateController(Environments.Development);
+            Assert.True(controller.GetIsDevelopment());
+        }
+
+        [Fact]
+        [DisplayName("IsDevelopment 在 Production 環境應回傳 false")]
+        public void IsDevelopment_ProductionEnvironment_ReturnsFalse()
+        {
+            var controller = CreateController(Environments.Production);
+            Assert.False(controller.GetIsDevelopment());
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderValidProgIdTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderValidProgIdTests.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using Bee.Db.Providers.MySql;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="MySqlFormCommandBuilder"/> progId 建構子的成功路徑覆蓋率。
+    /// </summary>
+    [Collection("Initialize")]
+    public class MySqlFormCommandBuilderValidProgIdTests
+    {
+        [Fact]
+        [DisplayName("ProgId 建構子有效程式代碼應正常建立實例")]
+        public void Constructor_ValidProgId_Succeeds()
+        {
+            var exception = Record.Exception(() => new MySqlFormCommandBuilder("Employee"));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/OracleFormCommandBuilderValidProgIdTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleFormCommandBuilderValidProgIdTests.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+using Bee.Db.Providers.Oracle;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="OracleFormCommandBuilder"/> progId 建構子的成功路徑覆蓋率。
+    /// </summary>
+    [Collection("Initialize")]
+    public class OracleFormCommandBuilderValidProgIdTests
+    {
+        [Fact]
+        [DisplayName("ProgId 建構子有效程式代碼應正常建立實例")]
+        public void Constructor_ValidProgId_Succeeds()
+        {
+            var exception = Record.Exception(() => new OracleFormCommandBuilder("Employee"));
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 | 說明 |
|------|------------|---------|------|
| `src/Bee.Api.AspNetCore/Controllers/ApiServiceController.cs` | 89.4% | 2 | 補 `IsDevelopment` 屬性覆蓋率（Development / Production 兩個環境情境） |
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` | 82.4% | 1 | 補 progId 建構子成功路徑覆蓋率（使用有效 FormSchema "Employee"） |
| `src/Bee.Db/Providers/Oracle/OracleFormCommandBuilder.cs` | 82.4% | 1 | 補 progId 建構子成功路徑覆蓋率（使用有效 FormSchema "Employee"） |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 條未涵蓋行全部位於 `ReadAllTextShared` 的 IOException 重試邏輯（`Thread.Sleep` / `attempt++`）與 `LoadFromFile` autoCreate 的競爭條件 catch 區塊，需要並行檔案存取模擬才能觸發，否則會引入不穩定測試。 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純 C# interface，無可執行程式碼；SonarCloud 回報 2 條未涵蓋行屬分析工具統計方式的邊緣情況，無法透過撰寫測試來覆蓋介面宣告行。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_015pftrzY8MQRS1Y6E7iCPvy)_