### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-12 16:30

### DIFF
--- a/tests/Bee.Base.UnitTests/AssemblyLoaderTests.cs
+++ b/tests/Bee.Base.UnitTests/AssemblyLoaderTests.cs
@@ -86,5 +86,25 @@ namespace Bee.Base.UnitTests
             Assert.True(result.IsSuccess);
             Assert.Equal("ok", result.Message);
         }
+
+        [Fact]
+        [DisplayName("LoadAssembly 短名稱（不含副檔名）應能正確載入並快取組件")]
+        public void LoadAssembly_ShortName_LoadsAndCachesAssembly()
+        {
+            // "Bee.Base" 無 .dll 副檔名，FindAssembly 以 ManifestModule.Name 比對會找不到，
+            // 因此觸發 Assembly.Load(AssemblyName) 載入路徑。
+            var assembly = AssemblyLoader.LoadAssembly("Bee.Base");
+            Assert.NotNull(assembly);
+            Assert.Equal("Bee.Base", assembly.GetName().Name);
+        }
+
+        [Fact]
+        [DisplayName("LoadAssembly 不存在的組件名稱應拋出 FileNotFoundException")]
+        public void LoadAssembly_NonExistentAssembly_ThrowsFileNotFoundException()
+        {
+            // Assembly.Load 失敗後走 LoadFile fallback，兩者皆找不到時拋出 FileNotFoundException。
+            Assert.Throws<FileNotFoundException>(() =>
+                AssemblyLoader.LoadAssembly("Does.Not.Exist.dll"));
+        }
     }
 }

--- a/tests/Bee.Db.UnitTests/DbAccessFactoryTests.cs
+++ b/tests/Bee.Db.UnitTests/DbAccessFactoryTests.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+
+namespace Bee.Db.UnitTests
+{
+    public class DbAccessFactoryTests
+    {
+        [Fact]
+        [DisplayName("DbAccessFactory 預設建構子應成功建立實例")]
+        public void Constructor_Default_Succeeds()
+        {
+            var exception = Record.Exception(() => new DbAccessFactory());
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("DbAccessFactory 指定 maxCommandTimeout 應成功建立實例")]
+        public void Constructor_WithMaxCommandTimeout_Succeeds()
+        {
+            var exception = Record.Exception(() => new DbAccessFactory(30));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("DbAccessFactory.Create 使用不存在的 databaseId 應拋出 InvalidOperationException")]
+        public void Create_UnknownDatabaseId_ThrowsInvalidOperationException()
+        {
+            var factory = new DbAccessFactory();
+            Assert.Throws<InvalidOperationException>(() => factory.Create("nonexistent_db_id_xyz"));
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/CacheInfoTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/CacheInfoTests.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel;
+using Bee.Definition.Settings;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    public class CacheInfoTests
+    {
+        [Fact]
+        [DisplayName("CacheInfo.Initialize 傳入 null 設定應拋出 ArgumentNullException")]
+        public void Initialize_NullConfiguration_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => CacheInfo.Initialize(null!));
+        }
+
+        [Fact]
+        [DisplayName("CacheInfo.Initialize CacheProvider 為空字串時應直接返回且不更換 Provider")]
+        public void Initialize_EmptyCacheProvider_DoesNotChangeProvider()
+        {
+            var original = CacheInfo.Provider;
+            var config = new BackendConfiguration();
+            config.Components.CacheProvider = string.Empty;
+
+            var exception = Record.Exception(() => CacheInfo.Initialize(config));
+
+            Assert.Null(exception);
+            Assert.Same(original, CacheInfo.Provider);
+        }
+
+        [Fact]
+        [DisplayName("CacheInfo.Initialize 使用無法解析的 Provider 型別字串時應拋出例外")]
+        public void Initialize_UnresolvableProviderType_ThrowsException()
+        {
+            // Type.GetType 回傳 null → 略過型別比對，直接進入 AssemblyLoader.CreateInstance，
+            // 因組件不存在而拋出 FileNotFoundException，驗證 line 46 有被執行。
+            var config = new BackendConfiguration();
+            config.Components.CacheProvider = "Invalid.Type, Invalid.Assembly";
+
+            Assert.ThrowsAny<Exception>(() => CacheInfo.Initialize(config));
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Base/AssemblyLoader.cs` | 85.0% | 2 |
| `src/Bee.Db/IDbAccessFactory.cs`（`DbAccessFactory`） | 0.0% | 3 |
| `src/Bee.ObjectCaching/CacheInfo.cs` | 75.0% | 3 |

### 測試說明

**Bee.Base — AssemblyLoader**（`tests/Bee.Base.UnitTests/AssemblyLoaderTests.cs`）
- `LoadAssembly_ShortName_LoadsAndCachesAssembly`：以短名稱（無 `.dll`）呼叫，`FindAssembly` 依 ManifestModule.Name 比對失敗，觸發 `Assembly.Load(AssemblyName)` 路徑。
- `LoadAssembly_NonExistentAssembly_ThrowsFileNotFoundException`：不存在組件觸發 `Assembly.Load` → `FileNotFoundException` → `LoadFile` fallback → 再次拋出，覆蓋 catch block。

**Bee.Db — DbAccessFactory**（`tests/Bee.Db.UnitTests/DbAccessFactoryTests.cs`）
- 建構子（預設 / 指定 `maxCommandTimeout`）與 `Create` 方法（不存在的 databaseId → `InvalidOperationException`）三條路徑。

**Bee.ObjectCaching — CacheInfo**（`tests/Bee.ObjectCaching.UnitTests/CacheInfoTests.cs`）
- `Initialize(null)` → `ArgumentNullException`
- `Initialize(config 空 CacheProvider)` → 提早返回，Provider 不變
- `Initialize(config 無法解析型別)` → 跳過型別比對，進入 `AssemblyLoader.CreateInstance` → 拋出例外

### 無法處理（共 2 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Business/BackendInfoServiceProvider.cs` | `internal sealed` 類別，且 `src/Bee.Business` 未設定 `[assembly: InternalsVisibleTo(...)]`，無法從測試專案存取。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 現有 11 個測試已涵蓋主要路徑；剩餘未覆蓋行為 `catch (IOException)` 的 race condition 路徑（並發 FileStream.CreateNew 衝突 & ReadAllTextShared 重試），需多進程並發才能觸發，非純邏輯測試可處理。 |

https://claude.ai/code/session_01HrLTVhzc2pzMMqvWeQVN3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01HrLTVhzc2pzMMqvWeQVN3V)_