### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-11 16:30

### DIFF
--- a/tests/Bee.Base.UnitTests/MemberPathTests.cs
+++ b/tests/Bee.Base.UnitTests/MemberPathTests.cs
@@ -60,5 +60,16 @@ namespace Bee.Base.UnitTests
         {
             Assert.Throws<ArgumentException>(() => MemberPath.Of(() => 123));
         }
+
+        [Fact]
+        [DisplayName("Of 以 object 泛型參數存取值型別屬性應觸發 UnaryExpression 分支並回傳路徑")]
+        public void Of_ValueTypeAsObject_UnaryExpression_ReturnsPath()
+        {
+            // 明確指定 T=object 強制編譯器插入 Convert(UnaryExpression) 以裝箱值型別，
+            // 觸發 expression.Body is UnaryExpression 分支（MemberPath.cs 第 21-22 行）。
+            var path = MemberPath.Of<object>(() => Holder.IntValue);
+
+            Assert.Equal("Holder.IntValue", path);
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/MySqlDialectFactoryTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlDialectFactoryTests.cs
@@ -66,7 +66,15 @@ namespace Bee.Db.UnitTests
             // CreateTableSchemaProvider 在實作後會 ctor 內 new DbAccess(databaseId)，
             // CI 未設 BEE_TEST_CONNSTR_MYSQL 時 'common_mysql' 沒註冊到 DbConnectionManager
             // → KeyNotFoundException；改由 MySqlIntegrationTests 覆蓋。
-            // CreateFormCommandBuilder 同理：實作後查 FormSchema，由 MySqlFormCommandBuilderTests 覆蓋。
+        }
+
+        [Fact]
+        [DisplayName("MySqlDialectFactory：CreateFormCommandBuilder 找不到 progId 應擲 FileNotFoundException")]
+        public void CreateFormCommandBuilder_UnknownProgId_Throws()
+        {
+            var factory = new MySqlDialectFactory();
+
+            Assert.Throws<System.IO.FileNotFoundException>(() => factory.CreateFormCommandBuilder("__not_exists__"));
         }
     }
 }

--- a/tests/Bee.Db.UnitTests/OracleDialectFactoryTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleDialectFactoryTests.cs
@@ -74,8 +74,16 @@ namespace Bee.Db.UnitTests
             Assert.NotNull(factory.CreateCreateTableCommandBuilder());
             Assert.NotNull(factory.CreateTableAlterCommandBuilder());
             Assert.NotNull(factory.CreateTableRebuildCommandBuilder());
-            // CreateTableSchemaProvider / CreateFormCommandBuilder 與 MySQL 同樣依賴
-            // databaseId / FormSchema，由整合與 builder 測試覆蓋（plan Phase C-2 / B-3）。
+            // CreateTableSchemaProvider 與 MySQL 同樣依賴 databaseId，由整合測試覆蓋。
+        }
+
+        [Fact]
+        [DisplayName("OracleDialectFactory：CreateFormCommandBuilder 找不到 progId 應擲 FileNotFoundException")]
+        public void CreateFormCommandBuilder_UnknownProgId_Throws()
+        {
+            var factory = new OracleDialectFactory();
+
+            Assert.Throws<System.IO.FileNotFoundException>(() => factory.CreateFormCommandBuilder("__not_exists__"));
         }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Base/MemberPath.cs` | 87.5% | 1 |
| `src/Bee.Db/Providers/MySql/MySqlDialectFactory.cs` | 83.3% | 1 |
| `src/Bee.Db/Providers/Oracle/OracleDialectFactory.cs` | 83.3% | 1 |

### 無法處理（2 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 個未覆蓋行均為競態條件（Race condition）與重試（Retry）handler：`LoadFromFile` 中 `catch (IOException)` 空區塊（並行寫入競爭）及 `ReadAllTextShared` 中 `Thread.Sleep` + `attempt++` 重試路徑，無法在 deterministic 單元測試中觸發。 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 介面（Interface）宣告，無可執行程式碼，無法直接測試。 |

### 測試說明

**MemberPath.cs — `Of_ValueTypeAsObject_UnaryExpression_ReturnsPath`**
以 `MemberPath.Of<object>(() => Holder.IntValue)` 明確指定 `T=object`，強制編譯器插入 `Convert`（`UnaryExpression`）裝箱值型別，觸發第 21-22 行 `UnaryExpression` 分支。

**MySqlDialectFactory.cs — `CreateFormCommandBuilder_UnknownProgId_Throws`**
以不存在的 progId 呼叫 `factory.CreateFormCommandBuilder("__not_exists__")`，底層 `GetFormSchema` 找不到檔案即擲 `FileNotFoundException`，覆蓋工廠方法的 `CreateFormCommandBuilder` 行。模式與 `SqliteDialectFactoryTests` 一致。

**OracleDialectFactory.cs — `CreateFormCommandBuilder_UnknownProgId_Throws`**
同上，針對 Oracle 工廠。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VoEKKzTCjSwsoBdc1gU7P2)_