### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-12 08:44

### DIFF
--- a/tests/Bee.Db.UnitTests/DbDialectRegistryTests.cs
+++ b/tests/Bee.Db.UnitTests/DbDialectRegistryTests.cs
@@ -117,6 +117,13 @@ namespace Bee.Db.UnitTests
             Assert.Contains("tmp_st_sample", sql);
         }
 
+        [Fact]
+        [DisplayName("CreateFormCommandBuilder 找不到 progId 應擲 FileNotFoundException")]
+        public void CreateFormCommandBuilder_UnknownProgId_ThrowsFileNotFoundException()
+        {
+            Assert.Throws<System.IO.FileNotFoundException>(() => _factory.CreateFormCommandBuilder("__not_exists__"));
+        }
+
         // 測試用 helper（避免為了單一煙霧測試依賴較重的 schema 建構）
         private sealed class DbFieldForTest : global::Bee.Definition.Database.DbField
         {

--- a/tests/Bee.ObjectCaching.UnitTests/SystemSettingsCacheTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/SystemSettingsCacheTests.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel;
+using Bee.ObjectCaching.Define;
+using Bee.Tests.Shared;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    [Collection("Initialize")]
+    public class SystemSettingsCacheTests
+    {
+        [Fact]
+        [DisplayName("CreateInstance 在 SystemSettings.xml 不存在時應拋出 FileNotFoundException")]
+        public void CreateInstance_FileMissing_ThrowsFileNotFoundException()
+        {
+            var cache = new SystemSettingsCache();
+            cache.Remove();
+
+            using var temp = new TempDefinePath();
+
+            Assert.Throws<FileNotFoundException>(() => cache.Get());
+        }
+
+        [Fact]
+        [DisplayName("Get 在 SystemSettings.xml 存在時應回傳非空物件並觸發 GetPolicy")]
+        public void Get_FileExists_ReturnsSettings()
+        {
+            // GlobalFixture 已將 BackendInfo.DefinePath 指向 tests/Define/，
+            // 該目錄下存有 SystemSettings.xml，確保 GetPolicy（含 ChangeMonitorFilePaths 設定）被覆蓋。
+            var cache = new SystemSettingsCache();
+            cache.Remove();
+
+            var result = cache.Get();
+
+            Assert.NotNull(result);
+
+            cache.Remove();
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.ObjectCaching/Define/SystemSettingsCache.cs` | 85.7% | 2 |
| `src/Bee.Db/Providers/SqlServer/SqlDialectFactory.cs` | 83.3% | 1 |

### 無法處理（共 2 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs`（87.8%，6 uncovered lines）| 未覆蓋行均位於競態條件錯誤處理路徑：`ReadAllTextShared` 的 `IOException` retry 迴圈（需系統層級 IO 錯誤觸發）及 `LoadFromFile` 中 `FileMode.CreateNew` 的 `IOException` catch（需並發進程競爭觸發），無法在常規單元測試中重現。 |
| `src/Bee.Base/Tracing/ITraceListener.cs`（0%，2 uncovered lines）| 純介面宣告，無可執行程式碼；SonarCloud 的覆蓋率計量為誤報。`TraceListener`（具體實作）已有完整測試（`TracerTests.cs`）。 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01D2xRdwemVHFMckDv9nJJte)_