### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-13 08:30

### DIFF
--- a/tests/Bee.Api.AspNetCore.UnitTests/BeeFrameworkApplicationBuilderExtensionsTests.cs
+++ b/tests/Bee.Api.AspNetCore.UnitTests/BeeFrameworkApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel;
+using Bee.Api.AspNetCore.Bootstrapping;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Api.AspNetCore.UnitTests
+{
+    public class BeeFrameworkApplicationBuilderExtensionsTests
+    {
+        private sealed class FakeCacheBootstrapper : ICacheBootstrapper { }
+        private sealed class FakeDbConnectionManagerBootstrapper : IDbConnectionManagerBootstrapper { }
+
+        private sealed class FakeApplicationBuilder : IApplicationBuilder
+        {
+            public IServiceProvider ApplicationServices { get; set; } = null!;
+            public IFeatureCollection ServerFeatures => null!;
+            public IDictionary<string, object?> Properties { get; } = new Dictionary<string, object?>();
+            public IApplicationBuilder Use(Func<RequestDelegate, RequestDelegate> middleware) => this;
+            public IApplicationBuilder New() => this;
+            public RequestDelegate Build() => _ => Task.CompletedTask;
+        }
+
+        [Fact]
+        [DisplayName("UseBeeFramework 傳入 null 應拋出 ArgumentNullException")]
+        public void UseBeeFramework_NullApp_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                BeeFrameworkApplicationBuilderExtensions.UseBeeFramework(null!));
+        }
+
+        [Fact]
+        [DisplayName("UseBeeFramework 應解析 bootstrapper 並回傳相同 IApplicationBuilder 實例")]
+        public void UseBeeFramework_ValidApp_ResolvesBootstrappersAndReturnsSameApp()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ICacheBootstrapper, FakeCacheBootstrapper>();
+            services.AddSingleton<IDbConnectionManagerBootstrapper, FakeDbConnectionManagerBootstrapper>();
+            var provider = services.BuildServiceProvider();
+
+            var app = new FakeApplicationBuilder { ApplicationServices = provider };
+            var result = app.UseBeeFramework();
+
+            Assert.Same(app, result);
+        }
+    }
+}

--- a/tests/Bee.Db.UnitTests/Manager/DbAccessFactoryTests.cs
+++ b/tests/Bee.Db.UnitTests/Manager/DbAccessFactoryTests.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+using Bee.Definition.Database;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.Db.Manager;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests.Manager
+{
+    [Collection("Initialize")]
+    public class DbAccessFactoryTests
+    {
+        [Fact]
+        [DisplayName("DbAccessFactory 預設建構子應建立實例")]
+        public void DbAccessFactory_DefaultConstructor_CreatesInstance()
+        {
+            var factory = new DbAccessFactory();
+            Assert.NotNull(factory);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(30)]
+        [InlineData(120)]
+        [DisplayName("DbAccessFactory 指定 maxCommandTimeout 應建立實例")]
+        public void DbAccessFactory_WithTimeout_CreatesInstance(int timeout)
+        {
+            var factory = new DbAccessFactory(timeout);
+            Assert.NotNull(factory);
+        }
+
+        [Fact]
+        [DisplayName("DbAccessFactory.Create 應回傳對應 DatabaseType 的 DbAccess 實例")]
+        public void Create_ValidDatabaseId_ReturnsDbAccessWithCorrectType()
+        {
+            string id = $"bee_factory_{Guid.NewGuid():N}";
+            DatabaseSettings settings = BeeTestServices.GetRequiredService<IDefineAccess>().GetDatabaseSettings();
+            settings.Items!.Add(new DatabaseItem
+            {
+                Id = id,
+                DatabaseType = DatabaseType.SQLServer,
+                ConnectionString = "Server=test;"
+            });
+
+            try
+            {
+                var factory = new DbAccessFactory(30);
+                var dbAccess = factory.Create(id);
+
+                Assert.NotNull(dbAccess);
+                Assert.Equal(DatabaseType.SQLServer, dbAccess.DatabaseType);
+            }
+            finally
+            {
+                settings.Items!.Remove(settings.Items[id]!);
+                DbConnectionManager.Remove(id);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Api.AspNetCore/BeeFrameworkApplicationBuilderExtensions.cs` | 0.0% | 2 |
| `src/Bee.Db/IDbAccessFactory.cs` | 0.0% | 5 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/BeeFrameworkServiceCollectionExtensions.cs` | 未覆蓋行皆在 private 方法中，須透過 `AddBeeFramework` 呼叫，而 `AddBeeFramework` 需要有效 master key 檔案；難以在純單元測試中建立所需條件。 |
| `src/Bee.Base/AssemblyLoader.cs` | 未覆蓋行為 `LoadAssembly` 的 `FileNotFoundException` fallback 路徑，須載入不在 probing path 的組件；無法在 CI 環境中可靠複現。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋行為並行寫入時的 `IOException` 競爭條件路徑與 `ReadAllTextShared` retry 邏輯；需要競態條件才能觸發，純單元測試無法可靠測試。 |


---
_Generated by [Claude Code](https://claude.ai/code/session_017Z4T5toeNPz4ZybGhGF2gZ)_