### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-17 00:30

### DIFF
--- a/tests/Bee.Base.UnitTests/AssemblyLoaderExtraTests.cs
+++ b/tests/Bee.Base.UnitTests/AssemblyLoaderExtraTests.cs
@@ -30,5 +30,14 @@ namespace Bee.Base.UnitTests
             Assert.True(result.IsSuccess);
             Assert.Equal("msg", result.Message);
         }
+
+        [Fact]
+        [DisplayName("LoadAssembly 不含 .dll 副檔名時應透過 Assembly.Load 載入正確組件")]
+        public void LoadAssembly_NameWithoutDllExtension_LoadsAssembly()
+        {
+            var assembly = AssemblyLoader.LoadAssembly("Bee.Base");
+            Assert.NotNull(assembly);
+            Assert.Equal("Bee.Base", assembly.GetName().Name);
+        }
     }
 }

--- a/tests/Bee.Base.UnitTests/AssemblyLoaderExtraTests.cs
+++ b/tests/Bee.Base.UnitTests/AssemblyLoaderExtraTests.cs
@@ -30,14 +30,5 @@ namespace Bee.Base.UnitTests
             Assert.True(result.IsSuccess);
             Assert.Equal("msg", result.Message);
         }
-
-        [Fact]
-        [DisplayName("LoadAssembly 不含 .dll 副檔名時應透過 Assembly.Load 載入正確組件")]
-        public void LoadAssembly_NameWithoutDllExtension_LoadsAssembly()
-        {
-            var assembly = AssemblyLoader.LoadAssembly("Bee.Base");
-            Assert.NotNull(assembly);
-            Assert.Equal("Bee.Base", assembly.GetName().Name);
-        }
     }
 }

--- a/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
@@ -106,5 +106,16 @@ namespace Bee.Db.UnitTests
 
             Assert.Contains("DELETE FROM `tb_foo`", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("BuildCount 應委派至 MySQL 方言並產生 SELECT COUNT(*) 語句（backtick 識別符）")]
+        public void BuildCount_DelegatesToMySqlDialect()
+        {
+            var builder = NewBuilder();
+            var spec = builder.BuildCount("Foo");
+
+            Assert.Contains("COUNT(*)", spec.CommandText);
+            Assert.Contains("`tb_foo`", spec.CommandText);
+        }
     }
 }

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceCollectionExtensionsTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceCollectionExtensionsTests.cs
@@ -33,5 +33,29 @@ namespace Bee.Hosting.UnitTests
             Assert.Throws<ArgumentNullException>(() =>
                 services.AddBeeFramework(new BackendConfiguration(), null!));
         }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 解析 IEnterpriseObjectService 應回傳預設實作（觸發 CreateOrDefault 路徑）")]
+        public void AddBeeFramework_ResolvesEnterpriseObjectService_ReturnsInstance()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-eos-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var configuration = new BackendConfiguration();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(configuration, pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var service = sp.GetRequiredService<IEnterpriseObjectService>();
+
+                Assert.NotNull(service);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` | 86.7% | 1 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 84.2% | 1 |

### 無法處理（3 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/AssemblyLoader.cs` | `LoadAssembly` 不含 `.dll` 副檔名路徑：靜態 `_loadedAssemblies` Dictionary 非執行緒安全，在 xUnit 平行測試下存在競態風險（PR #74 曾嘗試同一測試，CI 失敗後關閉未合併）。剩餘未覆蓋行暫列無法處理 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面宣告，無可執行程式碼，SonarCloud 所回報的 uncovered lines 為介面本體，無法以測試覆蓋 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 剩餘 6 條未覆蓋行均為並發競爭（`FileMode.CreateNew` 時其他程序搶先建檔的 `catch (IOException)` fallback）與重試計時器邏輯（`ReadAllTextShared` 的 catch-retry 路徑），需要特定競態條件才能觸發，無法以純單元測試可靠重現 |

### 各測試說明

- **`MySqlFormCommandBuilderTests.BuildCount_DelegatesToMySqlDialect`**：補上 `BuildCount` 方法的測試覆蓋（使用 backtick 識別符及 `SELECT COUNT(*)` 語句驗證）
- **`BeeFrameworkServiceCollectionExtensionsTests.AddBeeFramework_ResolvesEnterpriseObjectService_ReturnsInstance`**：解析 `IEnterpriseObjectService` 以觸發 `CreateOrDefault` 私有方法（透過 `AssemblyLoader.CreateInstance` 建立 `EnterpriseObjectService`）

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEVGPEHvw2Ax7s71tWftx8)_