### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-14 00:30

### DIFF
--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkIntegrationTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkIntegrationTests.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Settings;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Hosting.UnitTests
+{
+    public class BeeFrameworkIntegrationTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 傳入有效組態且 autoCreateMasterKey=true 應完成服務注冊並回傳 IServiceCollection")]
+        public void AddBeeFramework_ValidConfigurationAutoCreateKey_RegistersServices()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var configuration = new BackendConfiguration();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+
+                // autoCreateMasterKey=true → Master.key 自動建立於 tempDir
+                // 同時涵蓋 DecryptSecurityKeys、CacheInfo.Initialize 及所有 AddSingleton 注冊路徑
+                var result = services.AddBeeFramework(configuration, pathOptions, autoCreateMasterKey: true);
+
+                Assert.Same(services, result);
+                Assert.True(services.Count > 0);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/CacheInfoTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/CacheInfoTests.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel;
+using Bee.Definition.Settings;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    public class CacheInfoTests
+    {
+        [Fact]
+        [DisplayName("Initialize 設定型別與現有 Provider 相同時應保留現有 Provider 實例（覆蓋型別比對路徑）")]
+        public void Initialize_SameProviderType_DoesNotReplaceProvider()
+        {
+            var configuration = new BackendConfiguration();
+            configuration.Components.CacheProvider =
+                "Bee.ObjectCaching.Providers.MemoryCacheProvider, Bee.ObjectCaching";
+            var originalProvider = CacheInfo.Provider;
+
+            CacheInfo.Initialize(configuration);
+
+            // Provider 應保持同一實例（型別相同 → 提前返回）
+            Assert.Same(originalProvider, CacheInfo.Provider);
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/ProgramSettingsCacheTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/ProgramSettingsCacheTests.cs
@@ -1,0 +1,45 @@
+using System.ComponentModel;
+using Bee.Base.Serialization;
+using Bee.Definition;
+using Bee.Definition.Settings;
+using Bee.ObjectCaching.Define;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    public class ProgramSettingsCacheTests
+    {
+        [Fact]
+        [DisplayName("Get 於檔案存在時應反序列化並回傳 ProgramSettings（同時覆蓋 GetPolicy 路徑）")]
+        public void Get_FileExists_ReturnsProgramSettings()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-psc-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                XmlCodec.SerializeToFile(new ProgramSettings(), pathOptions.GetProgramSettingsFilePath());
+
+                // 使用唯一 prefix 避免與其他測試共用快取鍵
+                string cachePrefix = Guid.NewGuid().ToString("N");
+                var cache = new ProgramSettingsCache(pathOptions, cachePrefix);
+
+                // Get() → CreateInstance()（讀檔反序列化） → GetPolicy()（設定快取原則）
+                var result = cache.Get();
+
+                Assert.NotNull(result);
+                cache.Remove();
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null PathOptions 應拋出 ArgumentNullException")]
+        public void Constructor_NullPathOptions_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ProgramSettingsCache(null!));
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.ObjectCaching/Define/ProgramSettingsCache.cs` | 60.0% | 2 |
| `src/Bee.ObjectCaching/CacheInfo.cs` | 75.0% | 1 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 81.9% | 1 |

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/AssemblyLoader.cs`（85.0%，6 uncovered lines）| 未覆蓋路徑為 `catch (FileNotFoundException)` fallback，需在 AppDomain 外載入未知 assembly；無法在現有測試結構下隔離 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs`（87.8%，6 uncovered lines）| 未覆蓋路徑為 `ReadAllTextShared` 重試邏輯（需 IO 暫時性錯誤）及 `LoadFromFile` 競爭條件 catch 區塊；這兩條路徑均需要模擬非確定性的系統層面行為 |

### 測試說明

- **`ProgramSettingsCacheTests`**：補測 `CreateInstance` 成功路徑（反序列化 ProgramSettings.xml）及 `GetPolicy`（快取原則設定），使用 temp dir 隔離檔案 IO
- **`CacheInfoTests`**：補測 `Initialize` 的型別比對路徑（`Type.GetType` + `newType == Provider.GetType()` 提前返回），不修改靜態 Provider 實例
- **`BeeFrameworkIntegrationTests`**：以 `autoCreateMasterKey=true` 呼叫 `AddBeeFramework`，覆蓋 `DecryptSecurityKeys`、`CacheInfo.Initialize` 及所有服務注冊語句

https://claude.ai/code/session_01Qq8X6gGYxVCLkxaeUR5BSu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qq8X6gGYxVCLkxaeUR5BSu)_