### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-13 16:30

### DIFF
--- a/tests/Bee.Base.UnitTests/AssemblyLoaderTests.cs
+++ b/tests/Bee.Base.UnitTests/AssemblyLoaderTests.cs
@@ -86,5 +86,19 @@ namespace Bee.Base.UnitTests
             Assert.True(result.IsSuccess);
             Assert.Equal("ok", result.Message);
         }
+
+        [Fact]
+        [DisplayName("LoadAssembly 傳入帶目錄的完整路徑應從磁碟載入並回傳組件")]
+        public void LoadAssembly_FullPath_LoadsAssemblyFromDisk()
+        {
+            // 完整路徑（含目錄）使 FindAssembly 無法在 AppDomain 中比對（ManifestModule.Name 只有檔名），
+            // 觸發 LoadAssembly 內 else 分支（assemblyFile = assemblyName）並執行磁碟載入路徑。
+            string fullPath = Path.Combine(AppContext.BaseDirectory, "Bee.Base.dll");
+
+            var assembly = AssemblyLoader.LoadAssembly(fullPath);
+
+            Assert.NotNull(assembly);
+            Assert.Equal("Bee.Base", assembly.GetName().Name);
+        }
     }
 }

--- a/tests/Bee.ObjectCaching.UnitTests/ProgramSettingsCacheTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/ProgramSettingsCacheTests.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel;
+using Bee.Base.Serialization;
+using Bee.Definition;
+using Bee.Definition.Settings;
+using Bee.ObjectCaching.Define;
+using Bee.Tests.Shared;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    [Collection("Initialize")]
+    public class ProgramSettingsCacheTests
+    {
+        [Fact]
+        [DisplayName("CreateInstance 於 ProgramSettings.xml 存在時應回傳 ProgramSettings 並觸發 GetPolicy")]
+        public void CreateInstance_FileExists_ReturnsProgramSettings()
+        {
+            var cache = new ProgramSettingsCache();
+            cache.Remove();
+
+            using var temp = new TempDefinePath();
+            string filePath = DefinePathInfo.GetProgramSettingsFilePath();
+            XmlCodec.SerializeToFile(new ProgramSettings(), filePath);
+
+            try
+            {
+                var result = cache.Get();
+                Assert.NotNull(result);
+                Assert.IsType<ProgramSettings>(result);
+            }
+            finally
+            {
+                cache.Remove();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Base/AssemblyLoader.cs` | 85.0% | 1 |
| `src/Bee.ObjectCaching/Define/ProgramSettingsCache.cs` | 60.0% | 1 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Api.AspNetCore/BeeFrameworkServiceCollectionExtensions.cs` | 本機 `src/` 目錄下不存在此檔案（已從 main 移除或重命名），無法補測 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋行為均為併發競爭條件（`FileMode.CreateNew` 的 IOException catch 及 `ReadAllTextShared` 的重試迴圈），無法在純單元測試中可靠觸發 |
| `src/Bee.ObjectCaching/CacheInfo.cs` | 未覆蓋行為在靜態建構子的 `Initialize()` 路徑中，靜態建構子執行時序由 CLR 決定，無法在測試層面精確控制 |

## 補強說明

### `AssemblyLoader.cs`
新增 `LoadAssembly_FullPath_LoadsAssemblyFromDisk`：傳入含目錄的完整路徑（如 `AppContext.BaseDirectory + "Bee.Base.dll"`），使 `FindAssembly` 無法在 AppDomain 以 `ManifestModule.Name` 比對命中，強制進入 `else` 分支（`assemblyFile = assemblyName`）並執行 `Assembly.Load(File.ReadAllBytes(...))` 磁碟載入路徑。

### `ProgramSettingsCache.cs`
新增 `CreateInstance_FileExists_ReturnsProgramSettings`：使用 `TempDefinePath` 切換至隔離路徑、以 `XmlCodec.SerializeToFile` 建立最小化 `ProgramSettings.xml`，再呼叫 `cache.Get()` 觸發 `CreateInstance()` 的快樂路徑（`XmlCodec.DeserializeFromFile` 回傳）與 `GetPolicy()` 方法本體（`CacheItemPolicy` 建立及 `ChangeMonitorFilePaths` 設定）。

https://claude.ai/code/session_01JUz6Z4ok8TxntYpUMC9xwQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUz6Z4ok8TxntYpUMC9xwQ)_