### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-10 16:40

### DIFF
--- a/tests/Bee.Definition.UnitTests/Forms/FieldMappingTests.cs
+++ b/tests/Bee.Definition.UnitTests/Forms/FieldMappingTests.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel;
+using Bee.Definition.Forms;
+
+namespace Bee.Definition.UnitTests.Forms
+{
+    public class FieldMappingTests
+    {
+        [Fact]
+        [DisplayName("ToString 應回傳 \"{SourceField} -> {DestinationField}\" 格式")]
+        public void ToString_ReturnsFormattedString()
+        {
+            var mapping = new FieldMapping("dept_name", "name");
+
+            Assert.Equal("dept_name -> name", mapping.ToString());
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Forms/RelationFieldReferenceTests.cs
+++ b/tests/Bee.Definition.UnitTests/Forms/RelationFieldReferenceTests.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+
+namespace Bee.Definition.UnitTests.Forms
+{
+    public class RelationFieldReferenceTests
+    {
+        [Fact]
+        [DisplayName("預設建構子應建立 FieldName/SourceProgId/SourceField 皆為空字串的實例")]
+        public void DefaultConstructor_CreatesInstance_WithEmptyFields()
+        {
+            var reference = new RelationFieldReference();
+
+            Assert.Equal(string.Empty, reference.FieldName);
+            Assert.Equal(string.Empty, reference.SourceProgId);
+            Assert.Equal(string.Empty, reference.SourceField);
+        }
+
+        [Fact]
+        [DisplayName("ToString 應回傳 \"{SourceProgId}.{SourceField} -> {FieldName}\" 格式")]
+        public void ToString_ReturnsFormattedString()
+        {
+            var field = new FormField("dept_id", "部門 ID", FieldDbType.String);
+            var reference = new RelationFieldReference("dept_id", field, "Department", "dept_name");
+
+            Assert.Equal("Department.dept_name -> dept_id", reference.ToString());
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/DatabaseSettingsCacheTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/DatabaseSettingsCacheTests.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel;
+using Bee.ObjectCaching.Define;
+using Bee.Tests.Shared;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    [Collection("Initialize")]
+    public class DatabaseSettingsCacheTests
+    {
+        [Fact]
+        [DisplayName("CreateInstance 在 DatabaseSettings.xml 不存在時應拋出 FileNotFoundException")]
+        public void CreateInstance_FileMissing_ThrowsFileNotFoundException()
+        {
+            var cache = new DatabaseSettingsCache();
+            cache.Remove();
+
+            using var temp = new TempDefinePath();
+
+            Assert.Throws<FileNotFoundException>(() => cache.Get());
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Forms/RelationFieldReference.cs` | 84.6% | 2 |
| `src/Bee.Definition/Forms/FieldMapping.cs` | 88.9% | 1 |
| `src/Bee.ObjectCaching/Define/DatabaseSettingsCache.cs` | 88.9% | 1 |

## 無法處理

| 檔案 | 補強前覆蓋率 | 原因 |
|------|------------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% | 未覆蓋行位於私有方法的 race condition 處理路徑（`LoadFromFile` 的 `catch (IOException)` 及 `ReadAllTextShared` 的 retry），無法在不模擬檔案系統故障的情況下測試 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 0.0% | Interface，無可執行的實作程式碼，SonarCloud 覆蓋率回報為 false positive |


---
_Generated by [Claude Code](https://claude.ai/code/session_01CFnU8nCNaeqAHKHnWEgNU5)_