### PR TITLE
fix(security): 修補存取策略三項問題（P0/P1/P3）

### DIFF
--- a/docs/plans/plan-access-strategy-remediation.md
+++ b/docs/plans/plan-access-strategy-remediation.md
@@ -1,0 +1,226 @@
+# 計畫：存取策略修補
+
+**狀態：📝 擬定中**
+
+## 背景
+
+存取策略審查發現四項待修補問題，依嚴重程度排序：
+
+| 編號 | 問題 | 嚴重性 |
+|------|------|--------|
+| P0 | 解密先於授權 | 🔴 高 |
+| P1 | `BackendInfo` 缺啟動期驗證 | 🟡 中 |
+| P3 | `ApiAccessControlAttribute` 不支援 Class 層級 | 🟡 中 |
+| P4 | 缺細粒度授權（RBAC）框架 | 🟢 低（需另立計畫） |
+
+> P2（IsLocalCall 信任問題）已確認為設計正確行為，不納入修補範圍。
+
+---
+
+## P0：解密先於授權
+
+### 問題描述
+
+`JsonRpcExecutor.ExecuteAsyncCore()` 目前執行順序：
+
+```
+GetApiEncryptionKey(format)        // 取 Session Key（AccessToken → SessionInfoService）
+RestoreFrom(...)                   // Decrypt → Decompress → Deserialize  ← 先解密
+ParseMethod(request.Method)
+ExecuteMethodAsync()
+  └─ CreateBusinessObject()
+  └─ GetMethod(action)
+  └─ ApiAccessValidator.ValidateAccess()  // Token 驗證才在這裡
+  └─ method.Invoke()
+```
+
+**攻擊面**：伺服器在確認 AccessToken 有效之前已完成解密。若配置使用共用靜態金鑰（`BackendInfo.ApiEncryptionKey`），未認證的請求可觸發完整的反序列化路徑，造成：
+- CPU / 記憶體資源濫用
+- 在 MessagePack 反序列化路徑中暴露潛在的反序列化漏洞面
+
+### 核心挑戰
+
+Token 預驗的困難在於：在解密之前，我們無法取得 `ApiAccessControlAttribute`（需要知道 progId 與 action 才能 Reflect 取得 method），而不知道 AccessRequirement 就無法決定是否需要驗 Token（Login 等 Anonymous API 不需要 Token）。
+
+然而，`request.Method` 是明文欄位（不在加密 Payload 中），可以在解密前就取得 progId 與 action。
+
+### 解決方案
+
+**在解密前先 Parse Method，再做 Token 預驗**：
+
+```
+ParseMethod(request.Method)                  // 移至最前
+FindAccessAttribute(progId, action)          // 取得 ApiAccessControlAttribute
+if Authenticated → PreValidateToken()        // Token 預驗，無效直接 throw
+GetApiEncryptionKey(format)                  // 有效才取 Key
+RestoreFrom(...)                             // 才解密
+ExecuteMethodAsync()
+  └─ CreateBusinessObject()
+  └─ GetMethod(action)
+  └─ ApiAccessValidator.ValidateAccess()     // 完整驗證（含 Format 檢查）
+  └─ method.Invoke()
+```
+
+### 實作細節
+
+1. 新增 `FindAccessAttributeForMethod(progId, action)` 靜態輔助方法，在不建立 BO 實例的情況下透過 Reflection 找到對應 MethodInfo 並取得 attribute。
+
+2. 「預驗 Token」只做最低限度檢查（Guid.Empty 與 Session 存在性 + 過期），不重複完整的 Format 驗證（完整驗證仍由 `ApiAccessValidator.ValidateAccess` 執行，避免邏輯重複）。
+
+3. 此重構不影響 `ApiAccessValidator` 的邏輯，完整驗證路徑不變。
+
+### 影響範圍
+
+- `Bee.Api.Core/JsonRpc/JsonRpcExecutor.cs`（主要改動）
+- `Bee.Api.Core/Validator/ApiAccessValidator.cs`（可能新增 static helper）
+- 對應單元測試需新增「Token 無效時應在解密前 throw」的測試案例
+
+### 風險
+
+- `FindAccessAttributeForMethod` 需要能在不建立 BO 實例的情況下 Reflect，需確認 BO 型別解析路徑與 `CreateBusinessObject` 一致，避免兩段邏輯不同步。
+
+---
+
+## P1：`BackendInfo` 缺啟動期驗證
+
+### 問題描述
+
+三個必要元件以 `null!` 初始化：
+
+```csharp
+// Bee.Definition/BackendInfo.cs
+public static IApiEncryptionKeyProvider ApiEncryptionKeyProvider { get; set; } = null!;
+public static IAccessTokenValidator AccessTokenValidator { get; set; } = null!;
+public static IBusinessObjectFactory BusinessObjectFactory { get; set; } = null!;
+```
+
+若 `BackendInfo.Initialize()` 未被呼叫，或 `InitializeComponents` 因某些原因未完整執行，系統在第一次收到請求時才會拋出 `NullReferenceException`，且錯誤訊息不明確。
+
+### 解決方案
+
+在 `BackendInfo.Initialize()` 末尾新增 `ValidateComponents()` 呼叫，啟動時快速失敗：
+
+```csharp
+private static void ValidateComponents()
+{
+    if (SysInfo.IsSingleFile)
+        return;  // Single-file 模式不使用這些元件
+
+    if (ApiEncryptionKeyProvider == null)
+        throw new InvalidOperationException(
+            $"{nameof(ApiEncryptionKeyProvider)} is not configured. Call BackendInfo.Initialize() with a valid configuration.");
+    if (AccessTokenValidator == null)
+        throw new InvalidOperationException(...);
+    if (BusinessObjectFactory == null)
+        throw new InvalidOperationException(...);
+}
+```
+
+### 影響範圍
+
+- `Bee.Definition/BackendInfo.cs`（新增 `ValidateComponents` + 於 `Initialize` 末尾呼叫）
+- 單元測試：驗證未配置時的啟動期例外
+
+### 注意事項
+
+`SysInfo.IsSingleFile` 分支不使用這些元件，驗證需跳過（如現行 `InitializeComponents` 的做法）。
+
+---
+
+## P3：`ApiAccessControlAttribute` 不支援 Class 層級
+
+### 問題描述
+
+```csharp
+[AttributeUsage(AttributeTargets.Method, Inherited = true)]
+public class ApiAccessControlAttribute : Attribute { ... }
+```
+
+目前每個 BO 方法都必須逐一標注。新增方法時若遺漏，會在執行期拋出例外（Fail-Closed，行為正確），但開發體驗不佳，且每個 BO class 都有大量重複的屬性宣告。
+
+### 解決方案
+
+**擴充 `AttributeTargets.Method | AttributeTargets.Class`，並更新查找順序**：
+
+```csharp
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true)]
+public class ApiAccessControlAttribute : Attribute { ... }
+```
+
+查找順序（由特殊到一般）：
+1. Method 上的直接 `[ApiAccessControl]`（最高優先）
+2. Method 的 base definition 上的 `[ApiAccessControl]`（override 繼承）
+3. Method 的 `DeclaringType`（Class）上的 `[ApiAccessControl]`（class 預設）
+4. `null` → throw `UnauthorizedAccessException`（Fail-Closed 維持）
+
+### 典型使用場景
+
+```csharp
+// Class 層級設定預設：全部 Encrypted + Authenticated
+[ApiAccessControl(ApiProtectionLevel.Encrypted)]
+public class OrderBusinessObject : BusinessObjectBase
+{
+    // 繼承 class 預設，無需重複標注
+    public OrderResult GetOrder(GetOrderArgs args) { ... }
+
+    // 特例：覆蓋為公開 API
+    [ApiAccessControl(ApiProtectionLevel.Public, ApiAccessRequirement.Anonymous)]
+    public PingResult Ping(PingArgs args) { ... }
+}
+```
+
+### 影響範圍
+
+- `Bee.Definition/Attributes/ApiAccessControlAttribute.cs`（`AttributeUsage` 修改）
+- `Bee.Api.Core/Validator/ApiAccessValidator.cs`（`FindAccessAttribute` 擴充查找邏輯）
+- 現有所有 BO 可**選擇性**遷移至 class 層級宣告（不影響現有方法層級標注）
+- 需新增測試案例：class 層級屬性繼承、方法層級覆蓋 class 層級
+
+### 向下相容性
+
+現有標注方式完全相容，不需強制遷移。
+
+---
+
+## P4：細粒度授權（RBAC）
+
+### 問題描述
+
+目前框架僅有二元授權：`Anonymous` vs `Authenticated`。所有已登入使用者對同一 API 具有相同存取權，業務層無法宣告式地表達「只有管理員可呼叫」這類需求。
+
+### 評估
+
+此項改動對架構影響較大（涉及 Session 中的使用者角色/權限欄位、Attribute 宣告方式、執行期驗證邏輯），且未知現有 BO 層是否已有自己的授權實作。
+
+**建議**：另立獨立計畫，進行充分的需求討論後再設計實作方案。本修補計畫暫不納入。
+
+---
+
+## 執行順序
+
+```
+P1（BackendInfo 啟動驗證）   ← 改動最小，安全網最直接
+P0（解密先於授權）           ← 核心安全問題，需仔細測試
+P3（Class 層級屬性）         ← 功能增強，向下相容
+P4（RBAC）                   ← 另立計畫
+```
+
+P1 先做是因為它是安全網——若 P0 改動中有初始化相關的錯誤，P1 的驗證機制能在啟動期提前暴露問題。
+
+---
+
+## 受影響檔案清單（預估）
+
+### Bee.Definition
+- `BackendInfo.cs`
+
+### Bee.Definition（Attributes）
+- `Attributes/ApiAccessControlAttribute.cs`
+
+### Bee.Api.Core
+- `JsonRpc/JsonRpcExecutor.cs`
+- `Validator/ApiAccessValidator.cs`
+
+### Tests
+- `tests/Bee.Api.Core.UnitTests/` — P0、P3 驗證
+- `tests/Bee.Definition.UnitTests/` — P1 驗證

--- a/src/Bee.Api.Core/JsonRpc/JsonRpcExecutor.cs
+++ b/src/Bee.Api.Core/JsonRpc/JsonRpcExecutor.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Bee.Base;
 using Bee.Base.Tracing;
 using Bee.Definition;
@@ -63,24 +64,25 @@ namespace Bee.Api.Core.JsonRpc
             var response = new JsonRpcResponse(request);
             try
             {
-                // Payload transmission format
                 var format = request.Params.Format;
-                // Get the API encryption key
+
+                // Parse method, create BO, and validate access BEFORE decryption.
+                // This ensures unauthenticated or unauthorized requests are rejected without
+                // performing any decryption work.
+                var (progId, action) = ParseMethod(request.Method);
+                var businessObject = CreateBusinessObject(AccessToken, progId);
+                var method = GetMethod(businessObject, action);
+                ApiAccessValidator.ValidateAccess(method, new ApiCallContext(AccessToken, IsLocalCall, format));
+
+                // Access confirmed: retrieve the encryption key and decrypt the payload.
                 byte[]? apiEncryptionKey = GetApiEncryptionKey(format);
-                // Restore the request payload content
                 ApiPayloadConverter.RestoreFrom(request.Params, format, apiEncryptionKey);
 
-                // Parse the ProgId and Action from the Method property
-                var (progId, action) = ParseMethod(request.Method);
-                // Create the business object and invoke the specified method
-                var value = await ExecuteMethodAsync(progId, action, request.Params.Value, format);
-
-                // Convert BO result to API response type by naming convention
+                // Invoke the method and convert the result.
+                var value = await InvokeMethodAsync(businessObject, method, request.Params.Value);
                 value = ApiOutputConverter.Convert(value!);
 
-                // Return the result
                 response.Result = new JsonRpcResult { Value = value };
-                // Set the response payload format
                 ApiPayloadConverter.TransformTo(response.Result, format, apiEncryptionKey);
                 Tracer.End(ctx);
             }
@@ -125,23 +127,26 @@ namespace Bee.Api.Core.JsonRpc
         }
 
         /// <summary>
-        /// Creates the business object and asynchronously executes the specified method.
+        /// Resolves the <see cref="MethodInfo"/> for the specified action on the given business object.
         /// </summary>
-        /// <param name="progId">The program identifier.</param>
-        /// <param name="action">The action to execute.</param>
-        /// <param name="value">The input argument for the action.</param>
-        /// <param name="format">The payload encoding format for transmission.</param>
-        private async Task<object?> ExecuteMethodAsync(string progId, string action, object? value, PayloadFormat format)
+        /// <param name="businessObject">The business object instance.</param>
+        /// <param name="action">The action name.</param>
+        private static MethodInfo GetMethod(object businessObject, string action)
         {
-            // Create an instance of the business object for the specified progId
-            var businessObject = CreateBusinessObject(AccessToken, progId);
             var method = businessObject.GetType().GetMethod(action);
             if (method == null)
-                throw new MissingMethodException($"Method '{action}' not found in business object '{progId}'.");
+                throw new MissingMethodException($"Method '{action}' not found in business object '{businessObject.GetType().Name}'.");
+            return method;
+        }
 
-            // Access validation
-            ApiAccessValidator.ValidateAccess(method, new ApiCallContext(AccessToken, IsLocalCall, format));
-
+        /// <summary>
+        /// Converts the input argument and asynchronously invokes the specified method on the business object.
+        /// </summary>
+        /// <param name="businessObject">The business object instance.</param>
+        /// <param name="method">The resolved method to invoke.</param>
+        /// <param name="value">The deserialized input argument.</param>
+        private static async Task<object?> InvokeMethodAsync(object businessObject, MethodInfo method, object? value)
+        {
             // Convert the input parameter to the expected BO type if needed
             var methodParams = method.GetParameters();
             if (methodParams.Length > 0 && value != null)

--- a/src/Bee.Api.Core/Validator/ApiAccessValidator.cs
+++ b/src/Bee.Api.Core/Validator/ApiAccessValidator.cs
@@ -59,7 +59,10 @@ namespace Bee.Api.Core.Validator
         }
 
         /// <summary>
-        /// Attempts to retrieve the <see cref="ApiAccessControlAttribute"/> from the method or its base definition.
+        /// Attempts to retrieve the <see cref="ApiAccessControlAttribute"/> using the following priority:
+        /// 1. Directly on the method.
+        /// 2. On the base method definition (override inheritance).
+        /// 3. On the declaring class (class-level default).
         /// </summary>
         /// <param name="method">The target method.</param>
         /// <returns>The attribute if found; otherwise, null.</returns>
@@ -70,9 +73,14 @@ namespace Bee.Api.Core.Validator
                 return attr;
 
             var baseMethod = method.GetBaseDefinition();
-            return baseMethod != method
-                ? baseMethod.GetCustomAttribute<ApiAccessControlAttribute>()
-                : null;
+            if (baseMethod != method)
+            {
+                attr = baseMethod.GetCustomAttribute<ApiAccessControlAttribute>();
+                if (attr != null)
+                    return attr;
+            }
+
+            return method.DeclaringType?.GetCustomAttribute<ApiAccessControlAttribute>();
         }
 
         /// <summary>

--- a/src/Bee.Definition/Attributes/ApiAccessControlAttribute.cs
+++ b/src/Bee.Definition/Attributes/ApiAccessControlAttribute.cs
@@ -5,7 +5,7 @@ namespace Bee.Definition.Attributes
     /// <summary>
     /// Attribute for annotating API method access control.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Method, Inherited = true)]
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true)]
     public class ApiAccessControlAttribute : Attribute
     {
         /// <summary>

--- a/src/Bee.Definition/BackendInfo.cs
+++ b/src/Bee.Definition/BackendInfo.cs
@@ -190,7 +190,7 @@ namespace Bee.Definition
         /// Validates that all required backend components are configured.
         /// Throws <see cref="InvalidOperationException"/> at startup if any required component is missing.
         /// </summary>
-        private static void ValidateComponents()
+        internal static void ValidateComponents()
         {
             if (ApiEncryptionKeyProvider == null)
                 throw new InvalidOperationException(

--- a/src/Bee.Definition/BackendInfo.cs
+++ b/src/Bee.Definition/BackendInfo.cs
@@ -140,11 +140,12 @@ namespace Bee.Definition
             DatabaseId = configuration.DatabaseId;
             MaxDbCommandTimeout = configuration.MaxDbCommandTimeout;
             LogOptions = configuration.LogOptions;
-                       
+
             if (!SysInfo.IsSingleFile)
             {
                 // Initialize backend service instances
                 InitializeComponents(configuration);
+                ValidateComponents();
             }
 
             // Initialize security keys
@@ -183,6 +184,23 @@ namespace Bee.Definition
                 (Components.SessionInfoService, BackendDefaultTypes.SessionInfoService);
             EnterpriseObjectService = CreateOrDefault<IEnterpriseObjectService>
                 (Components.EnterpriseObjectService, BackendDefaultTypes.EnterpriseObjectService);
+        }
+
+        /// <summary>
+        /// Validates that all required backend components are configured.
+        /// Throws <see cref="InvalidOperationException"/> at startup if any required component is missing.
+        /// </summary>
+        private static void ValidateComponents()
+        {
+            if (ApiEncryptionKeyProvider == null)
+                throw new InvalidOperationException(
+                    $"BackendInfo.{nameof(ApiEncryptionKeyProvider)} is not configured. Ensure BackendInfo.Initialize() is called with a valid configuration.");
+            if (AccessTokenValidator == null)
+                throw new InvalidOperationException(
+                    $"BackendInfo.{nameof(AccessTokenValidator)} is not configured. Ensure BackendInfo.Initialize() is called with a valid configuration.");
+            if (BusinessObjectFactory == null)
+                throw new InvalidOperationException(
+                    $"BackendInfo.{nameof(BusinessObjectFactory)} is not configured. Ensure BackendInfo.Initialize() is called with a valid configuration.");
         }
 
         /// <summary>

--- a/tests/Bee.Api.Core.UnitTests/ApiAccessValidatorTests.cs
+++ b/tests/Bee.Api.Core.UnitTests/ApiAccessValidatorTests.cs
@@ -255,11 +255,11 @@ namespace Bee.Api.Core.UnitTests
         private class ClassLevelApi
         {
             // 沒有方法層級屬性，應使用 Class 層級的 Public + Anonymous
-            public void Method_NoAttribute() { }
+            public static void Method_NoAttribute() { }
 
             // 方法層級屬性覆蓋 Class 層級屬性
             [ApiAccessControl(ApiProtectionLevel.Encrypted, ApiAccessRequirement.Anonymous)]
-            public void Method_WithAttribute() { }
+            public static void Method_WithAttribute() { }
         }
     }
 }

--- a/tests/Bee.Api.Core.UnitTests/ApiAccessValidatorTests.cs
+++ b/tests/Bee.Api.Core.UnitTests/ApiAccessValidatorTests.cs
@@ -170,6 +170,55 @@ namespace Bee.Api.Core.UnitTests
             }
         }
 
+        [Fact]
+        [DisplayName("ValidateAccess 繼承 Base Method 的屬性：Override 未標記時應使用基底方法屬性")]
+        public void ValidateAccess_BaseMethodAttribute_InheritedByOverride_Succeeds()
+        {
+            var method = typeof(DerivedApi).GetMethod(nameof(DerivedApi.Method_Override));
+            var context = new ApiCallContext
+            {
+                Format = PayloadFormat.Plain,
+                IsLocalCall = false,
+                AccessToken = Guid.Empty
+            };
+
+            var ex = Record.Exception(() => ApiAccessValidator.ValidateAccess(method!, context));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("ValidateAccess Class 層級屬性：方法未標記時應使用 Class 屬性")]
+        public void ValidateAccess_ClassLevelAttribute_UsedWhenMethodHasNone_Succeeds()
+        {
+            var method = typeof(ClassLevelApi).GetMethod(nameof(ClassLevelApi.Method_NoAttribute));
+            var context = new ApiCallContext
+            {
+                Format = PayloadFormat.Plain,
+                IsLocalCall = false,
+                AccessToken = Guid.Empty
+            };
+
+            var ex = Record.Exception(() => ApiAccessValidator.ValidateAccess(method!, context));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("ValidateAccess 方法屬性應覆蓋 Class 層級屬性")]
+        public void ValidateAccess_MethodAttributeOverridesClassAttribute_MethodWins()
+        {
+            // Class 層級為 Public，方法標記為 Encrypted；Plain 傳輸應因方法屬性而被拒
+            var method = typeof(ClassLevelApi).GetMethod(nameof(ClassLevelApi.Method_WithAttribute));
+            var context = new ApiCallContext
+            {
+                Format = PayloadFormat.Plain,
+                IsLocalCall = false,
+                AccessToken = Guid.Empty
+            };
+
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                ApiAccessValidator.ValidateAccess(method!, context));
+        }
+
         private class DummyApi
         {
             [ApiAccessControl(ApiProtectionLevel.Public, ApiAccessRequirement.Anonymous)]
@@ -188,6 +237,29 @@ namespace Bee.Api.Core.UnitTests
 
             [ApiAccessControl(ApiProtectionLevel.Encrypted, ApiAccessRequirement.Authenticated)]
             public static void Method_Authenticated() { }
+        }
+
+        private class BaseApi
+        {
+            [ApiAccessControl(ApiProtectionLevel.Public, ApiAccessRequirement.Anonymous)]
+            public virtual void Method_Override() { }
+        }
+
+        private class DerivedApi : BaseApi
+        {
+            // 沒有標記 [ApiAccessControl]，應繼承 BaseApi.Method_Override 的屬性
+            public override void Method_Override() { }
+        }
+
+        [ApiAccessControl(ApiProtectionLevel.Public, ApiAccessRequirement.Anonymous)]
+        private class ClassLevelApi
+        {
+            // 沒有方法層級屬性，應使用 Class 層級的 Public + Anonymous
+            public void Method_NoAttribute() { }
+
+            // 方法層級屬性覆蓋 Class 層級屬性
+            [ApiAccessControl(ApiProtectionLevel.Encrypted, ApiAccessRequirement.Anonymous)]
+            public void Method_WithAttribute() { }
         }
     }
 }

--- a/tests/Bee.Definition.UnitTests/BackendInfoTests.cs
+++ b/tests/Bee.Definition.UnitTests/BackendInfoTests.cs
@@ -154,6 +154,62 @@ namespace Bee.Definition.UnitTests
         }
 
         [Fact]
+        [DisplayName("ValidateComponents 於 ApiEncryptionKeyProvider 為 null 時應拋 InvalidOperationException")]
+        public void ValidateComponents_ApiEncryptionKeyProviderNull_Throws()
+        {
+            var original = BackendInfo.ApiEncryptionKeyProvider;
+            try
+            {
+                BackendInfo.ApiEncryptionKeyProvider = null!;
+                Assert.Throws<InvalidOperationException>(() => BackendInfo.ValidateComponents());
+            }
+            finally
+            {
+                BackendInfo.ApiEncryptionKeyProvider = original;
+            }
+        }
+
+        [Fact]
+        [DisplayName("ValidateComponents 於 AccessTokenValidator 為 null 時應拋 InvalidOperationException")]
+        public void ValidateComponents_AccessTokenValidatorNull_Throws()
+        {
+            var original = BackendInfo.AccessTokenValidator;
+            try
+            {
+                BackendInfo.AccessTokenValidator = null!;
+                Assert.Throws<InvalidOperationException>(() => BackendInfo.ValidateComponents());
+            }
+            finally
+            {
+                BackendInfo.AccessTokenValidator = original;
+            }
+        }
+
+        [Fact]
+        [DisplayName("ValidateComponents 於 BusinessObjectFactory 為 null 時應拋 InvalidOperationException")]
+        public void ValidateComponents_BusinessObjectFactoryNull_Throws()
+        {
+            var original = BackendInfo.BusinessObjectFactory;
+            try
+            {
+                BackendInfo.BusinessObjectFactory = null!;
+                Assert.Throws<InvalidOperationException>(() => BackendInfo.ValidateComponents());
+            }
+            finally
+            {
+                BackendInfo.BusinessObjectFactory = original;
+            }
+        }
+
+        [Fact]
+        [DisplayName("ValidateComponents 於三個元件皆已配置時不拋例外")]
+        public void ValidateComponents_AllConfigured_Succeeds()
+        {
+            var ex = Record.Exception(() => BackendInfo.ValidateComponents());
+            Assert.Null(ex);
+        }
+
+        [Fact]
         [DisplayName("GetDatabaseItem 於 databaseId 為空字串時應拋 ArgumentNullException")]
         public void GetDatabaseItem_EmptyId_ThrowsArgumentNullException()
         {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

依 `docs/plans/plan-access-strategy-remediation.md` 執行三項存取策略修補。

- **P0** — 解密前先完成授權驗證：重排 `JsonRpcExecutor.ExecuteAsyncCore` 執行順序，將 `ParseMethod → CreateBO → GetMethod → ValidateAccess` 移至 `GetApiEncryptionKey → RestoreFrom（解密）` 之前，確保未授權請求在解密前即被拒絕
- **P1** — `BackendInfo` 啟動期快速失敗：`Initialize()` 末尾新增 `ValidateComponents()`，三個必要元件（`ApiEncryptionKeyProvider`、`AccessTokenValidator`、`BusinessObjectFactory`）未配置時於啟動期拋出明確的 `InvalidOperationException`
- **P3** — `ApiAccessControlAttribute` 支援 Class 層級：擴充 `AttributeTargets` 加入 `Class`，`FindAccessAttribute` 查找順序改為 Method → BaseMethod → DeclaringType

## Changed Files

| 檔案 | 變更 |
|------|------|
| `src/Bee.Api.Core/JsonRpc/JsonRpcExecutor.cs` | 重排執行順序；拆出 `GetMethod` + `InvokeMethodAsync` |
| `src/Bee.Api.Core/Validator/ApiAccessValidator.cs` | `FindAccessAttribute` 加入 Class 層級查找 |
| `src/Bee.Definition/Attributes/ApiAccessControlAttribute.cs` | `AttributeTargets` 加入 `Class` |
| `src/Bee.Definition/BackendInfo.cs` | 新增 `ValidateComponents()` |

## Test plan

- [ ] CI 建置通過（無編譯錯誤）
- [ ] `Bee.Api.Core.UnitTests` 全數通過（含 `ApiAccessValidatorTests`）
- [ ] `Bee.Definition.UnitTests` 全數通過（含 `BackendInfoTests`）

https://claude.ai/code/session_015pPcPySQ3rJhvm1HEdtQtr
EOF

---
_Generated by [Claude Code](https://claude.ai/code/session_015pPcPySQ3rJhvm1HEdtQtr)_