### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-15 00:47

### DIFF
--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkAdditionalTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkAdditionalTests.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Security;
+using Bee.Definition.Storage;
+using Bee.Repository.Abstractions.Factories;
+using Bee.Tests.Shared;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="BeeFrameworkServiceCollectionExtensions"/> 的 DI singleton 工廠延遲解析路徑。
+    /// </summary>
+    public class BeeFrameworkAdditionalTests : IClassFixture<BeeTestFixture>
+    {
+        private readonly BeeTestFixture _fx;
+
+        public BeeFrameworkAdditionalTests(BeeTestFixture fx) { _fx = fx; }
+
+        [Fact]
+        [DisplayName("DI 容器解析 IDefineAccess 應回傳非 null 實例（涵蓋 CreateDefineStorage 與 ResolveDefineAccess 路徑）")]
+        public void ResolveDefineAccess_FromDI_ReturnsNonNull()
+        {
+            var access = _fx.GetRequiredService<IDefineAccess>();
+            Assert.NotNull(access);
+        }
+
+        [Fact]
+        [DisplayName("DI 容器解析 IDbConnectionManager 應回傳非 null 實例")]
+        public void ResolveDbConnectionManager_FromDI_ReturnsNonNull()
+        {
+            var manager = _fx.GetRequiredService<IDbConnectionManager>();
+            Assert.NotNull(manager);
+        }
+
+        [Fact]
+        [DisplayName("DI 容器解析 IDbAccessFactory 應回傳非 null 實例")]
+        public void ResolveDbAccessFactory_FromDI_ReturnsNonNull()
+        {
+            var factory = _fx.GetRequiredService<IDbAccessFactory>();
+            Assert.NotNull(factory);
+        }
+
+        [Fact]
+        [DisplayName("DI 容器解析 IFormRepositoryFactory 應回傳非 null 實例（涵蓋 CreateConfigurableService 路徑）")]
+        public void ResolveFormRepositoryFactory_FromDI_ReturnsNonNull()
+        {
+            var factory = _fx.GetRequiredService<IFormRepositoryFactory>();
+            Assert.NotNull(factory);
+        }
+
+        [Fact]
+        [DisplayName("DI 容器解析 IBusinessObjectFactory 應回傳非 null 實例（涵蓋 CreateBusinessObjectFactory 路徑）")]
+        public void ResolveBusinessObjectFactory_FromDI_ReturnsNonNull()
+        {
+            var factory = _fx.GetRequiredService<IBusinessObjectFactory>();
+            Assert.NotNull(factory);
+        }
+
+        [Fact]
+        [DisplayName("DI 容器以預設設定解析 IApiEncryptionKeyProvider 應回傳非 null 實例（涵蓋 DynamicApiEncryptionKeyProvider 路徑）")]
+        public void ResolveApiEncryptionKeyProvider_DefaultConfig_ReturnsNonNull()
+        {
+            var provider = _fx.GetRequiredService<IApiEncryptionKeyProvider>();
+            Assert.NotNull(provider);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -22,7 +22,7 @@ namespace Bee.Repository.UnitTests
                 _fx.GetRequiredService<IDbConnectionManager>());
 
         [Fact]
-        [DisplayName("Ctor 傳入 null IDefineAccess 應拋出 ArgumentNullException")]
+        [DisplayName("FormRepositoryFactory 傳入 null defineAccess 應拋出 ArgumentNullException")]
         public void Ctor_NullDefineAccess_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
@@ -32,7 +32,7 @@ namespace Bee.Repository.UnitTests
         }
 
         [Fact]
-        [DisplayName("Ctor 傳入 null IDbAccessFactory 應拋出 ArgumentNullException")]
+        [DisplayName("FormRepositoryFactory 傳入 null dbAccessFactory 應拋出 ArgumentNullException")]
         public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
@@ -42,7 +42,7 @@ namespace Bee.Repository.UnitTests
         }
 
         [Fact]
-        [DisplayName("Ctor 傳入 null IDbConnectionManager 應拋出 ArgumentNullException")]
+        [DisplayName("FormRepositoryFactory 傳入 null connectionManager 應拋出 ArgumentNullException")]
         public void Ctor_NullConnectionManager_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -59,7 +59,7 @@ namespace Bee.Repository.UnitTests
         public void CreateDataFormRepository_NullOrWhitespaceProgId_ThrowsArgumentException(string? progId)
         {
             var factory = CreateFactory();
-            Assert.Throws<ArgumentException>(() => factory.CreateDataFormRepository(progId!));
+            Assert.ThrowsAny<ArgumentException>(() => factory.CreateDataFormRepository(progId!));
         }
 
         [Fact]

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition.Storage;
+using Bee.Repository.Factories;
+using Bee.Tests.Shared;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="FormRepositoryFactory"/> 的純邏輯測試。
+    /// </summary>
+    public class FormRepositoryFactoryTests : IClassFixture<BeeTestFixture>
+    {
+        private readonly BeeTestFixture _fx;
+
+        public FormRepositoryFactoryTests(BeeTestFixture fx) { _fx = fx; }
+
+        private FormRepositoryFactory CreateFactory() =>
+            new(_fx.GetRequiredService<IDefineAccess>(),
+                _fx.GetRequiredService<IDbAccessFactory>(),
+                _fx.GetRequiredService<IDbConnectionManager>());
+
+        [Fact]
+        [DisplayName("Ctor 傳入 null IDefineAccess 應拋出 ArgumentNullException")]
+        public void Ctor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
+                null!,
+                _fx.GetRequiredService<IDbAccessFactory>(),
+                _fx.GetRequiredService<IDbConnectionManager>()));
+        }
+
+        [Fact]
+        [DisplayName("Ctor 傳入 null IDbAccessFactory 應拋出 ArgumentNullException")]
+        public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
+                _fx.GetRequiredService<IDefineAccess>(),
+                null!,
+                _fx.GetRequiredService<IDbConnectionManager>()));
+        }
+
+        [Fact]
+        [DisplayName("Ctor 傳入 null IDbConnectionManager 應拋出 ArgumentNullException")]
+        public void Ctor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
+                _fx.GetRequiredService<IDefineAccess>(),
+                _fx.GetRequiredService<IDbAccessFactory>(),
+                null!));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("CreateDataFormRepository 傳入 null 或空白 progId 應拋出 ArgumentException")]
+        public void CreateDataFormRepository_NullOrWhitespaceProgId_ThrowsArgumentException(string? progId)
+        {
+            var factory = CreateFactory();
+            Assert.Throws<ArgumentException>(() => factory.CreateDataFormRepository(progId!));
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 有效 progId 應回傳 IDataFormRepository 實例")]
+        public void CreateDataFormRepository_ValidProgId_ReturnsIDataFormRepository()
+        {
+            var factory = CreateFactory();
+            var repo = factory.CreateDataFormRepository("Employee");
+            Assert.NotNull(repo);
+        }
+
+        [Fact]
+        [DisplayName("CreateReportFormRepository 有效 progId 應回傳 IReportFormRepository 實例")]
+        public void CreateReportFormRepository_ValidProgId_ReturnsIReportFormRepository()
+        {
+            var factory = CreateFactory();
+            var repo = factory.CreateReportFormRepository("Employee");
+            Assert.NotNull(repo);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Repository/Factories/FormRepositoryFactory.cs` | 0% | 6 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 83% | 6 |

## 無法處理（列入追蹤）

| 檔案 | 覆蓋率 | 原因 |
|------|--------|------|
| `src/Bee.Base/AssemblyLoader.cs` | 85% | 6 個未覆蓋行在 `FileNotFoundException` fallback 路徑，需要真實外部組件檔案才能觸發 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% | 6 個未覆蓋行在 `ReadAllTextShared` IOException 重試迴圈與 `LoadFromFile` race condition fallback，需並行 I/O 觸發 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 79.3% | 6 個未覆蓋行在 `GetCommandText` 的 `StringBuilder` 區塊，需要有 schema 差異的真實 DB 才能產生非空 upgrade plan |


---
_Generated by [Claude Code](https://claude.ai/code/session_014cuMRNWh9TzH9MQ1YYK6ee)_