### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-11 08:38

### DIFF
--- a/tests/Bee.Db.UnitTests/TableChangeTests.cs
+++ b/tests/Bee.Db.UnitTests/TableChangeTests.cs
@@ -60,7 +60,7 @@ namespace Bee.Db.UnitTests
         [DisplayName("DropIndexChange.Describe 應回傳含索引名的描述字串")]
         public void DropIndexChange_Describe_ReturnsIndexName()
         {
-            var index = new TableSchemaIndex { Name = "ix_user_email" };
+            var index = new DbTableIndex { Name = "ix_user_email" };
             var change = new DropIndexChange(index);
 
             Assert.Equal("DropIndexChange on 'ix_user_email'", change.Describe());

--- a/tests/Bee.Db.UnitTests/TableChangeTests.cs
+++ b/tests/Bee.Db.UnitTests/TableChangeTests.cs
@@ -57,6 +57,16 @@ namespace Bee.Db.UnitTests
         }
 
         [Fact]
+        [DisplayName("DropIndexChange.Describe 應回傳含索引名的描述字串")]
+        public void DropIndexChange_Describe_ReturnsIndexName()
+        {
+            var index = new TableSchemaIndex { Name = "ix_user_email" };
+            var change = new DropIndexChange(index);
+
+            Assert.Equal("DropIndexChange on 'ix_user_email'", change.Describe());
+        }
+
+        [Fact]
         [DisplayName("RenameFieldChange 應保留 OldFieldName 與 NewField")]
         public void RenameFieldChange_PreservesOldNameAndNewField()
         {

--- a/tests/Bee.Definition.UnitTests/Logging/LoggingTests.cs
+++ b/tests/Bee.Definition.UnitTests/Logging/LoggingTests.cs
@@ -36,6 +36,15 @@ namespace Bee.Definition.UnitTests.Logging
         }
 
         [Fact]
+        [DisplayName("LogEntry Category 屬性可設定與讀取")]
+        public void LogEntry_Category_CanBeSetAndRead()
+        {
+            var entry = new LogEntry { Category = 3 };
+
+            Assert.Equal((short)3, entry.Category);
+        }
+
+        [Fact]
         [DisplayName("LogOptions 預設應包含非 null 的 DbAccess 選項")]
         public void LogOptions_Defaults_HasDbAccessOptions()
         {

--- a/tests/Bee.Definition.UnitTests/Settings/SystemConfigurationTests.cs
+++ b/tests/Bee.Definition.UnitTests/Settings/SystemConfigurationTests.cs
@@ -36,6 +36,15 @@ namespace Bee.Definition.UnitTests.Settings
         }
 
         [Fact]
+        [DisplayName("BackendConfiguration.ToString 應回傳型別名稱")]
+        public void BackendConfiguration_ToString_ReturnsTypeName()
+        {
+            var config = new BackendConfiguration();
+
+            Assert.Equal(nameof(BackendConfiguration), config.ToString());
+        }
+
+        [Fact]
         [DisplayName("VersionFiles 預設值應為空字串")]
         public void VersionFiles_Default_HasEmptyProperties()
         {


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Settings/SystemSettings/BackendConfiguration.cs` | 87.5% | 1 |
| `src/Bee.Db/Schema/Changes/DropIndexChange.cs` | 80.0% | 1 |
| `src/Bee.Definition/Logging/LogEntry.cs` | 87.5% | 1 |

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 個未覆蓋行均位於 `IOException` 並發競爭路徑（`FileMode.CreateNew` 的 race condition catch）與 `ReadAllTextShared` 重試迴圈，需要特定 IO 競爭環境才能觸發，無法確定性測試 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面聲明，無預設實作，無法直接執行以產生覆蓋率 |

### 補強說明

- **BackendConfiguration.ToString**：`ToString()` override 回傳 `GetType().Name`，現有測試未曾呼叫，補一個明確斷言
- **DropIndexChange.Describe**：`Describe()` 方法回傳 `"DropIndexChange on '{Index.Name}'"` 字串，TableChangeTests 已測試建構子與 `Index` 屬性，但未呼叫 `Describe()`
- **LogEntry.Category**：`Category`（`short`）屬性的 setter 從未被任何測試顯式賦值，補一個設定並讀取的簡單斷言


---
_Generated by [Claude Code](https://claude.ai/code/session_016pPE7iiW5TJksWn9QCdJUR)_