### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-18 16:30

### DIFF
--- a/tests/Bee.Base.UnitTests/AssemblyLoaderFallbackTests.cs
+++ b/tests/Bee.Base.UnitTests/AssemblyLoaderFallbackTests.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel;
+
+namespace Bee.Base.UnitTests
+{
+    public class AssemblyLoaderFallbackTests
+    {
+        [Fact]
+        [DisplayName("LoadAssembly 不存在的組件名稱（無目錄）應進入 FileNotFoundException fallback 並拋出例外")]
+        public void LoadAssembly_UnknownNameNoDirectory_FallbackThrowsException()
+        {
+            var exception = Record.Exception(() => AssemblyLoader.LoadAssembly("BeeXyzNotExistFallback.dll"));
+            Assert.NotNull(exception);
+        }
+
+        [Fact]
+        [DisplayName("LoadAssembly 含目錄路徑的不存在組件應使用路徑直接作為 assemblyFile 並拋出例外")]
+        public void LoadAssembly_PathWithDirectoryNotFound_FallbackThrowsException()
+        {
+            string fakeAssemblyPath = Path.Combine(
+                Path.GetTempPath(), "bee_fake_dir_xyz", "BeeXyzNotExistFallback2.dll");
+            var exception = Record.Exception(() => AssemblyLoader.LoadAssembly(fakeAssemblyPath));
+            Assert.NotNull(exception);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Logging/LogOptionsTests.cs
+++ b/tests/Bee.Definition.UnitTests/Logging/LogOptionsTests.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using Bee.Definition.Database;
+using Bee.Definition.Logging;
+
+namespace Bee.Definition.UnitTests.Logging
+{
+    public class LogOptionsTests
+    {
+        [Fact]
+        [DisplayName("LogOptions.ToString 應回傳類別名稱")]
+        public void ToString_DefaultInstance_ReturnsTypeName()
+        {
+            var options = new LogOptions();
+            Assert.Equal("LogOptions", options.ToString());
+        }
+
+        [Fact]
+        [DisplayName("LogOptions 預設建構子應初始化 DbAccess 子選項")]
+        public void DefaultConstructor_InitializesDbAccess()
+        {
+            var options = new LogOptions();
+            Assert.NotNull(options.DbAccess);
+        }
+
+        [Fact]
+        [DisplayName("DbAccessAnomalyLogOptions.ToString 應回傳類別名稱")]
+        public void DbAccessAnomalyLogOptions_ToString_ReturnsTypeName()
+        {
+            var options = new DbAccessAnomalyLogOptions();
+            Assert.Equal("DbAccessAnomalyLogOptions", options.ToString());
+        }
+
+        [Fact]
+        [DisplayName("DbAccessAnomalyLogOptions 預設屬性值應與規格一致")]
+        public void DbAccessAnomalyLogOptions_DefaultValues_MatchSpecification()
+        {
+            var options = new DbAccessAnomalyLogOptions();
+            Assert.Equal(DbAccessAnomalyLogLevel.Warning, options.Level);
+            Assert.Equal(10000, options.AffectedRowThreshold);
+            Assert.Equal(10000, options.ResultRowThreshold);
+            Assert.Equal(300, options.ExecutionTimeThreshold);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Base/AssemblyLoader.cs` | 72.5% | 2 |
| `src/Bee.Definition/Logging/DbAccessAnomalyLogOptions.cs` | 80.0% | 2 |
| `src/Bee.Definition/Logging/LogOptions.cs` | 50.0% | 2 |

### 無法處理（2 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面宣告，無可執行程式碼；SonarCloud 回報的 2 行為介面方法簽名，無法透過測試覆蓋。 |
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 未覆蓋行為並發重試路徑（`ReadAllTextShared` 的 `Thread.Sleep`/`attempt++`）及 `FileMode.CreateNew` 競爭條件的 `catch (IOException)`；需要受控的檔案系統錯誤才能觸發，屬結構性限制。 |

### 測試說明

**AssemblyLoader**：補強 `LoadAssembly` 的 `catch (FileNotFoundException)` fallback 分支，涵蓋：
- 無目錄路徑 → 走 `Path.Combine(GetAssemblyPath(), assemblyName)`（第 77 行）
- 含目錄路徑 → 直接以 `assemblyName` 作為 assemblyFile（第 78 行）

**LogOptions / DbAccessAnomalyLogOptions**：補強 `ToString()` 方法及預設屬性值驗證。

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWNgj4iWUEF5W7saaCEPNs)_