### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-15 16:53

### DIFF
--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+using Bee.Business.Providers;
+using Bee.Definition;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Hosting.UnitTests
+{
+    public class BeeFrameworkServiceResolutionTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 預設設定解析 IApiEncryptionKeyProvider 應回傳 DynamicApiEncryptionKeyProvider")]
+        public void AddBeeFramework_DefaultConfig_ResolvesDynamicApiEncryptionKeyProvider()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-dyn-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(new BackendConfiguration(), pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var provider = sp.GetRequiredService<IApiEncryptionKeyProvider>();
+
+                Assert.IsType<DynamicApiEncryptionKeyProvider>(provider);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 預設設定解析 IEnterpriseObjectService 應回傳有效實例")]
+        public void AddBeeFramework_DefaultConfig_ResolvesEnterpriseObjectService()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-eos-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(new BackendConfiguration(), pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var eos = sp.GetRequiredService<IEnterpriseObjectService>();
+
+                Assert.NotNull(eos);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -1,0 +1,112 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.Repository.Factories;
+using Bee.Tests.Shared;
+
+namespace Bee.Repository.UnitTests
+{
+    public class FormRepositoryFactoryTests : IClassFixture<SharedDbFixture>
+    {
+        private readonly SharedDbFixture _fx;
+
+        public FormRepositoryFactoryTests(SharedDbFixture fx) { _fx = fx; }
+
+        private FormRepositoryFactory CreateFactory(IDefineAccess? defineAccess = null)
+            => new(
+                defineAccess ?? _fx.GetRequiredService<IDefineAccess>(),
+                _fx.GetRequiredService<IDbAccessFactory>(),
+                _fx.GetRequiredService<IDbConnectionManager>());
+
+        [Fact]
+        [DisplayName("FormRepositoryFactory 傳入 null defineAccess 應拋 ArgumentNullException")]
+        public void Ctor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(null!, null!, null!));
+        }
+
+        [Fact]
+        [DisplayName("FormRepositoryFactory 傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(
+                    _fx.GetRequiredService<IDefineAccess>(),
+                    null!,
+                    null!));
+        }
+
+        [Fact]
+        [DisplayName("FormRepositoryFactory 傳入 null connectionManager 應拋 ArgumentNullException")]
+        public void Ctor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(
+                    _fx.GetRequiredService<IDefineAccess>(),
+                    _fx.GetRequiredService<IDbAccessFactory>(),
+                    null!));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("CreateDataFormRepository 空白或 null progId 應拋 ArgumentException")]
+        public void CreateDataFormRepository_BlankProgId_ThrowsArgumentException(string? progId)
+        {
+            var factory = CreateFactory();
+            var ex = Record.Exception(() => factory.CreateDataFormRepository(progId!));
+            Assert.IsAssignableFrom<ArgumentException>(ex);
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository CategoryId 為空的 FormSchema 應拋 InvalidOperationException")]
+        public void CreateDataFormRepository_EmptyCategoryId_ThrowsInvalidOperationException()
+        {
+            var schema = new FormSchema("TestProg", "測試") { CategoryId = string.Empty };
+            var factory = CreateFactory(new MinimalDefineAccess(schema));
+
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                factory.CreateDataFormRepository("TestProg"));
+            Assert.Contains("CategoryId", ex.Message);
+        }
+
+        [Fact]
+        [DisplayName("CreateReportFormRepository 有效 progId 應回傳非 null 的 IReportFormRepository 實例")]
+        public void CreateReportFormRepository_ValidProgId_ReturnsRepository()
+        {
+            var factory = CreateFactory();
+            var repo = factory.CreateReportFormRepository("AnyReport");
+            Assert.NotNull(repo);
+        }
+
+        private sealed class MinimalDefineAccess : IDefineAccess
+        {
+            private readonly FormSchema _schema;
+            public MinimalDefineAccess(FormSchema schema) => _schema = schema;
+            public FormSchema GetFormSchema(string progId) => _schema;
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Repository/Factories/FormRepositoryFactory.cs` | 0% | 6 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 83% | 2 |

### 新增測試說明

**FormRepositoryFactory（6 個測試）**
- 建構子 null 參數防護（`defineAccess`、`dbAccessFactory`、`connectionManager`）
- `CreateDataFormRepository` 空白/null progId 防護（Theory）
- `CreateDataFormRepository` CategoryId 為空時拋出 InvalidOperationException
- `CreateReportFormRepository` 正常路徑回傳非 null 實例

**BeeFrameworkServiceCollectionExtensions（2 個測試）**
- 預設設定下解析 `IApiEncryptionKeyProvider` 應回傳 `DynamicApiEncryptionKeyProvider`（涵蓋 `CreateApiEncryptionKeyProvider` 非 static 路徑）
- 預設設定下解析 `IEnterpriseObjectService` 應回傳有效實例（涵蓋 `CreateOrDefault<T>`）

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/AssemblyLoader.cs` | `LoadAssembly` FileNotFoundException 回退路徑需要特定組件檔案情境，無法在一般單元測試中可靠重現 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | `ReadAllTextShared` retry catch 與 `LoadFromFile` 競態 IOException 需要 OS 層級檔案鎖定，無法在單元測試中可靠重現 |
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | `GetCommandText` StringBuilder 迴圈路徑需要真實 DB 且資料表結構有 schema drift，需整合測試環境設定 |

https://claude.ai/code/session_01U3pZyRWwAYQbmbfvHaU11j

---
_Generated by [Claude Code](https://claude.ai/code/session_01U3pZyRWwAYQbmbfvHaU11j)_