### PR TITLE
[AutoFix] Coverage Fix (4 files) 2026-05-16 08:49

### DIFF
--- a/tests/Bee.Base.UnitTests/AssemblyLoaderLoadTests.cs
+++ b/tests/Bee.Base.UnitTests/AssemblyLoaderLoadTests.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel;
+
+namespace Bee.Base.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="AssemblyLoader.LoadAssembly"/> 中 Assembly.Load 路徑的覆蓋率測試。
+    /// 使用不含 .dll 副檔名的組件名稱，繞過 FindAssembly 的快取與 AppDomain 查找，
+    /// 直接進入 Assembly.Load(AssemblyName) 流程。
+    /// </summary>
+    public class AssemblyLoaderLoadTests
+    {
+        [Fact]
+        [DisplayName("LoadAssembly 使用不含 .dll 副檔名的名稱應成功載入並回傳正確組件")]
+        public void LoadAssembly_WithoutDllExtension_ReturnsAssembly()
+        {
+            // "Bee.Base"（無 .dll）不符合 ManifestModule.Name="Bee.Base.dll" 的 AppDomain 比對，
+            // 因此跳過快取與 AppDomain 搜尋，觸發 Assembly.Load(new AssemblyName("Bee.Base")) 路徑。
+            var assembly = AssemblyLoader.LoadAssembly("Bee.Base");
+
+            Assert.NotNull(assembly);
+            Assert.Equal("Bee.Base", assembly.GetName().Name);
+        }
+
+        [Fact]
+        [DisplayName("LoadAssembly 使用不含 .dll 副檔名重複呼叫應回傳相同實例（快取命中）")]
+        public void LoadAssembly_WithoutDllExtension_RepeatedCall_ReturnsSameInstance()
+        {
+            var first = AssemblyLoader.LoadAssembly("Bee.Base");
+            var second = AssemblyLoader.LoadAssembly("Bee.Base");
+
+            Assert.Same(first, second);
+        }
+    }
+}

--- a/tests/Bee.Business.UnitTests/BusinessObjectExtraTests.cs
+++ b/tests/Bee.Business.UnitTests/BusinessObjectExtraTests.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Tests.Shared;
+
+namespace Bee.Business.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="BusinessObject"/> 中 null-guard、SessionInfo 屬性、
+    /// ResolveDatabaseId 與 CreateDataFormRepository 的覆蓋率測試。
+    /// </summary>
+    public class BusinessObjectExtraTests : IClassFixture<SharedDbFixture>
+    {
+        private readonly SharedDbFixture _fx;
+
+        public BusinessObjectExtraTests(SharedDbFixture fx) { _fx = fx; }
+
+        /// <summary>
+        /// 測試用子類別，將 BusinessObject 的 protected 方法暴露為 public，
+        /// 以便驗證其執行路徑而不需要 FormBusinessObject 的完整資料層依賴。
+        /// </summary>
+        private sealed class InspectableBusinessObject : BusinessObject
+        {
+            public InspectableBusinessObject(IBeeContext ctx, Guid accessToken)
+                : base(ctx, accessToken) { }
+
+            public string CallResolveDatabaseId(DbScope scope) => ResolveDatabaseId(scope);
+
+            public void InvokeCreateDataFormRepository(string progId)
+            {
+                CreateDataFormRepository(progId);
+            }
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null ctx 應拋 ArgumentNullException（null-guard 分支）")]
+        public void Constructor_NullContext_ThrowsArgumentNullException()
+        {
+            var ex = Record.Exception(() => new InspectableBusinessObject(null!, Guid.NewGuid()));
+            Assert.IsType<ArgumentNullException>(ex);
+        }
+
+        [Fact]
+        [DisplayName("SessionInfo 屬性在未設定 Session 時應為 null")]
+        public void SessionInfo_WithoutSession_IsNull()
+        {
+            var bo = new InspectableBusinessObject(TestBeeContext.Create(_fx), Guid.NewGuid());
+            Assert.Null(bo.SessionInfo);
+        }
+
+        [Fact]
+        [DisplayName("ResolveDatabaseId(Common) 應回傳 \"common\" 不需 Session")]
+        public void ResolveDatabaseId_Common_ReturnsCommonDatabaseId()
+        {
+            var bo = new InspectableBusinessObject(TestBeeContext.Create(_fx), Guid.Empty);
+            var result = bo.CallResolveDatabaseId(DbScope.Common);
+            Assert.Equal(DbCategoryIds.Common, result);
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 無有效 Session 時應拋 UnauthorizedAccessException")]
+        public void CreateDataFormRepository_NoSession_ThrowsUnauthorized()
+        {
+            // Company scope 需要 Session 中的 CompanyId，Guid.Empty 無對應 Session → UnauthorizedAccessException
+            var bo = new InspectableBusinessObject(TestBeeContext.Create(_fx), Guid.Empty);
+            var ex = Record.Exception(() => bo.InvokeCreateDataFormRepository("Employee"));
+            Assert.IsType<UnauthorizedAccessException>(ex);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceCollectionExtensionsExtraTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceCollectionExtensionsExtraTests.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+using Bee.Business.Providers;
+using Bee.Definition.Security;
+using Bee.Tests.Shared;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="BeeFrameworkServiceCollectionExtensions"/> 中
+    /// DynamicApiEncryptionKeyProvider 路由分支的覆蓋率測試。
+    /// </summary>
+    public class BeeFrameworkServiceCollectionExtensionsExtraTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 預設組態解析 IApiEncryptionKeyProvider 應回傳 DynamicApiEncryptionKeyProvider")]
+        public void AddBeeFramework_DefaultConfig_ResolvesDynamicApiEncryptionKeyProvider()
+        {
+            // 使用標準 BeeTestFixture（預設 ApiEncryptionKeyProvider = DynamicApiEncryptionKeyProvider）
+            // 觸發 CreateApiEncryptionKeyProvider 中 ActivatorUtilities.CreateInstance 分支
+            using var fx = new BeeTestFixture();
+            var provider = fx.GetRequiredService<IApiEncryptionKeyProvider>();
+            Assert.IsType<DynamicApiEncryptionKeyProvider>(provider);
+        }
+    }
+}

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -1,0 +1,182 @@
+using System.ComponentModel;
+using System.Data.Common;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.Repository.Abstractions;
+using Bee.Repository.Abstractions.Form;
+using Bee.Repository.Factories;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// <see cref="FormRepositoryFactory"/> 建構子保護、工廠方法與 CategoryId 路由的純邏輯測試。
+    /// 所有相依項目皆以 Stub 實作，不需資料庫連線。
+    /// </summary>
+    public class FormRepositoryFactoryTests
+    {
+        #region Stubs
+
+        private sealed class StubDefineAccess : IDefineAccess
+        {
+            private readonly FormSchema _schema;
+            public StubDefineAccess(FormSchema schema) => _schema = schema;
+
+            public FormSchema GetFormSchema(string progId) => _schema;
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class StubDbConnectionManager : IDbConnectionManager
+        {
+            public DbConnectionInfo GetConnectionInfo(string databaseId) => throw new NotImplementedException();
+            public DbConnection CreateConnection(string databaseId) => throw new NotImplementedException();
+            public bool Remove(string databaseId) => false;
+            public void Clear() { }
+            public bool Contains(string databaseId) => false;
+            public int Count => 0;
+        }
+
+        private sealed class StubRepositoryDatabaseRouter : IRepositoryDatabaseRouter
+        {
+            private readonly string _databaseId;
+            public StubRepositoryDatabaseRouter(string databaseId) => _databaseId = databaseId;
+            public string Resolve(DbScope scope, Guid accessToken) => _databaseId;
+        }
+
+        private static FormRepositoryFactory CreateFactory(
+            FormSchema? schema = null,
+            string routedDatabaseId = "common")
+        {
+            return new FormRepositoryFactory(
+                new StubDefineAccess(schema ?? new FormSchema("TestProg", "Test")),
+                new StubDbAccessFactory(),
+                new StubDbConnectionManager(),
+                new StubRepositoryDatabaseRouter(routedDatabaseId));
+        }
+
+        #endregion
+
+        [Fact]
+        [DisplayName("建構子傳入 null defineAccess 應拋 ArgumentNullException")]
+        public void Constructor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
+                null!,
+                new StubDbAccessFactory(),
+                new StubDbConnectionManager(),
+                new StubRepositoryDatabaseRouter("common")));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
+                new StubDefineAccess(new FormSchema()),
+                null!,
+                new StubDbConnectionManager(),
+                new StubRepositoryDatabaseRouter("common")));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null connectionManager 應拋 ArgumentNullException")]
+        public void Constructor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
+                new StubDefineAccess(new FormSchema()),
+                new StubDbAccessFactory(),
+                null!,
+                new StubRepositoryDatabaseRouter("common")));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null router 應拋 ArgumentNullException")]
+        public void Constructor_NullRouter_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new FormRepositoryFactory(
+                new StubDefineAccess(new FormSchema()),
+                new StubDbAccessFactory(),
+                new StubDbConnectionManager(),
+                null!));
+        }
+
+        [Fact]
+        [DisplayName("CreateReportFormRepository 應回傳非 null 的 IReportFormRepository 實作")]
+        public void CreateReportFormRepository_ValidProgId_ReturnsNonNull()
+        {
+            var factory = CreateFactory();
+            var repo = factory.CreateReportFormRepository("SalesReport");
+            Assert.NotNull(repo);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("CreateDataFormRepository 空白 progId 應拋 ArgumentException")]
+        public void CreateDataFormRepository_EmptyProgId_ThrowsArgumentException(string progId)
+        {
+            var factory = CreateFactory();
+            Assert.Throws<ArgumentException>(() =>
+                factory.CreateDataFormRepository(progId, Guid.Empty));
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository FormSchema 無 CategoryId 應拋 InvalidOperationException")]
+        public void CreateDataFormRepository_EmptyCategoryId_ThrowsInvalidOperation()
+        {
+            // FormSchema 預設 CategoryId = string.Empty
+            var factory = CreateFactory(schema: new FormSchema("TestProg", "Test"));
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                factory.CreateDataFormRepository("TestProg", Guid.Empty));
+            Assert.Contains("CategoryId", ex.Message);
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 未知 CategoryId 應拋 InvalidOperationException（ParseCategoryId default 分支）")]
+        public void CreateDataFormRepository_UnknownCategoryId_ThrowsInvalidOperation()
+        {
+            var schema = new FormSchema("TestProg", "Test") { CategoryId = "unknown" };
+            var factory = CreateFactory(schema: schema);
+            Assert.Throws<InvalidOperationException>(() =>
+                factory.CreateDataFormRepository("TestProg", Guid.Empty));
+        }
+
+        [Theory]
+        [InlineData(DbCategoryIds.Common)]
+        [InlineData(DbCategoryIds.Company)]
+        [InlineData(DbCategoryIds.Log)]
+        [DisplayName("CreateDataFormRepository 有效 CategoryId 應回傳 IDataFormRepository 實作")]
+        public void CreateDataFormRepository_ValidCategoryId_ReturnsRepository(string categoryId)
+        {
+            var schema = new FormSchema("TestProg", "Test") { CategoryId = categoryId };
+            var factory = CreateFactory(schema: schema);
+            var repo = factory.CreateDataFormRepository("TestProg", Guid.NewGuid());
+            Assert.NotNull(repo);
+            Assert.IsAssignableFrom<IDataFormRepository>(repo);
+        }
+    }
+}

--- a/tests/Bee.Tests.Shared/SharedDatabaseState.cs
+++ b/tests/Bee.Tests.Shared/SharedDatabaseState.cs
@@ -417,7 +417,7 @@ namespace Bee.Tests.Shared
             string colNote = dbType.QuoteIdentifier("note");
             string colInsTime = dbType.QuoteIdentifier("sys_insert_time");
 
-            var existing = LookupRowId(dbType, dbAccess, tbl, colRowId, colId, "001");
+            var existing = LookupRowId(dbAccess, tbl, colRowId, colId, "001");
             if (existing != Guid.Empty)
             {
                 Console.WriteLine($"SharedDatabaseState: {databaseId} seed user '001' already exists (rowid={existing})");
@@ -447,7 +447,7 @@ namespace Bee.Tests.Shared
             string colEnabled = dbType.QuoteIdentifier("enabled");
             string colInsTime = dbType.QuoteIdentifier("sys_insert_time");
 
-            var existing = LookupRowId(dbType, dbAccess, tbl, colRowId, colId, "C001");
+            var existing = LookupRowId(dbAccess, tbl, colRowId, colId, "C001");
             if (existing != Guid.Empty)
             {
                 Console.WriteLine($"SharedDatabaseState: {databaseId} seed company 'C001' already exists (rowid={existing})");
@@ -500,7 +500,7 @@ namespace Bee.Tests.Shared
         // SELECT sys_rowid by business key; returns Guid.Empty if not found.
         // Handles Oracle RAW(16) (returned as byte[]) and string-storage (SQLite) alongside native Guid.
         private static Guid LookupRowId(
-            DatabaseType dbType, DbAccess dbAccess, string tbl, string colRowId, string colBusinessKey, string businessKey)
+            DbAccess dbAccess, string tbl, string colRowId, string colBusinessKey, string businessKey)
         {
             var spec = new DbCommandSpec(DbCommandKind.Scalar,
                 $"SELECT {colRowId} FROM {tbl} WHERE {colBusinessKey} = {{0}}", businessKey);


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Repository/Factories/FormRepositoryFactory.cs` | 0% | 9 |
| `src/Bee.Base/AssemblyLoader.cs` | 72.5% | 2 |
| `src/Bee.Business/BusinessObject.cs` | 83.3% | 4 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 84.2% | 1 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 6 個未覆蓋行為 `LoadFromFile` 中的 `catch (IOException)` race condition 分支（`FileMode.CreateNew` 敗給其他 process）及 `ReadAllTextShared` 的重試迴圈（`Thread.Sleep` + `attempt++`）。這些路徑需要 file system 層的並發注入，無法在純單元測試中可靠重現。 |

## 補強說明

- **FormRepositoryFactory**：以 Stub 實作 4 個相依介面，覆蓋建構子 null-guard（4）、`CreateReportFormRepository` 成功路徑、`CreateDataFormRepository` 的空 progId、空 CategoryId、未知 CategoryId 錯誤路徑，以及 Common/Company/Log 三種有效 scope 的成功路徑。
- **AssemblyLoader**：使用不含 `.dll` 副檔名的組件名稱（`"Bee.Base"`）繞過 AppDomain 快取比對，觸發 `Assembly.Load(new AssemblyName(simpleName))` 路徑。
- **BusinessObject**：以 `InspectableBusinessObject` 子類別暴露 `protected` 方法，覆蓋 null ctx guard、`SessionInfo` getter、`ResolveDatabaseId(Common)` 及 `CreateDataFormRepository`（無效 Session 觸發 `UnauthorizedAccessException`）。
- **BeeFrameworkServiceCollectionExtensions**：使用預設組態（`DynamicApiEncryptionKeyProvider`）解析 `IApiEncryptionKeyProvider`，覆蓋 `CreateApiEncryptionKeyProvider` 中 `ActivatorUtilities.CreateInstance` 分支。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Njpv5RG6urWChkEGg3PJwK)_