### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-05-20 08:30

### DIFF
--- a/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderRetryTests.cs
+++ b/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderRetryTests.cs
@@ -27,7 +27,7 @@ namespace Bee.Definition.UnitTests.Security
                 MasterKeyProvider.GetMasterKey(source, definePath: string.Empty, autoCreate: true));
 
             Assert.NotNull(exception);
-            Assert.IsAssignableFrom<IOException>(exception);
+            Assert.IsType<IOException>(exception, exactMatch: false);
         }
     }
 }

--- a/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderRetryTests.cs
+++ b/tests/Bee.Definition.UnitTests/Security/MasterKeyProviderRetryTests.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel;
+using Bee.Definition.Security;
+using Bee.Definition.Settings;
+
+namespace Bee.Definition.UnitTests.Security
+{
+    public class MasterKeyProviderRetryTests
+    {
+        [Fact]
+        [DisplayName("GetMasterKey autoCreate=true 父目錄不存在時應觸發 catch(IOException) fallthrough 並於重試耗盡後拋出例外")]
+        public void GetMasterKey_AutoCreate_ParentDirMissing_TriggersIoExceptionFallback()
+        {
+            // 父目錄（bee-missing-<guid>）不存在：
+            //   FileStream(FileMode.CreateNew) → DirectoryNotFoundException（IOException 子類）
+            //   → LoadFromFile 的 catch(IOException) 捕獲，fallthrough 到 ReadAllTextShared
+            //   → ReadAllTextShared 逐次重試（ReadRetryCount=5，每次 Thread.Sleep 50ms），
+            //     第 5 次 when (attempt < 4) 為 false，例外向上傳播。
+            // 預期耗時約 200ms（4 × 50ms sleep）。
+            string missingParent = Path.Combine(
+                Path.GetTempPath(),
+                $"bee-missing-{Guid.NewGuid():N}",
+                "file.key");
+
+            var source = new MasterKeySource { Type = MasterKeySourceType.File, Value = missingParent };
+
+            var exception = Record.Exception(() =>
+                MasterKeyProvider.GetMasterKey(source, definePath: string.Empty, autoCreate: true));
+
+            Assert.NotNull(exception);
+            Assert.IsAssignableFrom<IOException>(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Security/MasterKeyProvider.cs` | 87.8% | 1 |

### 測試說明

新增 `MasterKeyProviderRetryTests.GetMasterKey_AutoCreate_ParentDirMissing_TriggersIoExceptionFallback`：

透過傳入父目錄不存在的路徑（如 `/tmp/bee-missing-<guid>/file.key`），觸發以下原本未覆蓋路徑：

1. **`LoadFromFile` 的 `catch (IOException)` fallthrough**（`MasterKeyProvider.cs` 約第 94 行）：`FileStream(FileMode.CreateNew)` 因父目錄不存在拋出 `DirectoryNotFoundException`（`IOException` 子類），由此 catch 捕獲後 fallthrough 至 `ReadAllTextShared`。

2. **`ReadAllTextShared` 的重試迴圈**（約第 121–124 行）：`ReadAllTextShared` 嘗試開啟同一不存在路徑，每次拋 `DirectoryNotFoundException`；`when (attempt < ReadRetryCount - 1)` 條件為 true 時重試（共 4 次 × 50ms sleep），第 5 次 when 子句為 false 時例外向上傳播。

預期測試耗時約 200ms（4 × Thread.Sleep(50ms)）。

---

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面（`interface`）宣告，無可執行程式碼；SonarCloud 報告的 2 行「未覆蓋」為介面方法簽名，無法透過一般測試直接覆蓋。建議於 SonarCloud UI 標記為 False Positive。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3cQfz5USSSKhWRkTQygyN)_