### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-05-13 00:30

### DIFF
--- a/tests/Bee.Api.AspNetCore.UnitTests/BeeFrameworkServiceCollectionExtensionsTests.cs
+++ b/tests/Bee.Api.AspNetCore.UnitTests/BeeFrameworkServiceCollectionExtensionsTests.cs
@@ -1,0 +1,37 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Settings;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Api.AspNetCore.UnitTests
+{
+    public class BeeFrameworkServiceCollectionExtensionsTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 傳入 null services 應拋出 ArgumentNullException")]
+        public void AddBeeFramework_NullServices_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                BeeFrameworkServiceCollectionExtensions.AddBeeFramework(
+                    null!, new BackendConfiguration(), new PathOptions()));
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 傳入 null configuration 應拋出 ArgumentNullException")]
+        public void AddBeeFramework_NullConfiguration_ThrowsArgumentNullException()
+        {
+            var services = new ServiceCollection();
+            Assert.Throws<ArgumentNullException>(() =>
+                services.AddBeeFramework(null!, new PathOptions()));
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 傳入 null pathOptions 應拋出 ArgumentNullException")]
+        public void AddBeeFramework_NullPathOptions_ThrowsArgumentNullException()
+        {
+            var services = new ServiceCollection();
+            Assert.Throws<ArgumentNullException>(() =>
+                services.AddBeeFramework(new BackendConfiguration(), null!));
+        }
+    }
+}

--- a/tests/Bee.Base.UnitTests/AssemblyLoaderExtraTests.cs
+++ b/tests/Bee.Base.UnitTests/AssemblyLoaderExtraTests.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel;
+
+namespace Bee.Base.UnitTests
+{
+    public class AssemblyLoaderExtraTests
+    {
+        [Fact]
+        [DisplayName("GetType 應支援分離的組件名稱與型別名稱參數")]
+        public void GetType_WithSeparateAssemblyAndTypeName_ReturnsType()
+        {
+            var type = AssemblyLoader.GetType("Bee.Base.dll", "Bee.Base.ConnectionTestResult");
+            Assert.Equal(typeof(ConnectionTestResult), type);
+        }
+
+        [Fact]
+        [DisplayName("CreateInstance 應支援分離的組件名稱與型別名稱參數")]
+        public void CreateInstance_SeparateAssemblyAndTypeName_ReturnsInstance()
+        {
+            var instance = AssemblyLoader.CreateInstance("Bee.Base.dll", "Bee.Base.ConnectionTestResult");
+            Assert.IsType<ConnectionTestResult>(instance);
+        }
+
+        [Fact]
+        [DisplayName("CreateInstance 分離參數應支援建構子引數")]
+        public void CreateInstance_SeparateParamsWithCtorArgs_UsesMatchingConstructor()
+        {
+            var instance = AssemblyLoader.CreateInstance(
+                "Bee.Base.dll", "Bee.Base.ConnectionTestResult", true, "msg");
+            var result = Assert.IsType<ConnectionTestResult>(instance);
+            Assert.True(result.IsSuccess);
+            Assert.Equal("msg", result.Message);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/DefineAccessDatabaseSettingsProviderTests.cs
+++ b/tests/Bee.Definition.UnitTests/DefineAccessDatabaseSettingsProviderTests.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Definition.UnitTests
+{
+    public class DefineAccessDatabaseSettingsProviderTests
+    {
+        private sealed class StubDefineAccess : IDefineAccess
+        {
+            private readonly DatabaseSettings _settings;
+
+            public StubDefineAccess(DatabaseSettings settings) => _settings = settings;
+
+            public DatabaseSettings GetDatabaseSettings() => _settings;
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private static DefineAccessDatabaseSettingsProvider CreateProvider(DatabaseSettings? settings = null)
+        {
+            return new DefineAccessDatabaseSettingsProvider(new StubDefineAccess(settings ?? new DatabaseSettings()));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null defineAccess 應拋出 ArgumentNullException")]
+        public void Constructor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new DefineAccessDatabaseSettingsProvider(null!));
+        }
+
+        [Fact]
+        [DisplayName("Get 應回傳底層 IDefineAccess 提供的 DatabaseSettings")]
+        public void Get_ReturnsSettingsFromDefineAccess()
+        {
+            var expected = new DatabaseSettings();
+            var provider = CreateProvider(expected);
+
+            Assert.Same(expected, provider.Get());
+        }
+
+        [Fact]
+        [DisplayName("GetItem 傳入 null 應拋出 ArgumentNullException")]
+        public void GetItem_NullId_ThrowsArgumentNullException()
+        {
+            var provider = CreateProvider();
+
+            Assert.Throws<ArgumentNullException>(() => provider.GetItem(null!));
+        }
+
+        [Fact]
+        [DisplayName("GetItem 傳入空白字串應拋出 ArgumentNullException")]
+        public void GetItem_WhitespaceId_ThrowsArgumentNullException()
+        {
+            var provider = CreateProvider();
+
+            Assert.Throws<ArgumentNullException>(() => provider.GetItem("   "));
+        }
+
+        [Fact]
+        [DisplayName("GetItem 找不到指定 id 應拋出 KeyNotFoundException")]
+        public void GetItem_UnknownId_ThrowsKeyNotFoundException()
+        {
+            var provider = CreateProvider();
+
+            Assert.Throws<KeyNotFoundException>(() => provider.GetItem("nonexistent"));
+        }
+
+        [Fact]
+        [DisplayName("GetItem 存在的 id 應回傳對應 DatabaseItem")]
+        public void GetItem_ExistingId_ReturnsDatabaseItem()
+        {
+            var settings = new DatabaseSettings();
+            settings.Items!.Add(new DatabaseItem { Id = "common", DatabaseType = DatabaseType.SQLServer });
+            var provider = CreateProvider(settings);
+
+            var item = provider.GetItem("common");
+
+            Assert.Equal("common", item.Id);
+        }
+
+        [Fact]
+        [DisplayName("ValidateRequired 缺少 common 項目應拋出 InvalidOperationException")]
+        public void ValidateRequired_MissingCommonItem_ThrowsInvalidOperationException()
+        {
+            var provider = CreateProvider();
+
+            Assert.Throws<InvalidOperationException>(() => provider.ValidateRequired());
+        }
+
+        [Fact]
+        [DisplayName("ValidateRequired 含有 common 項目應不拋出例外")]
+        public void ValidateRequired_WithCommonItem_DoesNotThrow()
+        {
+            var settings = new DatabaseSettings();
+            settings.Items!.Add(new DatabaseItem { Id = DbCategoryIds.Common, DatabaseType = DatabaseType.SQLServer });
+            var provider = CreateProvider(settings);
+
+            var exception = Record.Exception(() => provider.ValidateRequired());
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderRelativePathTests.cs
+++ b/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderRelativePathTests.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel;
+using Bee.Base.Security;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+
+namespace Bee.Definition.UnitTests.Security
+{
+    public class MasterKeyProviderRelativePathTests
+    {
+        [Fact]
+        [DisplayName("GetMasterKey 相對路徑應套用 definePath 組合成絕對路徑")]
+        public void GetMasterKey_RelativeFilePath_ResolvesAgainstDefinePath()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-mk-rel-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            string fileName = "relative.key";
+            string fullPath = Path.Combine(tempDir, fileName);
+            byte[] expected = AesCbcHmacKeyGenerator.GenerateCombinedKey();
+            File.WriteAllText(fullPath, Convert.ToBase64String(expected));
+
+            try
+            {
+                byte[] actual = MasterKeyProvider.GetMasterKey(
+                    new MasterKeySource { Type = MasterKeySourceType.File, Value = fileName },
+                    definePath: tempDir);
+
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                if (File.Exists(fullPath)) File.Delete(fullPath);
+                if (Directory.Exists(tempDir)) Directory.Delete(tempDir, false);
+            }
+        }
+
+        [Fact]
+        [DisplayName("GetMasterKey 相對路徑不存在且 autoCreate=true 應在 definePath 下建立檔案")]
+        public void GetMasterKey_RelativeFilePath_Missing_AutoCreate_CreatesInDefinePath()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-mk-relcreate-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            string fileName = "auto-created.key";
+            string fullPath = Path.Combine(tempDir, fileName);
+
+            try
+            {
+                byte[] result = MasterKeyProvider.GetMasterKey(
+                    new MasterKeySource { Type = MasterKeySourceType.File, Value = fileName },
+                    definePath: tempDir,
+                    autoCreate: true);
+
+                Assert.NotEmpty(result);
+                Assert.True(File.Exists(fullPath));
+            }
+            finally
+            {
+                if (File.Exists(fullPath)) File.Delete(fullPath);
+                if (Directory.Exists(tempDir)) Directory.Delete(tempDir, false);
+            }
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/FormLayoutCacheTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/FormLayoutCacheTests.cs
@@ -1,0 +1,98 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.ObjectCaching.Define;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    public class FormLayoutCacheTests
+    {
+        private sealed class StubDefineStorage : IDefineStorage
+        {
+            private readonly FormLayout? _layout;
+
+            public StubDefineStorage(FormLayout? layout = null) => _layout = layout;
+
+            public FormLayout? GetFormLayout(string layoutId) => _layout;
+            public DbCategorySettings? GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema? GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema? GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private sealed class TestableFormLayoutCache : FormLayoutCache
+        {
+            public TestableFormLayoutCache(IDefineStorage storage, string cachePrefix = "")
+                : base(storage, cachePrefix) { }
+
+            public CacheItemPolicy GetCachePolicy(string key) => GetPolicy(key);
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null storage 應拋出 ArgumentNullException")]
+        public void Constructor_NullStorage_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormLayoutCache(null!));
+        }
+
+        [Fact]
+        [DisplayName("GetPolicy 使用 FileDefineStorage 時應設定 ChangeMonitorFilePaths")]
+        public void GetPolicy_FileDefineStorage_SetsChangeMonitorFilePaths()
+        {
+            var storage = new FileDefineStorage(new PathOptions());
+            var cache = new TestableFormLayoutCache(storage);
+
+            var policy = cache.GetCachePolicy("Employee");
+
+            Assert.NotNull(policy.ChangeMonitorFilePaths);
+            Assert.Single(policy.ChangeMonitorFilePaths);
+        }
+
+        [Fact]
+        [DisplayName("GetPolicy 非 FileDefineStorage 時 ChangeMonitorFilePaths 應為 null")]
+        public void GetPolicy_NonFileDefineStorage_NoChangeMonitorFilePaths()
+        {
+            var stub = new StubDefineStorage();
+            var cache = new TestableFormLayoutCache(stub);
+
+            var policy = cache.GetCachePolicy("Employee");
+
+            Assert.Null(policy.ChangeMonitorFilePaths);
+        }
+
+        [Fact]
+        [DisplayName("Get 應呼叫 storage.GetFormLayout 並回傳結果")]
+        public void Get_StorageReturnsLayout_ReturnsSameLayout()
+        {
+            string prefix = Guid.NewGuid().ToString("N");
+            var layout = new FormLayout();
+            var stub = new StubDefineStorage(layout);
+            var cache = new FormLayoutCache(stub, prefix);
+
+            var result = cache.Get("TestLayout");
+
+            Assert.Same(layout, result);
+            cache.Remove("TestLayout");
+        }
+
+        [Fact]
+        [DisplayName("Get 當 storage.GetFormLayout 回傳 null 時應回傳 null")]
+        public void Get_StorageReturnsNull_ReturnsNull()
+        {
+            string prefix = Guid.NewGuid().ToString("N");
+            var stub = new StubDefineStorage();
+            var cache = new FormLayoutCache(stub, prefix);
+
+            var result = cache.Get("NonExistent");
+
+            Assert.Null(result);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Api.AspNetCore/BeeFrameworkServiceCollectionExtensions.cs` | 81.6% | 3 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% | 2 |
| `src/Bee.Base/AssemblyLoader.cs` | 85.0% | 3 |
| `src/Bee.Definition/IDatabaseSettingsProvider.cs` | 66.7% | 7 |
| `src/Bee.ObjectCaching/Define/FormLayoutCache.cs` | 50.0% | 4 |

### 說明

- **BeeFrameworkServiceCollectionExtensions**：補 `AddBeeFramework` null 參數守衛測試（`services`、`configuration`、`pathOptions`）
- **MasterKeyProvider**：補相對路徑解析測試（`definePath` 組合相對 `filePath`，含 `autoCreate=true` 情境）
- **AssemblyLoader**：補 `GetType(assemblyName, typeName)` 兩參數重載與 `CreateInstance(assemblyName, typeName, args)` 三參數重載測試
- **DefineAccessDatabaseSettingsProvider**：補建構子 null 守衛、`GetItem` 空白參數／找不到、`ValidateRequired` 缺少 common 等邊界路徑測試
- **FormLayoutCache**：補建構子 null 守衛、`GetPolicy` FileDefineStorage 路徑監控設定、非檔案儲存空路徑、`CreateInstance` 回傳值測試

### 無法處理

（本次無）

---
_Generated by [Claude Code](https://claude.ai/code/session_01LG1VfhpTw2dZqJk2JRChXA)_