### PR TITLE
chore: bump version to 4.2.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,9 +1,9 @@
 ﻿<Project>
   <PropertyGroup>
     <!-- 版本資訊 -->
-    <Version>4.1.0</Version>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <FileVersion>4.1.0.0</FileVersion>
+    <Version>4.2.0</Version>
+    <AssemblyVersion>4.2.0.0</AssemblyVersion>
+    <FileVersion>4.2.0.0</FileVersion>
 <!---->
     <!-- 套件 Metadata -->
     <Company>Bee.NET</Company>


### PR DESCRIPTION
## Summary

- 版號從 4.1.0 升至 4.2.0，反映 Phase 5–7 大幅架構改版（DI 遷移、靜態 facade 移除）
- 更新 `src/Directory.Build.props` 的 `Version`、`AssemblyVersion`、`FileVersion`

## Test plan

- [ ] 確認 CI build 通過
- [ ] 確認 NuGet 封裝版號正確顯示為 4.2.0

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLA2a7PMFbL3rvw7E4EHyZ)_