### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-16 16:30

### DIFF
--- a/tests/Bee.Business.UnitTests/BusinessObjectPropertyTests.cs
+++ b/tests/Bee.Business.UnitTests/BusinessObjectPropertyTests.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel;
+using Bee.Business;
+using Bee.Definition;
+using Bee.Definition.Identity;
+using Bee.Definition.Storage;
+using Bee.Tests.Shared;
+
+namespace Bee.Business.UnitTests
+{
+    /// <summary>
+    /// <see cref="BusinessObject"/> 受保護屬性與 <see cref="BusinessObject.SessionInfo"/> 覆蓋測試。
+    /// </summary>
+    public class BusinessObjectPropertyTests : IClassFixture<BeeTestFixture>
+    {
+        private readonly BeeTestFixture _fx;
+
+        public BusinessObjectPropertyTests(BeeTestFixture fx) { _fx = fx; }
+
+        /// <summary>
+        /// 將受保護的屬性與方法暴露為 public，供測試驗證。
+        /// </summary>
+        private sealed class ExposedBusinessObject : BusinessObject
+        {
+            public ExposedBusinessObject(IBeeContext ctx, Guid accessToken)
+                : base(ctx, accessToken) { }
+
+            public IDefineAccess ExposedDefineAccess => DefineAccess;
+            public ISessionInfoService ExposedSessionInfoService => SessionInfoService;
+            public IBusinessObjectFactory ExposedBoFactory => BoFactory;
+            public IServiceProvider ExposedServices => Services;
+            public string InvokeResolveDatabaseId(DbScope scope) => ResolveDatabaseId(scope);
+        }
+
+        [Fact]
+        [DisplayName("SessionInfo 屬性預設應回傳 null（基底類別不設定）")]
+        public void SessionInfo_DefaultValue_ReturnsNull()
+        {
+            var bo = new ExposedBusinessObject(TestBeeContext.Create(_fx), Guid.NewGuid());
+            Assert.Null(bo.SessionInfo);
+        }
+
+        [Fact]
+        [DisplayName("DefineAccess 屬性應轉發 Context 中的 IDefineAccess 實例")]
+        public void DefineAccess_Property_ForwardsContextDefineAccess()
+        {
+            var ctx = TestBeeContext.Create(_fx);
+            var bo = new ExposedBusinessObject(ctx, Guid.NewGuid());
+            Assert.Same(ctx.DefineAccess, bo.ExposedDefineAccess);
+        }
+
+        [Fact]
+        [DisplayName("SessionInfoService 屬性應轉發 Context 中的 ISessionInfoService 實例")]
+        public void SessionInfoService_Property_ForwardsContextSessionInfoService()
+        {
+            var ctx = TestBeeContext.Create(_fx);
+            var bo = new ExposedBusinessObject(ctx, Guid.NewGuid());
+            Assert.Same(ctx.SessionInfoService, bo.ExposedSessionInfoService);
+        }
+
+        [Fact]
+        [DisplayName("BoFactory 屬性應轉發 Context 中的 IBusinessObjectFactory 實例")]
+        public void BoFactory_Property_ForwardsContextBoFactory()
+        {
+            var ctx = TestBeeContext.Create(_fx);
+            var bo = new ExposedBusinessObject(ctx, Guid.NewGuid());
+            Assert.Same(ctx.BoFactory, bo.ExposedBoFactory);
+        }
+
+        [Fact]
+        [DisplayName("Services 屬性應轉發 Context 中的 IServiceProvider 實例")]
+        public void Services_Property_ForwardsContextServices()
+        {
+            var ctx = TestBeeContext.Create(_fx);
+            var bo = new ExposedBusinessObject(ctx, Guid.NewGuid());
+            Assert.Same(ctx.Services, bo.ExposedServices);
+        }
+
+        [Fact]
+        [DisplayName("ResolveDatabaseId(Common) 應回傳非空的 databaseId 字串")]
+        public void ResolveDatabaseId_CommonScope_ReturnsNonEmptyDatabaseId()
+        {
+            var bo = new ExposedBusinessObject(TestBeeContext.Create(_fx), Guid.NewGuid());
+            var databaseId = bo.InvokeResolveDatabaseId(DbScope.Common);
+            Assert.NotEmpty(databaseId);
+        }
+    }
+}

--- a/tests/Bee.Business.UnitTests/BusinessObjectPropertyTests.cs
+++ b/tests/Bee.Business.UnitTests/BusinessObjectPropertyTests.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Bee.Business;
 using Bee.Definition;
 using Bee.Definition.Identity;
 using Bee.Definition.Storage;

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkDynamicProviderTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkDynamicProviderTests.cs
@@ -1,0 +1,68 @@
+using System.ComponentModel;
+using Bee.Business.Providers;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 驗證 <c>AddBeeFramework</c> 以預設組態解析 <see cref="IApiEncryptionKeyProvider"/> 時
+    /// 走動態提供者（<see cref="DynamicApiEncryptionKeyProvider"/>）分支。
+    /// </summary>
+    public class BeeFrameworkDynamicProviderTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 預設組態解析 IApiEncryptionKeyProvider 應回傳 DynamicApiEncryptionKeyProvider")]
+        public void AddBeeFramework_DefaultConfig_ResolvesDynamicApiEncryptionKeyProvider()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-dynamic-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var configuration = new BackendConfiguration();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+
+                services.AddBeeFramework(configuration, pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var provider = sp.GetRequiredService<IApiEncryptionKeyProvider>();
+
+                Assert.IsType<DynamicApiEncryptionKeyProvider>(provider);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 預設組態完整解析服務鏈應不拋例外")]
+        public void AddBeeFramework_DefaultConfig_ResolvesServiceChainWithoutException()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-chain-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var configuration = new BackendConfiguration();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(configuration, pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var exception = Record.Exception(() =>
+                {
+                    _ = sp.GetRequiredService<IApiEncryptionKeyProvider>();
+                    _ = sp.GetRequiredService<Bee.Definition.Storage.IDefineAccess>();
+                });
+
+                Assert.Null(exception);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkDynamicProviderTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkDynamicProviderTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Bee.Business.Providers;
+using Bee.Definition;
 using Bee.Definition.Security;
 using Bee.Definition.Settings;
 using Microsoft.Extensions.DependencyInjection;

--- a/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/FormRepositoryFactoryTests.cs
@@ -1,0 +1,165 @@
+using System.ComponentModel;
+using System.Data.Common;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.Repository.Abstractions;
+using Bee.Repository.Factories;
+using Bee.Repository.Form;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// <see cref="FormRepositoryFactory"/> 建構子驗證與工廠方法測試。
+    /// </summary>
+    public class FormRepositoryFactoryTests
+    {
+        #region Stubs
+
+        private sealed class StubDefineAccess : IDefineAccess
+        {
+            public string CategoryId { get; set; } = DbCategoryIds.Common;
+
+            public DatabaseSettings GetDatabaseSettings() => new();
+            public FormSchema GetFormSchema(string progId) => new() { CategoryId = CategoryId };
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class StubConnectionManager : IDbConnectionManager
+        {
+            public DbConnectionInfo GetConnectionInfo(string databaseId) => throw new NotImplementedException();
+            public DbConnection CreateConnection(string databaseId) => throw new NotImplementedException();
+            public bool Remove(string databaseId) => false;
+            public void Clear() { }
+            public bool Contains(string databaseId) => false;
+            public int Count => 0;
+        }
+
+        private sealed class StubRouter : IRepositoryDatabaseRouter
+        {
+            public string Resolve(DbScope scope, Guid accessToken) => DbCategoryIds.Common;
+        }
+
+        private static FormRepositoryFactory CreateFactory(
+            StubDefineAccess? defineAccess = null,
+            IDbAccessFactory? dbAccessFactory = null,
+            IDbConnectionManager? connectionManager = null,
+            IRepositoryDatabaseRouter? router = null)
+            => new(
+                defineAccess ?? new StubDefineAccess(),
+                dbAccessFactory ?? new StubDbAccessFactory(),
+                connectionManager ?? new StubConnectionManager(),
+                router ?? new StubRouter());
+
+        #endregion
+
+        [Fact]
+        [DisplayName("建構子傳入 null defineAccess 應拋 ArgumentNullException")]
+        public void Constructor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(null!, new StubDbAccessFactory(), new StubConnectionManager(), new StubRouter()));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(new StubDefineAccess(), null!, new StubConnectionManager(), new StubRouter()));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null connectionManager 應拋 ArgumentNullException")]
+        public void Constructor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(new StubDefineAccess(), new StubDbAccessFactory(), null!, new StubRouter()));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null router 應拋 ArgumentNullException")]
+        public void Constructor_NullRouter_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new FormRepositoryFactory(new StubDefineAccess(), new StubDbAccessFactory(), new StubConnectionManager(), null!));
+        }
+
+        [Theory]
+        [InlineData("SalesReport")]
+        [InlineData("EmployeeList")]
+        [DisplayName("CreateReportFormRepository 應回傳 ReportFormRepository 實例")]
+        public void CreateReportFormRepository_ValidProgId_ReturnsReportFormRepository(string progId)
+        {
+            var factory = CreateFactory();
+            var repo = factory.CreateReportFormRepository(progId);
+            Assert.IsType<ReportFormRepository>(repo);
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 傳入空白 progId 應拋 ArgumentException")]
+        public void CreateDataFormRepository_WhitespaceProgId_ThrowsArgumentException()
+        {
+            var factory = CreateFactory();
+            Assert.Throws<ArgumentException>(() => factory.CreateDataFormRepository("   ", Guid.NewGuid()));
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository Schema 無 CategoryId 應拋 InvalidOperationException 且訊息含 CategoryId")]
+        public void CreateDataFormRepository_EmptyCategoryId_ThrowsInvalidOperationException()
+        {
+            var stub = new StubDefineAccess { CategoryId = string.Empty };
+            var factory = CreateFactory(defineAccess: stub);
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => factory.CreateDataFormRepository("Employee", Guid.NewGuid()));
+            Assert.Contains("CategoryId", ex.Message);
+        }
+
+        [Fact]
+        [DisplayName("CreateDataFormRepository 未知 CategoryId 應拋 InvalidOperationException 且訊息含未知值")]
+        public void CreateDataFormRepository_UnknownCategoryId_ThrowsInvalidOperationException()
+        {
+            var stub = new StubDefineAccess { CategoryId = "unknown_db" };
+            var factory = CreateFactory(defineAccess: stub);
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => factory.CreateDataFormRepository("Employee", Guid.NewGuid()));
+            Assert.Contains("unknown_db", ex.Message);
+        }
+
+        [Theory]
+        [InlineData(DbCategoryIds.Common)]
+        [InlineData(DbCategoryIds.Company)]
+        [InlineData(DbCategoryIds.Log)]
+        [DisplayName("CreateDataFormRepository 有效 CategoryId 應回傳 DataFormRepository")]
+        public void CreateDataFormRepository_ValidCategoryId_ReturnsDataFormRepository(string categoryId)
+        {
+            var stub = new StubDefineAccess { CategoryId = categoryId };
+            var factory = CreateFactory(defineAccess: stub);
+            var repo = factory.CreateDataFormRepository("Employee", Guid.NewGuid());
+            Assert.IsType<DataFormRepository>(repo);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Repository/Factories/FormRepositoryFactory.cs` | 0.0% | 9 |
| `src/Bee.Business/BusinessObject.cs` | 83.3% | 6 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 84.2% | 2 |

### 無法處理（共 2 個）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/AssemblyLoader.cs`（72.5%，11 uncovered lines） | 未覆蓋路徑集中在 `LoadAssembly` 的 `Assembly.Load` fallback 分支，需要載入一個尚未在 AppDomain 中的組件才能觸發，單元測試環境無法可靠重現。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs`（87.8%，6 uncovered lines） | 未覆蓋路徑為 `ReadAllTextShared` 重試邏輯（需 IOException 注入）與 `LoadFromFile` 的競爭條件 catch 區塊，需要真實並發模擬，不適合補在單元測試層。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhiNmvGuNEK8aeu6AM1d9e)_