### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-05-21 08:30

### DIFF
--- a/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
+++ b/tests/Bee.Db.UnitTests/TableSchemaBuilderTests.cs
@@ -1,7 +1,12 @@
 using System.ComponentModel;
+using Bee.Base.Data;
 using Bee.Db.Manager;
 using Bee.Db.Schema;
+using Bee.Definition;
 using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
 using Bee.Definition.Storage;
 using Bee.Tests.Shared;
 
@@ -64,6 +69,61 @@ namespace Bee.Db.UnitTests
             var builder = NewBuilder(TestDbConventions.GetDatabaseId(DatabaseType.PostgreSQL, "company"));
             string sql = builder.GetCommandText("company", "ft_project");
             Assert.Equal(string.Empty, sql);
+        }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("TableSchemaBuilder GetCommandText 有欄位差異時應回傳非空 ALTER SQL（SQL Server）")]
+        public void GetCommandText_OutOfSyncTable_SqlServer_ReturnsNonEmptyAlterSql()
+        {
+            var cm = _fx.GetRequiredService<IDbConnectionManager>();
+            var builder = new TableSchemaBuilder("common_sqlserver", new ExtraColumnDefineAccess(_fx.GetRequiredService<IDefineAccess>()), cm);
+
+            string sql = builder.GetCommandText("common", "st_user");
+
+            Assert.NotEmpty(sql);
+            Assert.Contains("zz_test_col", sql, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [DbFact(DatabaseType.PostgreSQL)]
+        [DisplayName("TableSchemaBuilder GetCommandText 有欄位差異時應回傳非空 ALTER SQL（PostgreSQL）")]
+        public void GetCommandText_OutOfSyncTable_PostgreSql_ReturnsNonEmptyAlterSql()
+        {
+            var cm = _fx.GetRequiredService<IDbConnectionManager>();
+            var builder = new TableSchemaBuilder(TestDbConventions.GetDatabaseId(DatabaseType.PostgreSQL), new ExtraColumnDefineAccess(_fx.GetRequiredService<IDefineAccess>()), cm);
+
+            string sql = builder.GetCommandText("common", "st_user");
+
+            Assert.NotEmpty(sql);
+            Assert.Contains("zz_test_col", sql, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private sealed class ExtraColumnDefineAccess : IDefineAccess
+        {
+            private readonly IDefineAccess _inner;
+            public ExtraColumnDefineAccess(IDefineAccess inner) => _inner = inner;
+
+            public TableSchema GetTableSchema(string categoryId, string tableName)
+            {
+                var schema = _inner.GetTableSchema(categoryId, tableName).Clone();
+                schema.Fields!.Add("zz_test_col", "Test Column", FieldDbType.String, 10);
+                return schema;
+            }
+
+            public object GetDefine(DefineType defineType, string[]? keys = null) => _inner.GetDefine(defineType, keys);
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => _inner.SaveDefine(defineType, defineObject, keys);
+            public SystemSettings GetSystemSettings() => _inner.GetSystemSettings();
+            public void SaveSystemSettings(SystemSettings settings) => _inner.SaveSystemSettings(settings);
+            public DatabaseSettings GetDatabaseSettings() => _inner.GetDatabaseSettings();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => _inner.SaveDatabaseSettings(settings);
+            public ProgramSettings GetProgramSettings() => _inner.GetProgramSettings();
+            public void SaveProgramSettings(ProgramSettings settings) => _inner.SaveProgramSettings(settings);
+            public DbCategorySettings GetDbCategorySettings() => _inner.GetDbCategorySettings();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => _inner.SaveDbCategorySettings(settings);
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => _inner.SaveTableSchema(categoryId, tableSchema);
+            public FormSchema GetFormSchema(string progId) => _inner.GetFormSchema(progId);
+            public void SaveFormSchema(FormSchema formSchema) => _inner.SaveFormSchema(formSchema);
+            public FormLayout GetFormLayout(string layoutId) => _inner.GetFormLayout(layoutId);
+            public void SaveFormLayout(FormLayout formLayout) => _inner.SaveFormLayout(formLayout);
         }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/Schema/TableSchemaBuilder.cs` | 79.3% | 2 |

### 說明

補強 `TableSchemaBuilder.GetCommandText` 的未覆蓋分支（lines 98-105），即當升級計畫非空時組裝 SQL 字串的邏輯。

新增 2 個 `[DbFact]` 測試（SQL Server 和 PostgreSQL 各一），透過 `ExtraColumnDefineAccess` 裝飾器，在讀取定義結構時插入一個資料庫中不存在的欄位 `zz_test_col`，使 diff 為非空，驗證 `GetCommandText` 能回傳含有對應 ALTER SQL 的非空字串。

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面宣告（無預設實作），SonarCloud 將介面方法簽名行（line 30、42）標記為 hits=0 屬工具回報的 artifact；已有 `TracerTests.cs` 透過介面型別呼叫 `TraceEnd` 和 `TraceWrite`，無法藉新增測試改善此計數。 |
| `src/Bee.Api.Client/ApiConnectValidator.cs` | 命中排除清單（Bee.Api.Client） |
| `src/Bee.Api.Client/Connectors/FormApiConnector.cs` | 命中排除清單（Bee.Api.Client） |
| `src/Bee.Api.Client/DefineAccess/RemoteDefineAccess.cs` | 命中排除清單（Bee.Api.Client） |
| `src/Bee.Api.Client/Providers/RemoteApiProvider.cs` | 命中排除清單（Bee.Api.Client） |
| `src/Bee.Api.Client/Connectors/SystemApiConnector.cs` | 命中排除清單（Bee.Api.Client） |

---
_Generated by [Claude Code](https://claude.ai/code/session_01UjcxuS38dJ2k6jwL62J2Pz)_