### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-14 08:30

### DIFF
--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkIntegrationTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkIntegrationTests.cs
@@ -1,5 +1,8 @@
 using System.ComponentModel;
+using Bee.Base.Security;
+using Bee.Business.Providers;
 using Bee.Definition;
+using Bee.Definition.Security;
 using Bee.Definition.Settings;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -25,6 +28,43 @@ namespace Bee.Hosting.UnitTests
 
                 Assert.Same(services, result);
                 Assert.True(services.Count > 0);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 設定 StaticApiEncryptionKeyProvider 解析服務應回傳靜態金鑰提供者")]
+        public void AddBeeFramework_StaticApiEncryptionKeyProvider_ResolvesStaticProvider()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-static-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                // 產生主金鑰並寫入暫存目錄（預設 Master.key 路徑）
+                string masterKeyBase64 = AesCbcHmacKeyGenerator.GenerateBase64CombinedKey();
+                byte[] masterKey = Convert.FromBase64String(masterKeyBase64);
+                File.WriteAllText(Path.Combine(tempDir, "Master.key"), masterKeyBase64);
+
+                // 用主金鑰加密一把 API 金鑰
+                string encryptedApiKey = EncryptionKeyProtector.GenerateEncryptedKey(masterKey);
+
+                var configuration = new BackendConfiguration();
+                configuration.SecurityKeySettings.ApiEncryptionKey = encryptedApiKey;
+                configuration.Components.ApiEncryptionKeyProvider =
+                    "Bee.Business.Providers.StaticApiEncryptionKeyProvider, Bee.Business";
+
+                var services = new ServiceCollection();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(configuration, pathOptions);
+
+                // 解析 IApiEncryptionKeyProvider 觸發 CreateApiEncryptionKeyProvider 私有方法的 static 分支
+                using var sp = services.BuildServiceProvider();
+                var provider = sp.GetRequiredService<IApiEncryptionKeyProvider>();
+
+                Assert.IsType<StaticApiEncryptionKeyProvider>(provider);
             }
             finally
             {

--- a/tests/Bee.ObjectCaching.UnitTests/CacheInfoTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/CacheInfoTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Bee.Definition.Settings;
+using Bee.ObjectCaching.Providers;
 
 namespace Bee.ObjectCaching.UnitTests
 {
@@ -18,6 +19,55 @@ namespace Bee.ObjectCaching.UnitTests
 
             // Provider 應保持同一實例（型別相同 → 提前返回）
             Assert.Same(originalProvider, CacheInfo.Provider);
+        }
+
+        [Fact]
+        [DisplayName("Initialize 傳入 null 應拋出 ArgumentNullException")]
+        public void Initialize_NullConfiguration_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => CacheInfo.Initialize(null!));
+        }
+
+        [Fact]
+        [DisplayName("Initialize CacheProvider 為空字串時應提前返回且不替換 Provider")]
+        public void Initialize_EmptyCacheProvider_ReturnsEarlyWithoutChange()
+        {
+            var config = new BackendConfiguration();
+            config.Components.CacheProvider = string.Empty;
+            var originalProvider = CacheInfo.Provider;
+
+            CacheInfo.Initialize(config);
+
+            Assert.Same(originalProvider, CacheInfo.Provider);
+        }
+
+        [Fact]
+        [DisplayName("Initialize 設定型別與現有 Provider 不同時應建立新 Provider 實例")]
+        public void Initialize_DifferentProviderType_ReplacesProvider()
+        {
+            // 使用預設 MemoryCacheProvider 設定，但先把靜態 Provider 換成不同型別
+            var config = new BackendConfiguration();
+            var originalProvider = CacheInfo.Provider;
+            CacheInfo.Provider = new FakeCacheProvider();
+            try
+            {
+                CacheInfo.Initialize(config);
+                // 型別不同 → 提前返回條件不成立 → 建立新的 MemoryCacheProvider
+                Assert.IsType<MemoryCacheProvider>(CacheInfo.Provider);
+            }
+            finally
+            {
+                CacheInfo.Provider = originalProvider;
+            }
+        }
+
+        private sealed class FakeCacheProvider : ICacheProvider
+        {
+            public bool Contains(string key) => false;
+            public void Set(string key, object value, CacheItemPolicy policy) { }
+            public object? Get(string key) => null;
+            public void Remove(string key) { }
+            public long GetCount() => 0;
         }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.ObjectCaching/CacheInfo.cs` | 75.0% | 3 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 81.9% | 1 |

### 測試說明

**CacheInfo（3 個新測試）**
- `Initialize_NullConfiguration_ThrowsArgumentNullException`：驗證 null 配置拋出例外
- `Initialize_EmptyCacheProvider_ReturnsEarlyWithoutChange`：驗證空字串 CacheProvider 提前返回（IsNullOrWhiteSpace true 分支）
- `Initialize_DifferentProviderType_ReplacesProvider`：驗證型別不同時 Provider 被替換（`Provider = AssemblyLoader.CreateInstance(...)` 行）

**BeeFrameworkServiceCollectionExtensions（1 個新測試）**
- `AddBeeFramework_StaticApiEncryptionKeyProvider_ResolvesStaticProvider`：設定 `StaticApiEncryptionKeyProvider` 並解析服務，覆蓋 `CreateApiEncryptionKeyProvider` 私有方法的 static 分支

### 無法處理（3 個檔案）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/AssemblyLoader.cs` | `LoadAssembly` 的非快取路徑需要載入不在目前 AppDomain 的組件，單元測試環境無法可靠重現 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋行為 `catch (IOException)` 屬 race condition 防禦路徑（並行檔案鎖），無法在單元測試中可靠觸發 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面定義，無可執行程式碼；SonarCloud 回報為誤報 |

---
_Generated by [Claude Code](https://claude.ai/code/session_015nMkvE6DqzaGNKLnkBYrRk)_