### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-11 00:30

### DIFF
--- a/tests/Bee.Api.Core.UnitTests/ApiAccessValidatorTests.cs
+++ b/tests/Bee.Api.Core.UnitTests/ApiAccessValidatorTests.cs
@@ -219,6 +219,22 @@ namespace Bee.Api.Core.UnitTests
                 ApiAccessValidator.ValidateAccess(method!, context));
         }
 
+        [Fact]
+        [DisplayName("ValidateAccess LocalOnly API 遠端呼叫應拋 UnauthorizedAccessException")]
+        public void ValidateAccess_LocalOnlyApi_RemoteCall_Throws()
+        {
+            var method = typeof(DummyApi).GetMethod(nameof(DummyApi.Method_LocalOnly));
+            var context = new ApiCallContext
+            {
+                Format = PayloadFormat.Plain,
+                IsLocalCall = false,
+                AccessToken = Guid.Empty
+            };
+
+            Assert.Throws<UnauthorizedAccessException>(() =>
+                ApiAccessValidator.ValidateAccess(method!, context));
+        }
+
         private class DummyApi
         {
             [ApiAccessControl(ApiProtectionLevel.Public, ApiAccessRequirement.Anonymous)]

--- a/tests/Bee.Db.UnitTests/TableChangeTests.cs
+++ b/tests/Bee.Db.UnitTests/TableChangeTests.cs
@@ -67,5 +67,25 @@ namespace Bee.Db.UnitTests
             Assert.Same(newField, change.NewField);
             Assert.IsType<ITableChange>(change, exactMatch: false);
         }
+
+        [Fact]
+        [DisplayName("AddFieldChange.Describe 應回傳包含欄位名稱的描述字串")]
+        public void AddFieldChange_Describe_ReturnsCorrectString()
+        {
+            var field = new DbField("email", "Email", FieldDbType.String);
+            var change = new AddFieldChange(field);
+
+            Assert.Equal("AddFieldChange on 'email'", change.Describe());
+        }
+
+        [Fact]
+        [DisplayName("AddIndexChange.Describe 應回傳包含索引名稱的描述字串")]
+        public void AddIndexChange_Describe_ReturnsCorrectString()
+        {
+            var index = new DbTableIndex { Name = "ix_test_email" };
+            var change = new AddIndexChange(index);
+
+            Assert.Equal("AddIndexChange on 'ix_test_email'", change.Describe());
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Api.Core/Validator/ApiAccessValidator.cs` | 87.9% | 1 |
| `src/Bee.Db/Schema/Changes/AddFieldChange.cs` | 80.0% | 1 |
| `src/Bee.Db/Schema/Changes/AddIndexChange.cs` | 80.0% | 1 |

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 剩餘未覆蓋行為為 `catch (IOException)` 競態條件路徑與 `ReadAllTextShared` 重試路徑，需真實 IO 錯誤或 mocking 才能觸發 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 介面宣告，無法直接撰寫單元測試 |

---
_Generated by [Claude Code](https://claude.ai/code/session_011nC2MzsmDao5GGVDzNAddt)_