### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-15 08:44

### DIFF
--- a/tests/Bee.Db.UnitTests/TableSchemaBuilderExtraTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaBuilderExtraTests.cs
@@ -6,11 +6,11 @@ using Bee.Tests.Shared;
 
 namespace Bee.Db.UnitTests
 {
-    public class TableSchemaBuilderExtraTests : IClassFixture<BeeTestFixture>
+    public class TableSchemaBuilderExtraTests : IClassFixture<SharedDbFixture>
     {
-        private readonly BeeTestFixture _fx;
+        private readonly SharedDbFixture _fx;
 
-        public TableSchemaBuilderExtraTests(BeeTestFixture fx) { _fx = fx; }
+        public TableSchemaBuilderExtraTests(SharedDbFixture fx) { _fx = fx; }
 
         [Fact]
         [DisplayName("TableSchemaBuilder 建構子傳入空白 databaseId 應拋出 ArgumentException")]

--- a/tests/Bee.Db.UnitTests/TableSchemaBuilderExtraTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaBuilderExtraTests.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using Bee.Db.Manager;
+using Bee.Db.Schema;
+using Bee.Definition.Storage;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests
+{
+    public class TableSchemaBuilderExtraTests : IClassFixture<BeeTestFixture>
+    {
+        private readonly BeeTestFixture _fx;
+
+        public TableSchemaBuilderExtraTests(BeeTestFixture fx) { _fx = fx; }
+
+        [Fact]
+        [DisplayName("TableSchemaBuilder 建構子傳入空白 databaseId 應拋出 ArgumentException")]
+        public void Ctor_WhitespaceDatabaseId_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new TableSchemaBuilder("   ", null!, null!));
+        }
+
+        [Fact]
+        [DisplayName("TableSchemaBuilder 建構子傳入 null defineAccess 應拋出 ArgumentNullException")]
+        public void Ctor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new TableSchemaBuilder(
+                    "test_db",
+                    null!,
+                    _fx.GetRequiredService<IDbConnectionManager>()));
+        }
+
+        [Fact]
+        [DisplayName("TableSchemaBuilder 建構子傳入 null connectionManager 應拋出 ArgumentNullException")]
+        public void Ctor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new TableSchemaBuilder(
+                    "test_db",
+                    _fx.GetRequiredService<IDefineAccess>(),
+                    null!));
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -3,75 +3,145 @@ using Bee.Business;
 using Bee.Definition;
 using Bee.Definition.Identity;
 using Bee.Definition.Security;
+using Bee.Definition.Settings;
 using Bee.Repository.Abstractions.Factories;
-using Bee.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Bee.Hosting.UnitTests
 {
-    /// <summary>
-    /// 驗證 AddBeeFramework 注冊的服務可從 DI 容器正常解析，
-    /// 同時涵蓋各 singleton lambda 中的 CreateConfigurableService 等私有方法路徑。
-    /// </summary>
-    public class BeeFrameworkServiceResolutionTests : IClassFixture<BeeTestFixture>
+    public class BeeFrameworkServiceResolutionTests
     {
-        private readonly BeeTestFixture _fx;
-
-        public BeeFrameworkServiceResolutionTests(BeeTestFixture fx) { _fx = fx; }
-
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 IFormRepositoryFactory")]
         public void AddBeeFramework_CanResolve_IFormRepositoryFactory()
         {
-            var service = _fx.GetRequiredService<IFormRepositoryFactory>();
-            Assert.NotNull(service);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(new BackendConfiguration(), new PathOptions { DefinePath = tempDir }, autoCreateMasterKey: true);
+                using var sp = services.BuildServiceProvider();
+                Assert.NotNull(sp.GetRequiredService<IFormRepositoryFactory>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
         }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 ISystemRepositoryFactory")]
         public void AddBeeFramework_CanResolve_ISystemRepositoryFactory()
         {
-            var service = _fx.GetRequiredService<ISystemRepositoryFactory>();
-            Assert.NotNull(service);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(new BackendConfiguration(), new PathOptions { DefinePath = tempDir }, autoCreateMasterKey: true);
+                using var sp = services.BuildServiceProvider();
+                Assert.NotNull(sp.GetRequiredService<ISystemRepositoryFactory>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
         }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 IBusinessObjectFactory")]
         public void AddBeeFramework_CanResolve_IBusinessObjectFactory()
         {
-            var service = _fx.GetRequiredService<IBusinessObjectFactory>();
-            Assert.NotNull(service);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(new BackendConfiguration(), new PathOptions { DefinePath = tempDir }, autoCreateMasterKey: true);
+                using var sp = services.BuildServiceProvider();
+                Assert.NotNull(sp.GetRequiredService<IBusinessObjectFactory>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
         }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 ISessionInfoService")]
         public void AddBeeFramework_CanResolve_ISessionInfoService()
         {
-            var service = _fx.GetRequiredService<ISessionInfoService>();
-            Assert.NotNull(service);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(new BackendConfiguration(), new PathOptions { DefinePath = tempDir }, autoCreateMasterKey: true);
+                using var sp = services.BuildServiceProvider();
+                Assert.NotNull(sp.GetRequiredService<ISessionInfoService>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
         }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 IAccessTokenValidator")]
         public void AddBeeFramework_CanResolve_IAccessTokenValidator()
         {
-            var service = _fx.GetRequiredService<IAccessTokenValidator>();
-            Assert.NotNull(service);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(new BackendConfiguration(), new PathOptions { DefinePath = tempDir }, autoCreateMasterKey: true);
+                using var sp = services.BuildServiceProvider();
+                Assert.NotNull(sp.GetRequiredService<IAccessTokenValidator>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
         }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 IFormBoTypeResolver")]
         public void AddBeeFramework_CanResolve_IFormBoTypeResolver()
         {
-            var service = _fx.GetRequiredService<IFormBoTypeResolver>();
-            Assert.NotNull(service);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(new BackendConfiguration(), new PathOptions { DefinePath = tempDir }, autoCreateMasterKey: true);
+                using var sp = services.BuildServiceProvider();
+                Assert.NotNull(sp.GetRequiredService<IFormBoTypeResolver>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
         }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 IEnterpriseObjectService")]
         public void AddBeeFramework_CanResolve_IEnterpriseObjectService()
         {
-            var service = _fx.GetRequiredService<IEnterpriseObjectService>();
-            Assert.NotNull(service);
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-res-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(new BackendConfiguration(), new PathOptions { DefinePath = tempDir }, autoCreateMasterKey: true);
+                using var sp = services.BuildServiceProvider();
+                Assert.NotNull(sp.GetRequiredService<IEnterpriseObjectService>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
         }
     }
 }

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -3,54 +3,20 @@ using Bee.Business;
 using Bee.Definition;
 using Bee.Definition.Identity;
 using Bee.Definition.Security;
-using Bee.Definition.Settings;
 using Bee.Repository.Abstractions.Factories;
-using Microsoft.Extensions.DependencyInjection;
+using Bee.Tests.Shared;
 
 namespace Bee.Hosting.UnitTests
 {
     /// <summary>
-    /// Fixture that builds an isolated <see cref="ServiceProvider"/> via
-    /// <c>AddBeeFramework</c> without the process-wide <c>TestProcessBootstrap</c>;
-    /// parallels the inline approach used by <see cref="BeeFrameworkIntegrationTests"/>.
-    /// </summary>
-    public sealed class BeeServiceProviderFixture : IDisposable
-    {
-        private readonly string _tempDir;
-        private readonly ServiceProvider _provider;
-
-        public BeeServiceProviderFixture()
-        {
-            _tempDir = Path.Combine(Path.GetTempPath(), $"bee-svc-{Guid.NewGuid():N}");
-            Directory.CreateDirectory(_tempDir);
-            var services = new ServiceCollection();
-            services.AddBeeFramework(
-                new BackendConfiguration(),
-                new PathOptions { DefinePath = _tempDir },
-                autoCreateMasterKey: true);
-            _provider = services.BuildServiceProvider();
-        }
-
-        public T GetRequiredService<T>() where T : notnull
-            => _provider.GetRequiredService<T>();
-
-        public void Dispose()
-        {
-            _provider.Dispose();
-            try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
-            GC.SuppressFinalize(this);
-        }
-    }
-
-    /// <summary>
     /// 驗證 AddBeeFramework 注冊的服務可從 DI 容器正常解析，
     /// 同時涵蓋各 singleton lambda 中的 CreateConfigurableService 等私有方法路徑。
     /// </summary>
-    public class BeeFrameworkServiceResolutionTests : IClassFixture<BeeServiceProviderFixture>
+    public class BeeFrameworkServiceResolutionTests : IClassFixture<BeeTestFixture>
     {
-        private readonly BeeServiceProviderFixture _fx;
+        private readonly BeeTestFixture _fx;
 
-        public BeeFrameworkServiceResolutionTests(BeeServiceProviderFixture fx) { _fx = fx; }
+        public BeeFrameworkServiceResolutionTests(BeeTestFixture fx) { _fx = fx; }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 IFormRepositoryFactory")]

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -3,20 +3,54 @@ using Bee.Business;
 using Bee.Definition;
 using Bee.Definition.Identity;
 using Bee.Definition.Security;
+using Bee.Definition.Settings;
 using Bee.Repository.Abstractions.Factories;
-using Bee.Tests.Shared;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Bee.Hosting.UnitTests
 {
     /// <summary>
+    /// Fixture that builds an isolated <see cref="ServiceProvider"/> via
+    /// <c>AddBeeFramework</c> without the process-wide <c>TestProcessBootstrap</c>;
+    /// parallels the inline approach used by <see cref="BeeFrameworkIntegrationTests"/>.
+    /// </summary>
+    public sealed class BeeServiceProviderFixture : IDisposable
+    {
+        private readonly string _tempDir;
+        private readonly ServiceProvider _provider;
+
+        public BeeServiceProviderFixture()
+        {
+            _tempDir = Path.Combine(Path.GetTempPath(), $"bee-svc-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_tempDir);
+            var services = new ServiceCollection();
+            services.AddBeeFramework(
+                new BackendConfiguration(),
+                new PathOptions { DefinePath = _tempDir },
+                autoCreateMasterKey: true);
+            _provider = services.BuildServiceProvider();
+        }
+
+        public T GetRequiredService<T>() where T : notnull
+            => _provider.GetRequiredService<T>();
+
+        public void Dispose()
+        {
+            _provider.Dispose();
+            try { Directory.Delete(_tempDir, recursive: true); } catch (IOException) { }
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <summary>
     /// 驗證 AddBeeFramework 注冊的服務可從 DI 容器正常解析，
     /// 同時涵蓋各 singleton lambda 中的 CreateConfigurableService 等私有方法路徑。
     /// </summary>
-    public class BeeFrameworkServiceResolutionTests : IClassFixture<BeeTestFixture>
+    public class BeeFrameworkServiceResolutionTests : IClassFixture<BeeServiceProviderFixture>
     {
-        private readonly BeeTestFixture _fx;
+        private readonly BeeServiceProviderFixture _fx;
 
-        public BeeFrameworkServiceResolutionTests(BeeTestFixture fx) { _fx = fx; }
+        public BeeFrameworkServiceResolutionTests(BeeServiceProviderFixture fx) { _fx = fx; }
 
         [Fact]
         [DisplayName("AddBeeFramework 建立的容器應能解析 IFormRepositoryFactory")]

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+using Bee.Business;
+using Bee.Definition;
+using Bee.Definition.Identity;
+using Bee.Definition.Security;
+using Bee.Repository.Abstractions.Factories;
+using Bee.Tests.Shared;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 驗證 AddBeeFramework 注冊的服務可從 DI 容器正常解析，
+    /// 同時涵蓋各 singleton lambda 中的 CreateConfigurableService 等私有方法路徑。
+    /// </summary>
+    public class BeeFrameworkServiceResolutionTests : IClassFixture<BeeTestFixture>
+    {
+        private readonly BeeTestFixture _fx;
+
+        public BeeFrameworkServiceResolutionTests(BeeTestFixture fx) { _fx = fx; }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 建立的容器應能解析 IFormRepositoryFactory")]
+        public void AddBeeFramework_CanResolve_IFormRepositoryFactory()
+        {
+            var service = _fx.GetRequiredService<IFormRepositoryFactory>();
+            Assert.NotNull(service);
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 建立的容器應能解析 ISystemRepositoryFactory")]
+        public void AddBeeFramework_CanResolve_ISystemRepositoryFactory()
+        {
+            var service = _fx.GetRequiredService<ISystemRepositoryFactory>();
+            Assert.NotNull(service);
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 建立的容器應能解析 IBusinessObjectFactory")]
+        public void AddBeeFramework_CanResolve_IBusinessObjectFactory()
+        {
+            var service = _fx.GetRequiredService<IBusinessObjectFactory>();
+            Assert.NotNull(service);
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 建立的容器應能解析 ISessionInfoService")]
+        public void AddBeeFramework_CanResolve_ISessionInfoService()
+        {
+            var service = _fx.GetRequiredService<ISessionInfoService>();
+            Assert.NotNull(service);
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 建立的容器應能解析 IAccessTokenValidator")]
+        public void AddBeeFramework_CanResolve_IAccessTokenValidator()
+        {
+            var service = _fx.GetRequiredService<IAccessTokenValidator>();
+            Assert.NotNull(service);
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 建立的容器應能解析 IFormBoTypeResolver")]
+        public void AddBeeFramework_CanResolve_IFormBoTypeResolver()
+        {
+            var service = _fx.GetRequiredService<IFormBoTypeResolver>();
+            Assert.NotNull(service);
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 建立的容器應能解析 IEnterpriseObjectService")]
+        public void AddBeeFramework_CanResolve_IEnterpriseObjectService()
+        {
+            var service = _fx.GetRequiredService<IEnterpriseObjectService>();
+            Assert.NotNull(service);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -63,11 +63,11 @@ namespace Bee.Repository.UnitTests
         }
 
         [Fact]
-        [DisplayName("CreateDataFormRepository 傳入 null progId 應拋出 ArgumentException")]
-        public void CreateDataFormRepository_NullProgId_ThrowsArgumentException()
+        [DisplayName("CreateDataFormRepository 傳入 null progId 應拋出 ArgumentNullException")]
+        public void CreateDataFormRepository_NullProgId_ThrowsArgumentNullException()
         {
             var factory = NewFactory();
-            Assert.Throws<ArgumentException>(() => factory.CreateDataFormRepository(null!));
+            Assert.Throws<ArgumentNullException>(() => factory.CreateDataFormRepository(null!));
         }
 
         [Fact]

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition.Storage;
+using Bee.Repository.Abstractions.Form;
+using Bee.Repository.Factories;
+using Bee.Repository.Form;
+using Bee.Tests.Shared;
+
+namespace Bee.Repository.UnitTests
+{
+    public class FormRepositoryFactoryTests : IClassFixture<BeeTestFixture>
+    {
+        private readonly BeeTestFixture _fx;
+
+        public FormRepositoryFactoryTests(BeeTestFixture fx) { _fx = fx; }
+
+        private FormRepositoryFactory NewFactory() => new(
+            _fx.GetRequiredService<IDefineAccess>(),
+            _fx.GetRequiredService<IDbAccessFactory>(),
+            _fx.GetRequiredService<IDbConnectionManager>());
+
+        [Fact]
+        [DisplayName("建構子傳入 null IDefineAccess 應拋出 ArgumentNullException")]
+        public void Ctor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(
+                    null!,
+                    _fx.GetRequiredService<IDbAccessFactory>(),
+                    _fx.GetRequiredService<IDbConnectionManager>()));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null IDbAccessFactory 應拋出 ArgumentNullException")]
+        public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(
+                    _fx.GetRequiredService<IDefineAccess>(),
+                    null!,
+                    _fx.GetRequiredService<IDbConnectionManager>()));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null IDbConnectionManager 應拋出 ArgumentNullException")]
+        public void Ctor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(
+                    _fx.GetRequiredService<IDefineAccess>(),
+                    _fx.GetRequiredService<IDbAccessFactory>(),
+                    null!));
+        }
+
+        [Fact]
+        [DisplayName("CreateReportFormRepository 傳入有效 progId 應回傳 ReportFormRepository 型別")]
+        public void CreateReportFormRepository_ValidProgId_ReturnsReportFormRepository()
+        {
+            var factory = NewFactory();
+            var repo = factory.CreateReportFormRepository("Employee");
+            Assert.IsType<ReportFormRepository>(repo);
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 傳入 null progId 應拋出 ArgumentException")]
+        public void CreateDataFormRepository_NullProgId_ThrowsArgumentException()
+        {
+            var factory = NewFactory();
+            Assert.Throws<ArgumentException>(() => factory.CreateDataFormRepository(null!));
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 傳入空白 progId 應拋出 ArgumentException")]
+        public void CreateDataFormRepository_WhitespaceProgId_ThrowsArgumentException()
+        {
+            var factory = NewFactory();
+            Assert.Throws<ArgumentException>(() => factory.CreateDataFormRepository("   "));
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 傳入有效 progId 應回傳 IDataFormRepository 實作")]
+        public void CreateDataFormRepository_ValidProgId_ReturnsDataFormRepository()
+        {
+            var factory = NewFactory();
+            var repo = factory.CreateDataFormRepository("Employee");
+            Assert.IsAssignableFrom<IDataFormRepository>(repo);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -9,11 +9,11 @@ using Bee.Tests.Shared;
 
 namespace Bee.Repository.UnitTests
 {
-    public class FormRepositoryFactoryTests : IClassFixture<BeeTestFixture>
+    public class FormRepositoryFactoryTests : IClassFixture<SharedDbFixture>
     {
-        private readonly BeeTestFixture _fx;
+        private readonly SharedDbFixture _fx;
 
-        public FormRepositoryFactoryTests(BeeTestFixture fx) { _fx = fx; }
+        public FormRepositoryFactoryTests(SharedDbFixture fx) { _fx = fx; }
 
         private FormRepositoryFactory NewFactory() => new(
             _fx.GetRequiredService<IDefineAccess>(),


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Repository/Factories/FormRepositoryFactory.cs` | 0.0% | 7 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 83.0% | 7 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 79.3% | 3 |

### 說明

**FormRepositoryFactory**（`tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs`）：
新增建構子 null 參數驗證（3 個）、`CreateReportFormRepository` 回傳型別驗證、`CreateDataFormRepository` 的空白/null progId 拋例外驗證，以及有效 progId 建立成功驗證。

**BeeFrameworkServiceCollectionExtensions**（`tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs`）：
透過解析 `IFormRepositoryFactory`、`ISystemRepositoryFactory`、`IBusinessObjectFactory`、`ISessionInfoService`、`IAccessTokenValidator`、`IFormBoTypeResolver`、`IEnterpriseObjectService` 等服務，涵蓋各 singleton lambda 中的 `CreateConfigurableService`、`CreateBusinessObjectFactory`、`CreateOrDefault` 私有方法路徑。

**TableSchemaBuilder**（`tests/Bee.Db.UnitTests/TableSchemaBuilderExtraTests.cs`）：
新增建構子的 whitespace databaseId、null defineAccess、null connectionManager 三條錯誤路徑驗證。

### 無法處理（需人工規劃）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/AssemblyLoader.cs` | 未覆蓋行為 `catch (FileNotFoundException)` 的 fallback 路徑，需載入不在 AppDomain 中的組件，標準 unit test 無法重現 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋行為為檔案建立競爭的 `IOException` catch 路徑及 `ReadAllTextShared` 的重試迴圈，屬競態條件，標準 unit test 無法重現 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ji83dWW28KZaSrGEw2yaQX)_