### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-22 00:41

### DIFF
--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormTests.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel;
 using System.Reflection;
 using Bee.Base.Data;
+using Bee.Definition.Collections;
 using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
 using Bee.Web.Blazor.Server.Components;
 using Bee.Web.Blazor.Server.DataObjects;
 using Microsoft.AspNetCore.Components;
@@ -88,6 +90,159 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
                 Assert.NotNull(section.Fields);
                 Assert.NotEmpty(section.Fields!);
             });
+        }
+
+        private static MethodInfo GetPrivateInstanceMethod(string name)
+        {
+            var method = typeof(DynamicForm).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static MethodInfo GetPrivateStaticMethod(string name)
+        {
+            var method = typeof(DynamicForm).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Fact]
+        [DisplayName("EnumerateSections 在 Layout 為 null 時回傳空列舉")]
+        public void EnumerateSections_NullLayout_ReturnsEmpty()
+        {
+            var component = new DynamicForm();
+            var method = GetPrivateInstanceMethod("EnumerateSections");
+            var result = (IEnumerable<LayoutSection>)method.Invoke(component, null)!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateSections 在 Layout 含有 Section 時回傳對應集合")]
+        public void EnumerateSections_WithSections_ReturnsSections()
+        {
+            var schema = BuildSchema();
+            var layout = schema.GetFormLayout();
+            var component = new DynamicForm();
+            GetProperty(nameof(DynamicForm.Layout)).SetValue(component, layout);
+            var method = GetPrivateInstanceMethod("EnumerateSections");
+            var result = ((IEnumerable<LayoutSection>)method.Invoke(component, null)!).ToList();
+            Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateFields 篩選後只回傳 Visible=true 的欄位")]
+        public void EnumerateFields_MixedVisibility_ReturnsOnlyVisible()
+        {
+            var section = new LayoutSection();
+            section.Fields!.Add(new LayoutField { FieldName = "visible_col", Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "hidden_col", Visible = false });
+            var method = GetPrivateStaticMethod("EnumerateFields");
+            var result = ((IEnumerable<LayoutField>)method.Invoke(null, new object[] { section })!).ToList();
+            Assert.Single(result);
+            Assert.Equal("visible_col", result[0].FieldName);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateFields 所有欄位 Visible=true 時全數回傳")]
+        public void EnumerateFields_AllVisible_ReturnsAllFields()
+        {
+            var section = new LayoutSection();
+            section.Fields!.Add(new LayoutField { FieldName = "field_a", Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "field_b", Visible = true });
+            var method = GetPrivateStaticMethod("EnumerateFields");
+            var result = ((IEnumerable<LayoutField>)method.Invoke(null, new object[] { section })!).ToList();
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions 在 DataObject 為 null 時回傳空列舉")]
+        public void EnumerateOptions_NullDataObject_ReturnsEmpty()
+        {
+            var component = new DynamicForm();
+            var field = new LayoutField { FieldName = "status" };
+            var method = GetPrivateInstanceMethod("EnumerateOptions");
+            var result = (IEnumerable<ListItem>)method.Invoke(component, new object[] { field })!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions 欄位名稱不在 Schema 時回傳空列舉")]
+        public void EnumerateOptions_FieldNotInSchema_ReturnsEmpty()
+        {
+            var schema = BuildSchema();
+            var dataObject = new FormDataObject(schema);
+            var component = new DynamicForm();
+            GetProperty(nameof(DynamicForm.DataObject)).SetValue(component, dataObject);
+            var field = new LayoutField { FieldName = "nonexistent_col" };
+            var method = GetPrivateInstanceMethod("EnumerateOptions");
+            var result = (IEnumerable<ListItem>)method.Invoke(component, new object[] { field })!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        [DisplayName("FieldInputId 回傳 IdPrefix 與 FieldName 組合的格式化字串")]
+        public void FieldInputId_ValidField_ReturnsFormattedId()
+        {
+            var component = new DynamicForm();
+            GetProperty(nameof(DynamicForm.IdPrefix)).SetValue(component, "my-form");
+            var field = new LayoutField { FieldName = "emp_name" };
+            var method = GetPrivateInstanceMethod("FieldInputId");
+            var result = (string)method.Invoke(component, new object[] { field })!;
+            Assert.Equal("my-form-emp_name", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle 在 Layout 為 null 時產生單欄格線樣式")]
+        public void BuildGridStyle_NullLayout_UsesOneColumnStyle()
+        {
+            var component = new DynamicForm();
+            var method = GetPrivateInstanceMethod("BuildGridStyle");
+            var result = (string)method.Invoke(component, null)!;
+            Assert.Equal("display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle 依 ColumnCount 產生對應欄數的格線樣式")]
+        public void BuildGridStyle_WithColumnCount_ReturnsCorrectStyle()
+        {
+            var component = new DynamicForm();
+            var layout = new FormLayout { ColumnCount = 3 };
+            GetProperty(nameof(DynamicForm.Layout)).SetValue(component, layout);
+            var method = GetPrivateInstanceMethod("BuildGridStyle");
+            var result = (string)method.Invoke(component, null)!;
+            Assert.Equal("display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle 在 ColumnCount 小於 1 時夾住為單欄格線樣式")]
+        public void BuildGridStyle_ZeroColumnCount_ClampsToOneColumn()
+        {
+            var component = new DynamicForm();
+            var layout = new FormLayout { ColumnCount = 0 };
+            GetProperty(nameof(DynamicForm.Layout)).SetValue(component, layout);
+            var method = GetPrivateInstanceMethod("BuildGridStyle");
+            var result = (string)method.Invoke(component, null)!;
+            Assert.Equal("display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildFieldStyle 在預設 Span 時回傳 grid-row:span 1;grid-column:span 1")]
+        public void BuildFieldStyle_DefaultSpans_ReturnsSpanOne()
+        {
+            var field = new LayoutField { FieldName = "test_col" };
+            var method = GetPrivateStaticMethod("BuildFieldStyle");
+            var result = (string)method.Invoke(null, new object[] { field })!;
+            Assert.Equal("grid-row:span 1;grid-column:span 1", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildFieldStyle 在自訂 Span 時回傳對應的 CSS Grid 樣式字串")]
+        public void BuildFieldStyle_CustomSpans_ReturnsCorrectStyle()
+        {
+            var field = new LayoutField { FieldName = "desc_col", RowSpan = 2, ColumnSpan = 3 };
+            var method = GetPrivateStaticMethod("BuildFieldStyle");
+            var result = (string)method.Invoke(null, new object[] { field })!;
+            Assert.Equal("grid-row:span 2;grid-column:span 3", result);
         }
     }
 }

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormTests.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel;
 using System.Reflection;
 using Bee.Base.Data;
+using Bee.Definition.Collections;
 using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
 using Bee.Web.Blazor.Wasm.Components;
 using Bee.Web.Blazor.Wasm.DataObjects;
 using Microsoft.AspNetCore.Components;
@@ -88,6 +90,159 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
                 Assert.NotNull(section.Fields);
                 Assert.NotEmpty(section.Fields!);
             });
+        }
+
+        private static MethodInfo GetPrivateInstanceMethod(string name)
+        {
+            var method = typeof(DynamicForm).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static MethodInfo GetPrivateStaticMethod(string name)
+        {
+            var method = typeof(DynamicForm).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Fact]
+        [DisplayName("EnumerateSections 在 Layout 為 null 時回傳空列舉")]
+        public void EnumerateSections_NullLayout_ReturnsEmpty()
+        {
+            var component = new DynamicForm();
+            var method = GetPrivateInstanceMethod("EnumerateSections");
+            var result = (IEnumerable<LayoutSection>)method.Invoke(component, null)!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateSections 在 Layout 含有 Section 時回傳對應集合")]
+        public void EnumerateSections_WithSections_ReturnsSections()
+        {
+            var schema = BuildSchema();
+            var layout = schema.GetFormLayout();
+            var component = new DynamicForm();
+            GetProperty(nameof(DynamicForm.Layout)).SetValue(component, layout);
+            var method = GetPrivateInstanceMethod("EnumerateSections");
+            var result = ((IEnumerable<LayoutSection>)method.Invoke(component, null)!).ToList();
+            Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateFields 篩選後只回傳 Visible=true 的欄位")]
+        public void EnumerateFields_MixedVisibility_ReturnsOnlyVisible()
+        {
+            var section = new LayoutSection();
+            section.Fields!.Add(new LayoutField { FieldName = "visible_col", Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "hidden_col", Visible = false });
+            var method = GetPrivateStaticMethod("EnumerateFields");
+            var result = ((IEnumerable<LayoutField>)method.Invoke(null, new object[] { section })!).ToList();
+            Assert.Single(result);
+            Assert.Equal("visible_col", result[0].FieldName);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateFields 所有欄位 Visible=true 時全數回傳")]
+        public void EnumerateFields_AllVisible_ReturnsAllFields()
+        {
+            var section = new LayoutSection();
+            section.Fields!.Add(new LayoutField { FieldName = "field_a", Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "field_b", Visible = true });
+            var method = GetPrivateStaticMethod("EnumerateFields");
+            var result = ((IEnumerable<LayoutField>)method.Invoke(null, new object[] { section })!).ToList();
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions 在 DataObject 為 null 時回傳空列舉")]
+        public void EnumerateOptions_NullDataObject_ReturnsEmpty()
+        {
+            var component = new DynamicForm();
+            var field = new LayoutField { FieldName = "status" };
+            var method = GetPrivateInstanceMethod("EnumerateOptions");
+            var result = (IEnumerable<ListItem>)method.Invoke(component, new object[] { field })!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions 欄位名稱不在 Schema 時回傳空列舉")]
+        public void EnumerateOptions_FieldNotInSchema_ReturnsEmpty()
+        {
+            var schema = BuildSchema();
+            var dataObject = new FormDataObject(schema);
+            var component = new DynamicForm();
+            GetProperty(nameof(DynamicForm.DataObject)).SetValue(component, dataObject);
+            var field = new LayoutField { FieldName = "nonexistent_col" };
+            var method = GetPrivateInstanceMethod("EnumerateOptions");
+            var result = (IEnumerable<ListItem>)method.Invoke(component, new object[] { field })!;
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        [DisplayName("FieldInputId 回傳 IdPrefix 與 FieldName 組合的格式化字串")]
+        public void FieldInputId_ValidField_ReturnsFormattedId()
+        {
+            var component = new DynamicForm();
+            GetProperty(nameof(DynamicForm.IdPrefix)).SetValue(component, "my-form");
+            var field = new LayoutField { FieldName = "emp_name" };
+            var method = GetPrivateInstanceMethod("FieldInputId");
+            var result = (string)method.Invoke(component, new object[] { field })!;
+            Assert.Equal("my-form-emp_name", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle 在 Layout 為 null 時產生單欄格線樣式")]
+        public void BuildGridStyle_NullLayout_UsesOneColumnStyle()
+        {
+            var component = new DynamicForm();
+            var method = GetPrivateInstanceMethod("BuildGridStyle");
+            var result = (string)method.Invoke(component, null)!;
+            Assert.Equal("display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle 依 ColumnCount 產生對應欄數的格線樣式")]
+        public void BuildGridStyle_WithColumnCount_ReturnsCorrectStyle()
+        {
+            var component = new DynamicForm();
+            var layout = new FormLayout { ColumnCount = 3 };
+            GetProperty(nameof(DynamicForm.Layout)).SetValue(component, layout);
+            var method = GetPrivateInstanceMethod("BuildGridStyle");
+            var result = (string)method.Invoke(component, null)!;
+            Assert.Equal("display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle 在 ColumnCount 小於 1 時夾住為單欄格線樣式")]
+        public void BuildGridStyle_ZeroColumnCount_ClampsToOneColumn()
+        {
+            var component = new DynamicForm();
+            var layout = new FormLayout { ColumnCount = 0 };
+            GetProperty(nameof(DynamicForm.Layout)).SetValue(component, layout);
+            var method = GetPrivateInstanceMethod("BuildGridStyle");
+            var result = (string)method.Invoke(component, null)!;
+            Assert.Equal("display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildFieldStyle 在預設 Span 時回傳 grid-row:span 1;grid-column:span 1")]
+        public void BuildFieldStyle_DefaultSpans_ReturnsSpanOne()
+        {
+            var field = new LayoutField { FieldName = "test_col" };
+            var method = GetPrivateStaticMethod("BuildFieldStyle");
+            var result = (string)method.Invoke(null, new object[] { field })!;
+            Assert.Equal("grid-row:span 1;grid-column:span 1", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildFieldStyle 在自訂 Span 時回傳對應的 CSS Grid 樣式字串")]
+        public void BuildFieldStyle_CustomSpans_ReturnsCorrectStyle()
+        {
+            var field = new LayoutField { FieldName = "desc_col", RowSpan = 2, ColumnSpan = 3 };
+            var method = GetPrivateStaticMethod("BuildFieldStyle");
+            var result = (string)method.Invoke(null, new object[] { field })!;
+            Assert.Equal("grid-row:span 2;grid-column:span 3", result);
         }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor.cs` | 15.8% | 11 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor.cs` | 15.8% | 11 |

### 補強說明

兩個 `DynamicForm.razor.cs` 的私有方法（`EnumerateSections`、`EnumerateFields`、`EnumerateOptions`、`FieldInputId`、`BuildGridStyle`、`BuildFieldStyle`）均未被現有測試覆蓋。本 PR 透過 Reflection 呼叫這些私有方法，新增以下測試：

- `EnumerateSections` — Layout 為 null 與有 Section 的兩種情境
- `EnumerateFields` — 全部可見、可見/隱藏混合兩種情境
- `EnumerateOptions` — DataObject 為 null、欄位不在 Schema 兩種情境
- `FieldInputId` — 格式化字串輸出
- `BuildGridStyle` — null Layout、自訂欄數、ColumnCount < 1 夾住三種情境
- `BuildFieldStyle` — 預設 Span（1x1）、自訂 Span（2x3）兩種情境

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | `.razor` 模板需要 bUnit 才能測試 render 行為；測試專案目前未引入 bUnit |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面定義，無可執行程式碼；已透過 `TraceListenerTests.cs` 中的 `ITraceListener` 型別參考間接覆蓋 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXccVivVemRNAqhJkykCUU)_