### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-17 16:30

### DIFF
--- a/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/MySqlFormCommandBuilderTests.cs
@@ -106,5 +106,16 @@ namespace Bee.Db.UnitTests
 
             Assert.Contains("DELETE FROM `tb_foo`", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("BuildCount 應委派至 MySQL 方言並產生 SELECT COUNT(*) 語句")]
+        public void BuildCount_DelegatesToMySqlDialect()
+        {
+            var builder = NewBuilder();
+            var spec = builder.BuildCount("Foo", null);
+
+            Assert.Contains("SELECT COUNT(*)", spec.CommandText);
+            Assert.Contains("`tb_foo`", spec.CommandText);
+        }
     }
 }

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkErrorHandlingTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkErrorHandlingTests.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 驗證 <c>AddBeeFramework</c> 在元件型別設定無效時，
+    /// 解析服務時能正確拋出 <see cref="InvalidOperationException"/>。
+    /// </summary>
+    public class BeeFrameworkErrorHandlingTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 設定不存在的 DefineAccess 型別名稱，解析 IDefineAccess 應拋出 InvalidOperationException")]
+        public void AddBeeFramework_InvalidDefineAccessTypeName_ThrowsOnResolve()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-err1-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var config = new BackendConfiguration();
+                config.Components.DefineAccess = "NonExistent.DefineAccessType, Bee.Base";
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(config, pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                Assert.Throws<InvalidOperationException>(() => sp.GetRequiredService<IDefineAccess>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 設定不存在的 DefineStorage 型別名稱，解析 IDefineStorage 應拋出 InvalidOperationException")]
+        public void AddBeeFramework_InvalidDefineStorageTypeName_ThrowsOnResolve()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-err2-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var config = new BackendConfiguration();
+                config.Components.DefineStorage = "NonExistent.StorageType, Bee.Base";
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(config, pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                Assert.Throws<InvalidOperationException>(() => sp.GetRequiredService<IDefineStorage>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AddBeeFramework 設定不存在的 AccessTokenValidator 型別名稱，解析 IAccessTokenValidator 應拋出 InvalidOperationException")]
+        public void AddBeeFramework_InvalidAccessTokenValidatorTypeName_ThrowsOnResolve()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-err3-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                var config = new BackendConfiguration();
+                config.Components.AccessTokenValidator = "NonExistent.ValidatorType, Bee.Base";
+                var pathOptions = new PathOptions { DefinePath = tempDir };
+                services.AddBeeFramework(config, pathOptions, autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                Assert.Throws<InvalidOperationException>(() => sp.GetRequiredService<IAccessTokenValidator>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/MySql/MySqlFormCommandBuilder.cs` | 86.7% | 1 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 84.2% | 3 |

### 補強說明

**MySqlFormCommandBuilder（+1 測試）**
- `BuildCount_DelegatesToMySqlDialect`：補強 `BuildCount` 方法路徑，驗證 MySQL 方言生成 `SELECT COUNT(*)` 並以 backtick 引用資料表名稱

**BeeFrameworkServiceCollectionExtensions（+3 測試）**
- `AddBeeFramework_InvalidDefineAccessTypeName_ThrowsOnResolve`：補強 `ResolveDefineAccess` 的 `?? throw` 錯誤路徑
- `AddBeeFramework_InvalidDefineStorageTypeName_ThrowsOnResolve`：補強 `CreateDefineStorage` 的 `?? throw` 錯誤路徑
- `AddBeeFramework_InvalidAccessTokenValidatorTypeName_ThrowsOnResolve`：補強 `CreateConfigurableService` 的 `?? throw` 錯誤路徑

### 無法處理

| 檔案 | 覆蓋率 | 原因 |
|------|-------|------|
| `src/Bee.Base/AssemblyLoader.cs` | 72.5% (11 uncovered) | `LoadAssembly` try/catch 區塊需要在 AppDomain 外的組件才能觸發；所有被測環境下的組件均已在 AppDomain 中，無法製造 `FindAssembly` 回傳 null 的條件 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% (6 uncovered) | `ReadAllTextShared` 重試迴圈及 auto-create 的 race condition catch 需要多執行緒檔案鎖定才能觸發，不適合單元測試 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 0% (2 uncovered) | 介面宣告本身無可執行程式碼；SonarCloud 將 default 參數值計為可涵蓋行，但無法透過測試直接覆蓋介面宣告行 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXdXTbDvtPn5QMHzBQsxHn)_