### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-18 00:30

### DIFF
--- a/tests/Bee.Db.UnitTests/OracleFormCommandBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/OracleFormCommandBuilderTests.cs
@@ -124,5 +124,16 @@ namespace Bee.Db.UnitTests
             // 透過 DatabaseType.Oracle.GetParameterPrefix() 注入，純語法測試不涵蓋。
             Assert.Contains("{0}", spec.CommandText);
         }
+
+        [Fact]
+        [DisplayName("BuildCount 應委派至 Oracle 方言並產生 SELECT COUNT(*) 語句（雙引號識別符）")]
+        public void BuildCount_DelegatesToOracleDialect()
+        {
+            var builder = NewBuilder();
+            var spec = builder.BuildCount("Foo");
+
+            Assert.Contains("COUNT", spec.CommandText, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("\"TB_FOO\"", spec.CommandText);
+        }
     }
 }

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkServiceResolutionTests.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+using Bee.Api.Core.JsonRpc;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Identity;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+using Bee.Repository.Abstractions;
+using Bee.Repository.Abstractions.Factories;
+using Bee.Repository.Abstractions.System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 驗證 AddBeeFramework 所有 DI 服務的 singleton factory lambda 均可正常解析，
+    /// 覆蓋 BeeFrameworkServiceCollectionExtensions 中 singleton 工廠委派的未覆蓋行。
+    /// </summary>
+    public class BeeFrameworkServiceResolutionTests
+    {
+        [Fact]
+        [DisplayName("AddBeeFramework 預設組態應能解析完整 DI 服務鏈（IDbConnectionManager 至 JsonRpcExecutor）")]
+        public void AddBeeFramework_DefaultConfig_ResolvesFullServiceChain()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-fullchain-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var services = new ServiceCollection();
+                services.AddBeeFramework(
+                    new BackendConfiguration(),
+                    new PathOptions { DefinePath = tempDir },
+                    autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+
+                Assert.NotNull(sp.GetRequiredService<IDbConnectionManager>());
+                Assert.NotNull(sp.GetRequiredService<IDbAccessFactory>());
+                Assert.NotNull(sp.GetRequiredService<IAccessTokenValidator>());
+                Assert.NotNull(sp.GetRequiredService<ISessionInfoService>());
+                Assert.NotNull(sp.GetRequiredService<ICompanyInfoService>());
+                Assert.NotNull(sp.GetRequiredService<ICacheDataSourceProvider>());
+                Assert.NotNull(sp.GetRequiredService<IBusinessObjectFactory>());
+                Assert.NotNull(sp.GetRequiredService<IRepositoryDatabaseRouter>());
+                Assert.NotNull(sp.GetRequiredService<ISystemRepositoryFactory>());
+                Assert.NotNull(sp.GetRequiredService<IFormRepositoryFactory>());
+                Assert.NotNull(sp.GetRequiredService<ICompanyRepository>());
+                Assert.NotNull(sp.GetRequiredService<IUserCompanyRepository>());
+                Assert.NotNull(sp.GetRequiredService<JsonRpcExecutor>());
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { /* best effort */ }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 86.8% | 1 |
| `src/Bee.Db/Providers/Oracle/OracleFormCommandBuilder.cs` | 86.7% | 1 |

### 補強說明

**`BeeFrameworkServiceResolutionTests`**（新增）
補強 `AddBeeFramework` 中各 singleton factory lambda 的覆蓋率。新增一個整合測試，解析完整 DI 服務鏈：`IDbConnectionManager`、`IDbAccessFactory`、`IAccessTokenValidator`、`ISessionInfoService`、`ICompanyInfoService`、`ICacheDataSourceProvider`、`IBusinessObjectFactory`、`IRepositoryDatabaseRouter`、`ISystemRepositoryFactory`、`IFormRepositoryFactory`、`ICompanyRepository`、`IUserCompanyRepository`、`JsonRpcExecutor`。

**`OracleFormCommandBuilderTests`**（追加 1 個測試）
補 `BuildCount` 方法缺少的覆蓋：驗證委派至 Oracle 方言並產生含 `COUNT` 與 `"TB_FOO"` 的 SQL 語句。

### 無法處理清單

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/AssemblyLoader.cs`（11 行） | `LoadAssembly` 非快取路徑（`Assembly.Load` 及 fallback 檔案載入）需要未預載至 AppDomain 的組件，無法在標準單元測試環境中觸發 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs`（6 行） | `LoadFromFile` 中的競爭條件 `catch (IOException)` 以及 `ReadAllTextShared` 的重試分支，需要並發操作才能觸發，無法在確定性單元測試中驗證 |
| `src/Bee.Base/Tracing/ITraceListener.cs`（2 行） | 純介面定義，無可執行程式碼，SonarCloud 誤報為未覆蓋行 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrevaeC38xfxWQtd7Azhxy)_