### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-05-21 16:30

### DIFF
--- a/tests/Bee.Base.UnitTests/TraceListenerTests.cs
+++ b/tests/Bee.Base.UnitTests/TraceListenerTests.cs
@@ -1,0 +1,105 @@
+using System.ComponentModel;
+using Bee.Base.Tracing;
+
+namespace Bee.Base.UnitTests
+{
+    public class TraceListenerTests
+    {
+        private sealed class CapturingWriter : ITraceWriter
+        {
+            public List<TraceEvent> Events { get; } = [];
+            public void Write(TraceEvent evt) => Events.Add(evt);
+        }
+
+        [Fact]
+        [DisplayName("TraceStart 透過 ITraceListener 介面參考應建立正確 Context")]
+        public void TraceStart_ViaInterface_ReturnsContextWithCorrectProperties()
+        {
+            ITraceListener listener = new TraceListener(new CapturingWriter());
+
+            var ctx = listener.TraceStart(TraceLayers.Business, "detail", name: "TestOp");
+
+            Assert.Equal(TraceLayers.Business, ctx.Layer);
+            Assert.Equal("TestOp", ctx.Name);
+            Assert.Equal("detail", ctx.Detail);
+            Assert.True(ctx.Stopwatch.IsRunning);
+        }
+
+        [Fact]
+        [DisplayName("TraceStart 省略所有選用參數應建立含預設值的 Context")]
+        public void TraceStart_WithOnlyRequiredLayer_CreatesContextWithDefaults()
+        {
+            ITraceListener listener = new TraceListener(new CapturingWriter());
+
+            var ctx = listener.TraceStart(TraceLayers.Data, name: "TestMethod");
+
+            Assert.Equal(TraceLayers.Data, ctx.Layer);
+            Assert.Equal(string.Empty, ctx.Category);
+            Assert.Null(ctx.Tag);
+            Assert.Equal(string.Empty, ctx.Detail);
+        }
+
+        [Fact]
+        [DisplayName("TraceEnd 透過 ITraceListener 介面參考應停止計時器並發送 End 事件")]
+        public void TraceEnd_ViaInterface_StopsStopwatchAndEmitsEndEvent()
+        {
+            var writer = new CapturingWriter();
+            ITraceListener listener = new TraceListener(writer);
+
+            var ctx = listener.TraceStart(TraceLayers.UI, name: "Op");
+            listener.TraceEnd(ctx, TraceStatus.Ok);
+
+            Assert.False(ctx.Stopwatch.IsRunning);
+            Assert.Equal(2, writer.Events.Count);
+            Assert.Equal(TraceEventKind.End, writer.Events[1].Kind);
+        }
+
+        [Fact]
+        [DisplayName("TraceEnd 傳入 detail 應覆蓋 Context 原有的 Detail")]
+        public void TraceEnd_WithExplicitDetail_OverridesContextDetail()
+        {
+            var writer = new CapturingWriter();
+            ITraceListener listener = new TraceListener(writer);
+
+            var ctx = listener.TraceStart(TraceLayers.Data, "original-detail", name: "Op");
+            listener.TraceEnd(ctx, TraceStatus.Error, "override-detail");
+
+            Assert.Equal("override-detail", writer.Events[1].Detail);
+            Assert.Equal(TraceStatus.Error, writer.Events[1].Status);
+        }
+
+        [Fact]
+        [DisplayName("TraceWrite 透過 ITraceListener 介面參考應發送 Point 事件")]
+        public void TraceWrite_ViaInterface_EmitsPointEvent()
+        {
+            var writer = new CapturingWriter();
+            ITraceListener listener = new TraceListener(writer);
+
+            listener.TraceWrite(TraceLayers.ApiServer, "write-detail", TraceStatus.Cancelled, name: "WriteOp");
+
+            var evt = Assert.Single(writer.Events);
+            Assert.Equal(TraceEventKind.Point, evt.Kind);
+            Assert.Equal(TraceLayers.ApiServer, evt.Layer);
+            Assert.Equal("write-detail", evt.Detail);
+            Assert.Equal(TraceStatus.Cancelled, evt.Status);
+            Assert.Equal(0, evt.DurationMs);
+        }
+
+        [Fact]
+        [DisplayName("TraceWrite 省略所有選用參數應發送預設狀態的 Point 事件")]
+        public void TraceWrite_WithOnlyRequiredLayer_EmitsDefaultStatusEvent()
+        {
+            var writer = new CapturingWriter();
+            ITraceListener listener = new TraceListener(writer);
+
+            listener.TraceWrite(TraceLayers.None, name: "TestMethod");
+
+            var evt = Assert.Single(writer.Events);
+            Assert.Equal(TraceEventKind.Point, evt.Kind);
+            Assert.Equal(TraceStatus.Ok, evt.Status);
+            Assert.Equal(string.Empty, evt.Detail);
+            Assert.Equal(string.Empty, evt.Category);
+            Assert.Null(evt.Tag);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Base/Tracing/ITraceListener.cs` | 0.0% | 6 |

### 補強說明

新增 `tests/Bee.Base.UnitTests/TraceListenerTests.cs`，透過 `ITraceListener` **介面參考**呼叫 `TraceListener` 的三個實作方法（`TraceStart`、`TraceEnd`、`TraceWrite`），讓 SonarCloud 能將覆蓋率計算回 `ITraceListener.cs` 檔案本身。

測試涵蓋場景：
- `TraceStart` 帶齊參數，驗證 Context 屬性正確
- `TraceStart` 使用全預設參數，驗證 Category / Tag / Detail 為預設值
- `TraceEnd` 驗證計時器停止且發送 End 事件
- `TraceEnd` 傳入 detail 覆蓋 Context 原有 Detail
- `TraceWrite` 帶齊參數，驗證 Point 事件內容
- `TraceWrite` 使用全預設參數，驗證預設 Status / Detail / Category


---
_Generated by [Claude Code](https://claude.ai/code/session_01747Rh9vGzCdXE4sYph5mBb)_