### PR TITLE
[AutoFix] SonarCloud Issues (5 issues) 2026-05-12 16:00

### DIFF
--- a/src/Bee.Business/BusinessObjectFactory.cs
+++ b/src/Bee.Business/BusinessObjectFactory.cs
@@ -77,7 +77,7 @@ namespace Bee.Business
             return Activator.CreateInstance(type, ctx, accessToken, progId, isLocalCall)!;
         }
 
-        private IBeeContext BuildContext()
+        private BeeContext BuildContext()
         {
             if (_defineAccess == null || _sessionInfoService == null)
                 throw new InvalidOperationException(

--- a/src/Bee.Definition/BackendInfo.cs
+++ b/src/Bee.Definition/BackendInfo.cs
@@ -116,6 +116,8 @@ namespace Bee.Definition
             Initialize(configuration, false);
         }
 
+        private const string InitializeMethodName = "Initialize";
+
         /// <summary>
         /// Initializes backend service instances and wires up <c>Bee.ObjectCaching</c>
         /// + <c>Bee.Db</c> static state. Cross-layer wire-up uses reflection to avoid a
@@ -137,14 +139,14 @@ namespace Bee.Definition
 
             // 3. Wire up Bee.ObjectCaching static state via reflection.
             InvokeStaticMethod("Bee.ObjectCaching.CacheContainer, Bee.ObjectCaching",
-                "Initialize", new object[] { storage });
+                InitializeMethodName, new object[] { storage });
             InvokeStaticMethod("Bee.ObjectCaching.CacheInfo, Bee.ObjectCaching",
-                "Initialize", new object[] { configuration });
+                InitializeMethodName, new object[] { configuration });
 
             // 4. Wire up Bee.Db.DbConnectionManager via reflection.
             var dbProvider = new DefineAccessDatabaseSettingsProvider(DefineAccess);
             InvokeStaticMethod("Bee.Db.Manager.DbConnectionManager, Bee.Db",
-                "Initialize", new object[] { dbProvider });
+                InitializeMethodName, new object[] { dbProvider });
 
             // 5. Other services (no inter-dependencies).
             ApiEncryptionKeyProvider = CreateOrDefault<IApiEncryptionKeyProvider>
@@ -162,9 +164,9 @@ namespace Bee.Definition
 
             // 6. Wire up Phase 3 BusinessObjectFactory + RepositoryInfo per-call context plumbing.
             InvokeStaticMethod("Bee.Business.BusinessObjectFactory, Bee.Business",
-                "Initialize", new object[] { DefineAccess, SessionInfoService });
+                InitializeMethodName, new object[] { DefineAccess, SessionInfoService });
             InvokeStaticMethod("Bee.Repository.Abstractions.RepositoryInfo, Bee.Repository.Abstractions",
-                "Initialize", new object[] { configuration });
+                InitializeMethodName, new object[] { configuration });
         }
 
         /// <summary>

--- a/src/Bee.ObjectCaching/CacheContainer.cs
+++ b/src/Bee.ObjectCaching/CacheContainer.cs
@@ -30,7 +30,7 @@ namespace Bee.ObjectCaching
         /// <param name="storage">The define storage shared by storage-backed caches.</param>
         public static void Initialize(IDefineStorage storage)
         {
-            if (storage == null) throw new ArgumentNullException(nameof(storage));
+            ArgumentNullException.ThrowIfNull(storage);
 
             _systemSettings = new SystemSettingsCache();
             _databaseSettings = new DatabaseSettingsCache();

--- a/src/Bee.ObjectCaching/CacheInfo.cs
+++ b/src/Bee.ObjectCaching/CacheInfo.cs
@@ -36,7 +36,7 @@ namespace Bee.ObjectCaching
         /// <param name="configuration">The backend configuration.</param>
         public static void Initialize(BackendConfiguration configuration)
         {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            ArgumentNullException.ThrowIfNull(configuration);
             var configured = configuration.Components.CacheProvider;
             if (string.IsNullOrWhiteSpace(configured)) return;
 

--- a/src/Bee.Repository.Abstractions/RepositoryInfo.cs
+++ b/src/Bee.Repository.Abstractions/RepositoryInfo.cs
@@ -33,7 +33,7 @@ namespace Bee.Repository.Abstractions
         /// <param name="configuration">The backend configuration.</param>
         public static void Initialize(BackendConfiguration configuration)
         {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
+            ArgumentNullException.ThrowIfNull(configuration);
             var components = configuration.Components;
             SystemFactory = CreateOrDefault<ISystemRepositoryFactory>
                 (components.SystemRepositoryFactory, BackendDefaultTypes.SystemRepositoryFactory);


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ4a_WQWCcHxYlSRcZxU | S1192 | `src/Bee.Definition/BackendInfo.cs` | 新增 `private const string InitializeMethodName = "Initialize"` 常數，取代 5 處重複字面值 |
| AZ4a_WtDCcHxYlSRcZxW | CA1859 | `src/Bee.Business/BusinessObjectFactory.cs` | `BuildContext()` 回傳型別由 `IBeeContext` 改為具體型別 `BeeContext` |
| AZ4a_WzbCcHxYlSRcZxX | CA1510 | `src/Bee.Repository.Abstractions/RepositoryInfo.cs` | 改用 `ArgumentNullException.ThrowIfNull(configuration)` |
| AZ4arviEG630vzaXc1Yi | CA1510 | `src/Bee.ObjectCaching/CacheContainer.cs` | 改用 `ArgumentNullException.ThrowIfNull(storage)` |
| AZ4arvkuG630vzaXc1Yj | CA1510 | `src/Bee.ObjectCaching/CacheInfo.cs` | 改用 `ArgumentNullException.ThrowIfNull(configuration)` |

## 無法處理

| Issue Key | Rule | 原因 |
|-----------|------|------|
| AZ4a_WcTCcHxYlSRcZxV | S3885 | `AssemblyLoader.cs:74` 使用 `Assembly.LoadFile` 是有文件記錄的刻意設計：此為 `catch (FileNotFoundException)` 的後備路徑，用於載入探測路徑外的組件。改用 `Assembly.Load(AssemblyName.GetAssemblyName(...))` 仍採相同探測機制，會在同一情境下再次失敗，行為將破壞 fallback 功能。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxYCcvgYqVVJtMgTgMZkMS)_