### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-17 08:45

### DIFF
--- a/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
@@ -106,5 +106,16 @@ namespace Bee.Db.UnitTests
 
             Assert.Contains("DELETE FROM `tb_foo`", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("BuildCount 應委派至 MySQL 方言並產生 COUNT(*) 語句（backtick 識別符）")]
+        public void BuildCount_DelegatesToMySqlDialect()
+        {
+            var builder = NewBuilder();
+            var spec = builder.BuildCount("Foo");
+
+            Assert.Contains("COUNT(*)", spec.CommandText);
+            Assert.Contains("`tb_foo`", spec.CommandText);
+        }
     }
 }

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkDynamicProviderTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkDynamicProviderTests.cs
@@ -65,5 +65,29 @@ namespace Bee.Hosting.UnitTests
                 try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
             }
         }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 預設組態解析 IEnterpriseObjectService 應成功（CreateOrDefault 路徑）")]
+        public void AddBeeFramework_DefaultConfig_ResolvesEnterpriseObjectService()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-eos-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var configuration = new BackendConfiguration();
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(configuration, pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var exception = Record.Exception(() => sp.GetRequiredService<IEnterpriseObjectService>());
+
+                Assert.Null(exception);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` | 86.7% | 1 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 84.2% | 1 |

### 無法處理（共 3 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面定義，無可執行程式碼；覆蓋率需透過實作類別 `TraceListener.cs` 取得（已有 `TracerTests.cs` 覆蓋其實作） |
| `src/Bee.Base/AssemblyLoader.cs` | `LoadAssembly` 第 62-79 行的 `Assembly.Load` 備援路徑需要組件不在 AppDomain 中；測試專案所有相依組件均已預先載入，無法在標準單元測試中可靠觸發 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋路徑為 `ReadAllTextShared` 重試邏輯（第 120-124 行）與 `LoadFromFile` 競態條件（第 94-98 行），兩者需並行執行方能觸發，不適合在確定性單元測試中補測 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5QkGW3wgA4fJyvsF2dwCM)_