### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-18 08:51

### DIFF
--- a/tests/Bee.Db.UnitTests/PgFormCommandBuilderExtraTests.cs
+++ b/tests/Bee.Db.UnitTests/PgFormCommandBuilderExtraTests.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel;
+using Bee.Db.Providers.PostgreSql;
+using Bee.Definition.Forms;
+using Bee.Definition.Storage;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests
+{
+    public class PgFormCommandBuilderExtraTests : IClassFixture<SharedDbFixture>
+    {
+        private readonly SharedDbFixture _fx;
+
+        public PgFormCommandBuilderExtraTests(SharedDbFixture fx) { _fx = fx; }
+        private IDefineAccess DefineAccess => _fx.GetRequiredService<IDefineAccess>();
+
+        private static FormSchema BuildFooSchema()
+        {
+            var schema = new FormSchema("X", "X");
+            var table = schema.Tables!.Add("Foo", "Foo");
+            table.DbTableName = "tb_foo";
+            table.Fields!.AddStringField("name", "Name", 50);
+            return schema;
+        }
+
+        private PgFormCommandBuilder NewBuilder()
+            => new(BuildFooSchema(), DefineAccess);
+
+        [Fact]
+        [DisplayName("BuildCount 應委派至 PostgreSQL 方言並產生 SELECT COUNT(*) 語句（雙引號識別符）")]
+        public void BuildCount_DelegatesToPostgreSqlDialect()
+        {
+            var builder = NewBuilder();
+            var spec = builder.BuildCount("Foo");
+
+            Assert.Contains("COUNT(*)", spec.CommandText);
+            Assert.Contains("\"tb_foo\"", spec.CommandText);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/BeeFrameworkFallbackCtorTests.cs
+++ b/tests/Bee.Hosting.UnitTests/BeeFrameworkFallbackCtorTests.cs
@@ -1,0 +1,109 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bee.Hosting.UnitTests
+{
+    // Stub with only (IDefineStorage, PathOptions) ctor — exercises ResolveDefineAccess
+    // 2-arg ctor fallback path (the 4-arg ctor is intentionally absent).
+    public sealed class TwoArgDefineAccessStub : IDefineAccess
+    {
+        public TwoArgDefineAccessStub(IDefineStorage storage, PathOptions paths) { }
+        public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+        public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+        public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+        public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+        public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+        public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+        public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+        public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+        public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+        public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+        public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+        public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+        public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+        public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+        public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+        public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+    }
+
+    // Stub with only a parameterless ctor — exercises CreateDefineStorage
+    // parameterless ctor fallback path (the PathOptions ctor is intentionally absent).
+    public sealed class ParameterlessDefineStorageStub : IDefineStorage
+    {
+        public DbCategorySettings? GetDbCategorySettings() => null;
+        public void SaveDbCategorySettings(DbCategorySettings settings) { }
+        public TableSchema? GetTableSchema(string categoryId, string tableName) => null;
+        public void SaveTableSchema(string categoryId, TableSchema tableSchema) { }
+        public FormSchema? GetFormSchema(string progId) => null;
+        public void SaveFormSchema(FormSchema formSchema) { }
+        public FormLayout? GetFormLayout(string layoutId) => null;
+        public void SaveFormLayout(FormLayout formLayout) { }
+    }
+
+    public class BeeFrameworkFallbackCtorTests
+    {
+        [Fact]
+        [DisplayName("ResolveDefineAccess 應支援僅有 (IDefineStorage, PathOptions) 建構子的 IDefineAccess 實作")]
+        public void ResolveDefineAccess_TwoArgCtor_CreatesCorrectType()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-2arg-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var configuration = new BackendConfiguration();
+                configuration.Components.DefineAccess =
+                    "Bee.Hosting.UnitTests.TwoArgDefineAccessStub, Bee.Hosting.UnitTests";
+
+                var services = new ServiceCollection();
+                services.AddBeeFramework(
+                    configuration,
+                    new PathOptions { DefinePath = tempDir },
+                    autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var access = sp.GetRequiredService<IDefineAccess>();
+
+                Assert.IsType<TwoArgDefineAccessStub>(access);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        [DisplayName("CreateDefineStorage 應支援僅有無參數建構子的 IDefineStorage 實作")]
+        public void CreateDefineStorage_ParameterlessCtorFallback_CreatesCorrectType()
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), $"bee-fw-pless-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            try
+            {
+                var configuration = new BackendConfiguration();
+                configuration.Components.DefineStorage =
+                    "Bee.Hosting.UnitTests.ParameterlessDefineStorageStub, Bee.Hosting.UnitTests";
+
+                var services = new ServiceCollection();
+                services.AddBeeFramework(
+                    configuration,
+                    new PathOptions { DefinePath = tempDir },
+                    autoCreateMasterKey: true);
+
+                using var sp = services.BuildServiceProvider();
+                var storage = sp.GetRequiredService<IDefineStorage>();
+
+                Assert.IsType<ParameterlessDefineStorageStub>(storage);
+            }
+            finally
+            {
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Providers/PostgreSql/PgFormCommandBuilder.cs` | 86.7% | 1 |
| `src/Bee.Hosting/BeeFrameworkServiceCollectionExtensions.cs` | 86.8% | 2 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/Tracing/ITraceListener.cs` | 介面定義，無可執行程式碼，SonarCloud 計算的「未覆蓋行」為介面方法簽章 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋路徑為並行 `IOException` 重試邏輯（`ReadAllTextShared` retry 與 `FileMode.CreateNew` race handler），需要執行緒競爭條件才能觸發，不適合單元測試 |
| `src/Bee.Base/AssemblyLoader.cs` | 未覆蓋路徑為 `LoadAssembly` 的 `FileNotFoundException` fallback，需要一個存在於磁碟但不在 .NET probing path 的組件，無法可靠地在 CI 中設置 |

## 新增測試說明

### `PgFormCommandBuilderExtraTests.cs`
- `BuildCount_DelegatesToPostgreSqlDialect`：補強先前完全未覆蓋的 `BuildCount` 方法

### `BeeFrameworkFallbackCtorTests.cs`
- `ResolveDefineAccess_TwoArgCtor_CreatesCorrectType`：使用僅有 `(IDefineStorage, PathOptions)` 建構子的 stub，觸發 `ResolveDefineAccess` 的 2-arg ctor fallback 路徑（之前因預設 `LocalDefineAccess` 有 4-arg ctor 而從未執行）
- `CreateDefineStorage_ParameterlessCtorFallback_CreatesCorrectType`：使用僅有無參數建構子的 stub，觸發 `CreateDefineStorage` 的 `AssemblyLoader.CreateInstance` fallback 路徑

---
_Generated by [Claude Code](https://claude.ai/code/session_015e4EkVkWz8H9s7Tq6wbeaZ)_