### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-14 16:30

### DIFF
--- a/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
@@ -1,7 +1,12 @@
 using System.ComponentModel;
+using Bee.Base.Data;
 using Bee.Db.Manager;
 using Bee.Db.Schema;
+using Bee.Definition;
 using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
 using Bee.Definition.Storage;
 using Bee.Tests.Shared;
 
@@ -64,6 +69,97 @@ namespace Bee.Db.UnitTests
             var builder = NewBuilder(TestDbConventions.GetDatabaseId(DatabaseType.PostgreSQL, "company"));
             string sql = builder.GetCommandText("company", "ft_project");
             Assert.Equal(string.Empty, sql);
+        }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("TableSchemaBuilder GetCommandText SQL Server 有欄位差異時應回傳非空 SQL 升級指令")]
+        public void GetCommandText_SchemaDrift_SqlServer_ReturnsNonEmptySql()
+        {
+            const string tableName = "zz_tsb_getcommand_test";
+            const string databaseId = "common_sqlserver";
+            var db = _fx.NewDbAccess(databaseId);
+            db.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                $"IF OBJECT_ID(N'{tableName}', N'U') IS NOT NULL DROP TABLE [{tableName}]; " +
+                $"CREATE TABLE [{tableName}] ([sys_rowid] uniqueidentifier NOT NULL, " +
+                $"CONSTRAINT [pk_{tableName}] PRIMARY KEY ([sys_rowid]));"));
+            try
+            {
+                var builder = new TableSchemaBuilder(
+                    databaseId,
+                    new StubDefineAccess(BuildDriftSchema(tableName)),
+                    _fx.GetRequiredService<IDbConnectionManager>());
+
+                string sql = builder.GetCommandText("test", tableName);
+
+                Assert.NotEmpty(sql);
+            }
+            finally
+            {
+                db.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"IF OBJECT_ID(N'{tableName}', N'U') IS NOT NULL DROP TABLE [{tableName}];"));
+            }
+        }
+
+        [DbFact(DatabaseType.PostgreSQL)]
+        [DisplayName("TableSchemaBuilder GetCommandText PostgreSQL 有欄位差異時應回傳非空 SQL 升級指令")]
+        public void GetCommandText_SchemaDrift_PostgreSql_ReturnsNonEmptySql()
+        {
+            const string tableName = "zz_tsb_getcommand_test";
+            const string databaseId = "common_postgresql";
+            var db = _fx.NewDbAccess(databaseId);
+            db.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                $"DROP TABLE IF EXISTS {tableName}; " +
+                $"CREATE TABLE {tableName} (sys_rowid uuid NOT NULL, " +
+                $"CONSTRAINT pk_{tableName} PRIMARY KEY (sys_rowid));"));
+            try
+            {
+                var builder = new TableSchemaBuilder(
+                    databaseId,
+                    new StubDefineAccess(BuildDriftSchema(tableName)),
+                    _fx.GetRequiredService<IDbConnectionManager>());
+
+                string sql = builder.GetCommandText("test", tableName);
+
+                Assert.NotEmpty(sql);
+            }
+            finally
+            {
+                db.Execute(new DbCommandSpec(DbCommandKind.NonQuery,
+                    $"DROP TABLE IF EXISTS {tableName};"));
+            }
+        }
+
+        private static TableSchema BuildDriftSchema(string tableName)
+        {
+            var schema = new TableSchema { TableName = tableName };
+            schema.Fields!.Add(SysFields.RowId, "Row ID", FieldDbType.Guid);
+            schema.Fields!.Add("name", "Name", FieldDbType.String, 50);
+            schema.Indexes!.AddPrimaryKey(SysFields.RowId);
+            return schema;
+        }
+
+        private sealed class StubDefineAccess : IDefineAccess
+        {
+            private readonly TableSchema _schema;
+            public StubDefineAccess(TableSchema schema) { _schema = schema; }
+
+            public TableSchema GetTableSchema(string categoryId, string tableName) => _schema;
+
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotSupportedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotSupportedException();
+            public SystemSettings GetSystemSettings() => throw new NotSupportedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotSupportedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotSupportedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotSupportedException();
+            public ProgramSettings GetProgramSettings() => throw new NotSupportedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotSupportedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotSupportedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotSupportedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotSupportedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotSupportedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotSupportedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotSupportedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotSupportedException();
         }
     }
 }

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Bee.Definition;
 using Bee.Definition.Security;
 using Bee.Definition.Settings;
 using Bee.Definition.Storage;

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Hosting.UnitTests
+{
+    public class BeeFrameworkServiceResolutionTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 預設組態解析 IDefineStorage 及 IDefineAccess 應各回傳非 null")]
+        public void AddBeeFramework_DefaultConfiguration_DefineServicesAreResolvable()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(
+                    new BackendConfiguration(),
+                    new PathOptions { DefinePath = tempDir },
+                    autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+
+                // 驗證工廠 lambda 執行不拋出例外（覆蓋 CreateDefineStorage 與 ResolveDefineAccess 方法體）
+                var ex = Record.Exception(() =>
+                {
+                    _ = sp.GetRequiredService<IDefineStorage>();
+                    _ = sp.GetRequiredService<IDefineAccess>();
+                });
+                Assert.Null(ex);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 設定不存在的 DefineAccess 型別，解析 IDefineAccess 時應拋出例外")]
+        public void AddBeeFramework_InvalidDefineAccessType_ThrowsOnResolution()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-inv-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var config = new BackendConfiguration();
+                config.Components.DefineAccess = "Bee.Base.TypeNotExistXxxPlaceholder, Bee.Base";
+                var services = new ServiceCollection();
+                services.AddBeeFramework(
+                    config,
+                    new PathOptions { DefinePath = tempDir },
+                    autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var ex = Record.Exception(() => sp.GetRequiredService<IDefineAccess>());
+
+                Assert.NotNull(ex);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 設定靜態類別為 AccessTokenValidator，解析服務時應拋出例外")]
+        public void AddBeeFramework_StaticClassAsAccessTokenValidator_ThrowsOnResolution()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-static-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var config = new BackendConfiguration();
+                // AssemblyLoader 為 static class，無法被 ActivatorUtilities 或 AssemblyLoader.CreateInstance 實體化，
+                // 會觸發 CreateConfigurableService 的 catch(InvalidOperationException) 分支及後續 ?? throw
+                config.Components.AccessTokenValidator = "Bee.Base.AssemblyLoader, Bee.Base";
+                var services = new ServiceCollection();
+                services.AddBeeFramework(
+                    config,
+                    new PathOptions { DefinePath = tempDir },
+                    autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var ex = Record.Exception(() => sp.GetRequiredService<IAccessTokenValidator>());
+
+                Assert.NotNull(ex);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 82.9% | 3 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 79.3% | 2 |

## 無法處理

| 檔案 | 補強前覆蓋率 | 原因 |
|------|------------|------|
| `src/Bee.Base/AssemblyLoader.cs` | 85.0% | 6 個未覆蓋行位於 `LoadAssembly` 的 `FileNotFoundException` fallback 路徑，需要在 probing path 外的組件檔才能觸發，無法在單元測試中確定性重現 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% | 6 個未覆蓋行位於 `ReadAllTextShared` 的重試邏輯（`Thread.Sleep` + `attempt++`）與 `LoadFromFile` 的 race condition catch，需要 `IOException` 在讀取時發生才能觸發，無法確定性模擬 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 0% | 純介面，2 個統計行為 SonarCloud 計入但沒有可執行程式碼可測試 |

## 補測詳情

### `BeeFrameworkServiceCollectionExtensions`（新增 `BeeFrameworkServiceResolutionTests.cs`）

- `AddBeeFramework_DefaultConfiguration_DefineServicesAreResolvable`：以預設組態建立 ServiceProvider 並解析 `IDefineStorage`、`IDefineAccess`，覆蓋 `CreateDefineStorage` 及 `ResolveDefineAccess` 方法體（full 4-param ctor 路徑）
- `AddBeeFramework_InvalidDefineAccessType_ThrowsOnResolution`：設定不存在的 DefineAccess 型別名稱（在可載入組件中），觸發 `ResolveDefineAccess` 的 `?? throw new InvalidOperationException(...)` 行
- `AddBeeFramework_StaticClassAsAccessTokenValidator_ThrowsOnResolution`：設定 `Bee.Base.AssemblyLoader`（static class）為 AccessTokenValidator，觸發 `CreateConfigurableService` 的 `catch(InvalidOperationException)` 分支

### `TableSchemaBuilder`（修改 `TableSchemaBuilderTests.cs`）

- `GetCommandText_SchemaDrift_SqlServer_ReturnsNonEmptySql`：在 SQL Server 建立僅有 `sys_rowid` 的臨時表，以含 `sys_rowid` + `name` 的 `StubDefineAccess` 觸發 `GetCommandText` 非空路徑（Lines 98–105）
- `GetCommandText_SchemaDrift_PostgreSql_ReturnsNonEmptySql`：同上，PostgreSQL 版本

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDB2NbY3j6rS64vGJPYigU)_