### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-05-23 09:00

### DIFF
--- a/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using Bee.Base.Data;

--- a/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
@@ -1,0 +1,373 @@
+using System.ComponentModel;
+using System.Data;
+using System.Data.Common;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Sorting;
+using Bee.Definition.Storage;
+using Bee.Repository.Form;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// <see cref="DataFormRepository"/> 建構子驗證、<see cref="DataFormRepository.GetNewData"/> 以及
+    /// 私有 static 純方法（<c>DefaultSortForPaging</c>、<c>ConvertDefaultValue</c>、
+    /// <c>TryCoerceToGuid</c>）的單元測試。
+    /// </summary>
+    public class DataFormRepositoryTests
+    {
+        #region Stubs
+
+        private sealed class StubDefineAccess : IDefineAccess
+        {
+            public DatabaseSettings GetDatabaseSettings() => new();
+            public FormSchema GetFormSchema(string progId) => new();
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class StubConnectionManager : IDbConnectionManager
+        {
+            public DbConnectionInfo GetConnectionInfo(string databaseId) => throw new NotImplementedException();
+            public DbConnection CreateConnection(string databaseId) => throw new NotImplementedException();
+            public bool Remove(string databaseId) => false;
+            public void Clear() { }
+            public bool Contains(string databaseId) => false;
+            public int Count => 0;
+        }
+
+        #endregion
+
+        private static FormSchema BuildSchemaWithRowId(string progId = "Employee")
+        {
+            var schema = new FormSchema(progId, progId);
+            var master = schema.Tables!.Add(progId, progId);
+            master.Fields!.Add(SysFields.RowId, "Row ID", FieldDbType.Guid);
+            master.Fields.Add("emp_id", "ID", FieldDbType.String);
+            return schema;
+        }
+
+        private static DataFormRepository CreateRepository(string progId = "Employee", FormSchema? schema = null)
+        {
+            schema ??= BuildSchemaWithRowId(progId);
+            return new DataFormRepository(
+                progId, schema,
+                new StubDefineAccess(), new StubDbAccessFactory(), new StubConnectionManager(),
+                "common_sqlserver");
+        }
+
+        // ---- 建構子引數驗證 ----
+
+        [Fact]
+        [DisplayName("建構子傳入 null progId 應拋 ArgumentNullException")]
+        public void Constructor_NullProgId_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository(
+                    null!, BuildSchemaWithRowId(),
+                    new StubDefineAccess(), new StubDbAccessFactory(), new StubConnectionManager(), "db"));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null schema 應拋 ArgumentNullException")]
+        public void Constructor_NullSchema_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository(
+                    "Employee", null!,
+                    new StubDefineAccess(), new StubDbAccessFactory(), new StubConnectionManager(), "db"));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null defineAccess 應拋 ArgumentNullException")]
+        public void Constructor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository(
+                    "Employee", BuildSchemaWithRowId(),
+                    null!, new StubDbAccessFactory(), new StubConnectionManager(), "db"));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository(
+                    "Employee", BuildSchemaWithRowId(),
+                    new StubDefineAccess(), null!, new StubConnectionManager(), "db"));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null connectionManager 應拋 ArgumentNullException")]
+        public void Constructor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository(
+                    "Employee", BuildSchemaWithRowId(),
+                    new StubDefineAccess(), new StubDbAccessFactory(), null!, "db"));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null databaseId 應拋 ArgumentNullException")]
+        public void Constructor_NullDatabaseId_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository(
+                    "Employee", BuildSchemaWithRowId(),
+                    new StubDefineAccess(), new StubDbAccessFactory(), new StubConnectionManager(), null!));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入有效引數應正確設定 ProgId 屬性")]
+        public void Constructor_ValidArguments_SetsProgId()
+        {
+            var repo = CreateRepository("SalesOrder");
+            Assert.Equal("SalesOrder", repo.ProgId);
+        }
+
+        // ---- GetNewData ----
+
+        [Fact]
+        [DisplayName("GetNewData Schema 的 MasterTable 為 null 時應拋 InvalidOperationException")]
+        public void GetNewData_SchemaWithNoMasterTable_ThrowsInvalidOperationException()
+        {
+            // FormSchema() without ProgId → MasterTable returns null
+            var schema = new FormSchema();
+            var repo = new DataFormRepository(
+                "Employee", schema,
+                new StubDefineAccess(), new StubDbAccessFactory(), new StubConnectionManager(), "db");
+
+            Assert.Throws<InvalidOperationException>(() => repo.GetNewData());
+        }
+
+        [Fact]
+        [DisplayName("GetNewData 有效 Schema 應回傳含主表名稱的 DataSet")]
+        public void GetNewData_ValidSchema_ReturnsMasterDataSet()
+        {
+            var repo = CreateRepository();
+            var dataSet = repo.GetNewData();
+
+            Assert.NotNull(dataSet);
+            Assert.Equal("Employee", dataSet.DataSetName);
+            Assert.True(dataSet.Tables.Contains("Employee"));
+        }
+
+        [Fact]
+        [DisplayName("GetNewData 主表應有一筆新增列且 sys_rowid 為有效的非 Empty Guid")]
+        public void GetNewData_ValidSchema_MasterRowHasNonEmptyRowId()
+        {
+            var repo = CreateRepository();
+            var dataSet = repo.GetNewData();
+            var masterTable = dataSet.Tables["Employee"]!;
+
+            Assert.Single(masterTable.Rows);
+            var rowId = masterTable.Rows[0][SysFields.RowId];
+            Assert.IsType<Guid>(rowId);
+            Assert.NotEqual(Guid.Empty, (Guid)rowId);
+        }
+
+        [Fact]
+        [DisplayName("GetNewData Schema 含 Detail Table 時應回傳含主表與明細表的 DataSet")]
+        public void GetNewData_SchemaWithDetailTable_ReturnsDataSetWithBothTables()
+        {
+            var schema = BuildSchemaWithRowId("Order");
+            var detail = schema.Tables!.Add("OrderDetail", "Order Detail");
+            detail.Fields!.Add("item_no", "Item No", FieldDbType.String);
+
+            var repo = new DataFormRepository(
+                "Order", schema,
+                new StubDefineAccess(), new StubDbAccessFactory(), new StubConnectionManager(), "db");
+
+            var dataSet = repo.GetNewData();
+
+            Assert.True(dataSet.Tables.Contains("Order"));
+            Assert.True(dataSet.Tables.Contains("OrderDetail"));
+        }
+
+        // ---- DefaultSortForPaging (private static，透過 Reflection 測試) ----
+
+        private static readonly Type[] s_formSchemaParam = [typeof(FormSchema)];
+
+        private static MethodInfo GetDefaultSortForPaging()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "DefaultSortForPaging",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_formSchemaParam,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Fact]
+        [DisplayName("DefaultSortForPaging Schema 無 MasterTable 應拋 InvalidOperationException")]
+        public void DefaultSortForPaging_NoMasterTable_ThrowsInvalidOperationException()
+        {
+            var schema = new FormSchema();
+            var method = GetDefaultSortForPaging();
+            var outer = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object[] { schema }));
+            Assert.IsType<InvalidOperationException>(outer.InnerException);
+        }
+
+        [Fact]
+        [DisplayName("DefaultSortForPaging MasterTable 無 sys_no 欄位應拋 InvalidOperationException")]
+        public void DefaultSortForPaging_NoSysNoField_ThrowsInvalidOperationException()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            schema.Tables!.Add("Employee", "Employee");
+            var method = GetDefaultSortForPaging();
+            var outer = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object[] { schema }));
+            Assert.IsType<InvalidOperationException>(outer.InnerException);
+        }
+
+        [Fact]
+        [DisplayName("DefaultSortForPaging MasterTable 含 sys_no 應回傳單一 sys_no ASC 排序")]
+        public void DefaultSortForPaging_WithSysNoField_ReturnsSysNoAscSort()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add(SysFields.No, "No", FieldDbType.Integer);
+
+            var method = GetDefaultSortForPaging();
+            var result = (SortFieldCollection)method.Invoke(null, new object[] { schema })!;
+
+            Assert.Single(result);
+            Assert.Equal(SysFields.No, result[0].FieldName);
+            Assert.Equal(SortDirection.Asc, result[0].Direction);
+        }
+
+        // ---- ConvertDefaultValue (private static，透過 Reflection 測試) ----
+
+        private static MethodInfo GetConvertDefaultValue()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "ConvertDefaultValue",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Fact]
+        [DisplayName("ConvertDefaultValue targetType 為 string 應回傳原始字串")]
+        public void ConvertDefaultValue_StringType_ReturnsRawString()
+        {
+            var method = GetConvertDefaultValue();
+            var result = method.Invoke(null, new object[] { "hello", typeof(string) });
+            Assert.Equal("hello", result);
+        }
+
+        [Fact]
+        [DisplayName("ConvertDefaultValue targetType 為 Guid 且輸入有效 GUID 字串應回傳解析後的 Guid")]
+        public void ConvertDefaultValue_GuidTypeValidString_ReturnsParsedGuid()
+        {
+            var expected = new Guid("12345678-1234-1234-1234-123456789012");
+            var method = GetConvertDefaultValue();
+            var result = method.Invoke(null, new object[] { expected.ToString(), typeof(Guid) });
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("ConvertDefaultValue targetType 為 Guid 且輸入無效字串應回傳 Guid.Empty")]
+        public void ConvertDefaultValue_GuidTypeInvalidString_ReturnsGuidEmpty()
+        {
+            var method = GetConvertDefaultValue();
+            var result = method.Invoke(null, new object[] { "not-a-guid", typeof(Guid) });
+            Assert.Equal(Guid.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("ConvertDefaultValue targetType 為 int 且輸入無效字串應回傳 DBNull.Value")]
+        public void ConvertDefaultValue_IntTypeInvalidString_ReturnsDbNull()
+        {
+            var method = GetConvertDefaultValue();
+            var result = method.Invoke(null, new object[] { "abc", typeof(int) });
+            Assert.Equal(DBNull.Value, result);
+        }
+
+        [Fact]
+        [DisplayName("ConvertDefaultValue targetType 為 int 且輸入有效字串應回傳轉換後的 int")]
+        public void ConvertDefaultValue_IntTypeValidString_ReturnsInt()
+        {
+            var method = GetConvertDefaultValue();
+            var result = method.Invoke(null, new object[] { "42", typeof(int) });
+            Assert.Equal(42, result);
+        }
+
+        // ---- TryCoerceToGuid (private static，透過 Reflection 測試) ----
+
+        private static MethodInfo GetTryCoerceToGuid()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "TryCoerceToGuid",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Fact]
+        [DisplayName("TryCoerceToGuid 傳入 Guid 值應回傳相同 Guid")]
+        public void TryCoerceToGuid_GuidValue_ReturnsGuid()
+        {
+            var id = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+            var method = GetTryCoerceToGuid();
+            var result = (Guid?)method.Invoke(null, new object?[] { id });
+            Assert.Equal(id, result);
+        }
+
+        [Fact]
+        [DisplayName("TryCoerceToGuid 傳入有效 GUID 字串應回傳解析後的 Guid")]
+        public void TryCoerceToGuid_ValidGuidString_ReturnsParsedGuid()
+        {
+            var id = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+            var method = GetTryCoerceToGuid();
+            var result = (Guid?)method.Invoke(null, new object?[] { id.ToString() });
+            Assert.Equal(id, result);
+        }
+
+        [Fact]
+        [DisplayName("TryCoerceToGuid 傳入非 Guid 相容物件應回傳 null")]
+        public void TryCoerceToGuid_NonGuidValue_ReturnsNull()
+        {
+            var method = GetTryCoerceToGuid();
+            int intValue = 42;
+            var result = (Guid?)method.Invoke(null, new object?[] { intValue });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("TryCoerceToGuid 傳入 null 應回傳 null")]
+        public void TryCoerceToGuid_NullValue_ReturnsNull()
+        {
+            var method = GetTryCoerceToGuid();
+            object? nullObj = null;
+            var result = (Guid?)method.Invoke(null, new object?[] { nullObj });
+            Assert.Null(result);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
@@ -1,0 +1,281 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Server.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// Structural smoke tests and reflection-based checks for <see cref="DynamicGrid"/>.
+    /// Covers parameter surface, default values, and the private static helper methods
+    /// <c>TryGetRowId</c>, <c>FormatCell</c>, and <c>BuildColumnStyle</c>.
+    /// </summary>
+    public class DynamicGridTests
+    {
+        private static readonly Type[] s_dataRowGuidOutParam = [typeof(DataRow), typeof(Guid).MakeByRefType()];
+        private static readonly Type[] s_dataRowColumnParam = [typeof(DataRow), typeof(LayoutColumn)];
+        private static readonly Type[] s_layoutColumnParam = [typeof(LayoutColumn)];
+
+        private static PropertyInfo GetPublicProperty(string name)
+        {
+            var property = typeof(DynamicGrid).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        private static MethodInfo GetTryGetRowId()
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "TryGetRowId",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_dataRowGuidOutParam,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static MethodInfo GetFormatCell()
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "FormatCell",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_dataRowColumnParam,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static MethodInfo GetBuildColumnStyle()
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "BuildColumnStyle",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_layoutColumnParam,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        // ---- 結構性測試 ----
+
+        [Fact]
+        [DisplayName("DynamicGrid 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(DynamicGrid)));
+        }
+
+        [Theory]
+        [InlineData(nameof(DynamicGrid.Layout))]
+        [InlineData(nameof(DynamicGrid.Rows))]
+        [InlineData(nameof(DynamicGrid.OnRowSelected))]
+        [InlineData(nameof(DynamicGrid.EmptyText))]
+        [DisplayName("公開屬性皆標註 [Parameter]")]
+        public void PublicProperties_AreMarkedAsParameters(string name)
+        {
+            var property = GetPublicProperty(name);
+            Assert.NotNull(property.GetCustomAttribute<ParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("EmptyText 屬性預設值為 \"No data.\"")]
+        public void EmptyText_DefaultValue_IsNoData()
+        {
+            var grid = new DynamicGrid();
+            Assert.Equal("No data.", grid.EmptyText);
+        }
+
+        // ---- TryGetRowId ----
+
+        [Fact]
+        [DisplayName("TryGetRowId 列無 sys_rowid 欄位應回傳 false")]
+        public void TryGetRowId_NoRowIdColumn_ReturnsFalse()
+        {
+            var table = new DataTable();
+            var row = table.NewRow();
+            var method = GetTryGetRowId();
+            var args = new object[] { row, Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+            Assert.False(result);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId 列含 Guid 型別的 sys_rowid 應回傳 true 及正確 Guid")]
+        public void TryGetRowId_GuidRowId_ReturnsTrueWithCorrectGuid()
+        {
+            var expected = new Guid("11111111-2222-3333-4444-555555555555");
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected;
+            table.Rows.Add(row);
+
+            var method = GetTryGetRowId();
+            var args = new object[] { table.Rows[0], Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+
+            Assert.True(result);
+            Assert.Equal(expected, (Guid)args[1]);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId 列含 string 型別的有效 GUID 應回傳 true 及解析後 Guid")]
+        public void TryGetRowId_StringRowId_ReturnsTrueWithParsedGuid()
+        {
+            var expected = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected.ToString();
+            table.Rows.Add(row);
+
+            var method = GetTryGetRowId();
+            var args = new object[] { table.Rows[0], Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+
+            Assert.True(result);
+            Assert.Equal(expected, (Guid)args[1]);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 值為 DBNull 應回傳 false")]
+        public void TryGetRowId_DbNullRowId_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = DBNull.Value;
+            table.Rows.Add(row);
+
+            var method = GetTryGetRowId();
+            var args = new object[] { table.Rows[0], Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+            Assert.False(result);
+        }
+
+        // ---- FormatCell ----
+
+        [Fact]
+        [DisplayName("FormatCell 欄位不存在於列時應回傳空字串")]
+        public void FormatCell_ColumnNotInTable_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            var row = table.NewRow();
+            var column = new LayoutColumn { FieldName = "missing_field" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { row, column })!;
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位值為 DBNull 應回傳空字串")]
+        public void FormatCell_DbNullValue_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            table.Columns.Add("status", typeof(string));
+            var row = table.NewRow();
+            row["status"] = DBNull.Value;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "status" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 字串值應直接回傳字串內容")]
+        public void FormatCell_StringValue_ReturnsStringAsIs()
+        {
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = "Alice";
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "name" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("Alice", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 無時間部分應回傳 yyyy-MM-dd 格式")]
+        public void FormatCell_DateOnlyDateTime_ReturnsDateOnlyFormat()
+        {
+            var dt = new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+            var table = new DataTable();
+            table.Columns.Add("hire_date", typeof(DateTime));
+            var row = table.NewRow();
+            row["hire_date"] = dt;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "hire_date" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("2024-03-15", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 含時間部分應回傳 yyyy-MM-dd HH:mm:ss 格式")]
+        public void FormatCell_DateTimeWithTime_ReturnsFullDateTimeFormat()
+        {
+            var dt = new DateTime(2024, 3, 15, 14, 30, 0, DateTimeKind.Utc);
+            var table = new DataTable();
+            table.Columns.Add("updated_at", typeof(DateTime));
+            var row = table.NewRow();
+            row["updated_at"] = dt;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "updated_at" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("2024-03-15 14:30:00", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 設定 DisplayFormat 時應套用格式")]
+        public void FormatCell_WithDisplayFormat_AppliesFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("seq_no", typeof(int));
+            var row = table.NewRow();
+            row["seq_no"] = 42;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "seq_no", DisplayFormat = "D5" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("00042", result);
+        }
+
+        // ---- BuildColumnStyle ----
+
+        [Fact]
+        [DisplayName("BuildColumnStyle 寬度大於 0 應回傳 width:{n}px 樣式字串")]
+        public void BuildColumnStyle_PositiveWidth_ReturnsWidthStyle()
+        {
+            var column = new LayoutColumn { Width = 120 };
+            var method = GetBuildColumnStyle();
+            var result = (string)method.Invoke(null, new object[] { column })!;
+            Assert.Equal("width:120px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildColumnStyle 寬度為 0 應回傳空字串")]
+        public void BuildColumnStyle_ZeroWidth_ReturnsEmpty()
+        {
+            var column = new LayoutColumn { Width = 0 };
+            var method = GetBuildColumnStyle();
+            var result = (string)method.Invoke(null, new object[] { column })!;
+            Assert.Equal(string.Empty, result);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageTests.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DependencyInjection;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// Structural smoke tests for <see cref="FormPage"/>: confirms the component
+    /// type hierarchy, the public/private parameter surface, and default values.
+    /// Actual rendering behaviour (OnInitializedAsync, data loading) requires a
+    /// running backend and is exercised by the host sample application, not by
+    /// in-memory unit tests.
+    /// </summary>
+    public class FormPageTests
+    {
+        private static PropertyInfo GetPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        private static PropertyInfo GetNonPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        [Fact]
+        [DisplayName("FormPage 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(FormPage)));
+        }
+
+        [Fact]
+        [DisplayName("ProgId 屬性標註 [Parameter]")]
+        public void ProgId_IsMarkedAsParameter()
+        {
+            var property = GetPublicProperty(nameof(FormPage.ProgId));
+            Assert.NotNull(property.GetCustomAttribute<ParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("ProgId 屬性標註 [EditorRequired]")]
+        public void ProgId_IsMarkedAsEditorRequired()
+        {
+            var property = GetPublicProperty(nameof(FormPage.ProgId));
+            Assert.NotNull(property.GetCustomAttribute<EditorRequiredAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("AccessToken 屬性標註 [CascadingParameter]")]
+        public void AccessToken_IsMarkedAsCascadingParameter()
+        {
+            var property = GetPublicProperty(nameof(FormPage.AccessToken));
+            Assert.NotNull(property.GetCustomAttribute<CascadingParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("Factory 私有屬性標註 [Inject] 且型別為 BeeApiConnectorFactory")]
+        public void Factory_IsInjectedBeeApiConnectorFactory()
+        {
+            var property = GetNonPublicProperty("Factory");
+            Assert.NotNull(property.GetCustomAttribute<InjectAttribute>());
+            Assert.Equal(typeof(BeeApiConnectorFactory), property.PropertyType);
+        }
+
+        [Fact]
+        [DisplayName("可建立 FormPage 執行個體且 ProgId 預設為空字串")]
+        public void Instance_ProgIdDefaultsToEmptyString()
+        {
+            var page = new FormPage();
+            Assert.Equal(string.Empty, page.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("可建立 FormPage 執行個體且 AccessToken 預設為 Guid.Empty")]
+        public void Instance_AccessTokenDefaultsToGuidEmpty()
+        {
+            var page = new FormPage();
+            Assert.Equal(Guid.Empty, page.AccessToken);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
@@ -1,0 +1,281 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Wasm.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// Structural smoke tests and reflection-based checks for <see cref="DynamicGrid"/>.
+    /// Covers parameter surface, default values, and the private static helper methods
+    /// <c>TryGetRowId</c>, <c>FormatCell</c>, and <c>BuildColumnStyle</c>.
+    /// </summary>
+    public class DynamicGridTests
+    {
+        private static readonly Type[] s_dataRowGuidOutParam = [typeof(DataRow), typeof(Guid).MakeByRefType()];
+        private static readonly Type[] s_dataRowColumnParam = [typeof(DataRow), typeof(LayoutColumn)];
+        private static readonly Type[] s_layoutColumnParam = [typeof(LayoutColumn)];
+
+        private static PropertyInfo GetPublicProperty(string name)
+        {
+            var property = typeof(DynamicGrid).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        private static MethodInfo GetTryGetRowId()
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "TryGetRowId",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_dataRowGuidOutParam,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static MethodInfo GetFormatCell()
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "FormatCell",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_dataRowColumnParam,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static MethodInfo GetBuildColumnStyle()
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "BuildColumnStyle",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_layoutColumnParam,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        // ---- 結構性測試 ----
+
+        [Fact]
+        [DisplayName("DynamicGrid 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(DynamicGrid)));
+        }
+
+        [Theory]
+        [InlineData(nameof(DynamicGrid.Layout))]
+        [InlineData(nameof(DynamicGrid.Rows))]
+        [InlineData(nameof(DynamicGrid.OnRowSelected))]
+        [InlineData(nameof(DynamicGrid.EmptyText))]
+        [DisplayName("公開屬性皆標註 [Parameter]")]
+        public void PublicProperties_AreMarkedAsParameters(string name)
+        {
+            var property = GetPublicProperty(name);
+            Assert.NotNull(property.GetCustomAttribute<ParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("EmptyText 屬性預設值為 \"No data.\"")]
+        public void EmptyText_DefaultValue_IsNoData()
+        {
+            var grid = new DynamicGrid();
+            Assert.Equal("No data.", grid.EmptyText);
+        }
+
+        // ---- TryGetRowId ----
+
+        [Fact]
+        [DisplayName("TryGetRowId 列無 sys_rowid 欄位應回傳 false")]
+        public void TryGetRowId_NoRowIdColumn_ReturnsFalse()
+        {
+            var table = new DataTable();
+            var row = table.NewRow();
+            var method = GetTryGetRowId();
+            var args = new object[] { row, Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+            Assert.False(result);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId 列含 Guid 型別的 sys_rowid 應回傳 true 及正確 Guid")]
+        public void TryGetRowId_GuidRowId_ReturnsTrueWithCorrectGuid()
+        {
+            var expected = new Guid("11111111-2222-3333-4444-555555555555");
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected;
+            table.Rows.Add(row);
+
+            var method = GetTryGetRowId();
+            var args = new object[] { table.Rows[0], Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+
+            Assert.True(result);
+            Assert.Equal(expected, (Guid)args[1]);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId 列含 string 型別的有效 GUID 應回傳 true 及解析後 Guid")]
+        public void TryGetRowId_StringRowId_ReturnsTrueWithParsedGuid()
+        {
+            var expected = new Guid("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected.ToString();
+            table.Rows.Add(row);
+
+            var method = GetTryGetRowId();
+            var args = new object[] { table.Rows[0], Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+
+            Assert.True(result);
+            Assert.Equal(expected, (Guid)args[1]);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 值為 DBNull 應回傳 false")]
+        public void TryGetRowId_DbNullRowId_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = DBNull.Value;
+            table.Rows.Add(row);
+
+            var method = GetTryGetRowId();
+            var args = new object[] { table.Rows[0], Guid.Empty };
+            var result = (bool)method.Invoke(null, args)!;
+            Assert.False(result);
+        }
+
+        // ---- FormatCell ----
+
+        [Fact]
+        [DisplayName("FormatCell 欄位不存在於列時應回傳空字串")]
+        public void FormatCell_ColumnNotInTable_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            var row = table.NewRow();
+            var column = new LayoutColumn { FieldName = "missing_field" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { row, column })!;
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位值為 DBNull 應回傳空字串")]
+        public void FormatCell_DbNullValue_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            table.Columns.Add("status", typeof(string));
+            var row = table.NewRow();
+            row["status"] = DBNull.Value;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "status" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 字串值應直接回傳字串內容")]
+        public void FormatCell_StringValue_ReturnsStringAsIs()
+        {
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = "Alice";
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "name" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("Alice", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 無時間部分應回傳 yyyy-MM-dd 格式")]
+        public void FormatCell_DateOnlyDateTime_ReturnsDateOnlyFormat()
+        {
+            var dt = new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+            var table = new DataTable();
+            table.Columns.Add("hire_date", typeof(DateTime));
+            var row = table.NewRow();
+            row["hire_date"] = dt;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "hire_date" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("2024-03-15", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 含時間部分應回傳 yyyy-MM-dd HH:mm:ss 格式")]
+        public void FormatCell_DateTimeWithTime_ReturnsFullDateTimeFormat()
+        {
+            var dt = new DateTime(2024, 3, 15, 14, 30, 0, DateTimeKind.Utc);
+            var table = new DataTable();
+            table.Columns.Add("updated_at", typeof(DateTime));
+            var row = table.NewRow();
+            row["updated_at"] = dt;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "updated_at" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("2024-03-15 14:30:00", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 設定 DisplayFormat 時應套用格式")]
+        public void FormatCell_WithDisplayFormat_AppliesFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("seq_no", typeof(int));
+            var row = table.NewRow();
+            row["seq_no"] = 42;
+            table.Rows.Add(row);
+
+            var column = new LayoutColumn { FieldName = "seq_no", DisplayFormat = "D5" };
+            var method = GetFormatCell();
+            var result = (string)method.Invoke(null, new object[] { table.Rows[0], column })!;
+            Assert.Equal("00042", result);
+        }
+
+        // ---- BuildColumnStyle ----
+
+        [Fact]
+        [DisplayName("BuildColumnStyle 寬度大於 0 應回傳 width:{n}px 樣式字串")]
+        public void BuildColumnStyle_PositiveWidth_ReturnsWidthStyle()
+        {
+            var column = new LayoutColumn { Width = 120 };
+            var method = GetBuildColumnStyle();
+            var result = (string)method.Invoke(null, new object[] { column })!;
+            Assert.Equal("width:120px", result);
+        }
+
+        [Fact]
+        [DisplayName("BuildColumnStyle 寬度為 0 應回傳空字串")]
+        public void BuildColumnStyle_ZeroWidth_ReturnsEmpty()
+        {
+            var column = new LayoutColumn { Width = 0 };
+            var method = GetBuildColumnStyle();
+            var result = (string)method.Invoke(null, new object[] { column })!;
+            Assert.Equal(string.Empty, result);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageTests.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DependencyInjection;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// Structural smoke tests for <see cref="FormPage"/>: confirms the component
+    /// type hierarchy, the public/private parameter surface, and default values.
+    /// Actual rendering behaviour (OnInitializedAsync, data loading) requires a
+    /// running backend and is exercised by the host sample application, not by
+    /// in-memory unit tests.
+    /// </summary>
+    public class FormPageTests
+    {
+        private static PropertyInfo GetPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        private static PropertyInfo GetNonPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        [Fact]
+        [DisplayName("FormPage 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(FormPage)));
+        }
+
+        [Fact]
+        [DisplayName("ProgId 屬性標註 [Parameter]")]
+        public void ProgId_IsMarkedAsParameter()
+        {
+            var property = GetPublicProperty(nameof(FormPage.ProgId));
+            Assert.NotNull(property.GetCustomAttribute<ParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("ProgId 屬性標註 [EditorRequired]")]
+        public void ProgId_IsMarkedAsEditorRequired()
+        {
+            var property = GetPublicProperty(nameof(FormPage.ProgId));
+            Assert.NotNull(property.GetCustomAttribute<EditorRequiredAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("AccessToken 屬性標註 [CascadingParameter]")]
+        public void AccessToken_IsMarkedAsCascadingParameter()
+        {
+            var property = GetPublicProperty(nameof(FormPage.AccessToken));
+            Assert.NotNull(property.GetCustomAttribute<CascadingParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("Factory 私有屬性標註 [Inject] 且型別為 BeeApiConnectorFactory")]
+        public void Factory_IsInjectedBeeApiConnectorFactory()
+        {
+            var property = GetNonPublicProperty("Factory");
+            Assert.NotNull(property.GetCustomAttribute<InjectAttribute>());
+            Assert.Equal(typeof(BeeApiConnectorFactory), property.PropertyType);
+        }
+
+        [Fact]
+        [DisplayName("可建立 FormPage 執行個體且 ProgId 預設為空字串")]
+        public void Instance_ProgIdDefaultsToEmptyString()
+        {
+            var page = new FormPage();
+            Assert.Equal(string.Empty, page.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("可建立 FormPage 執行個體且 AccessToken 預設為 Guid.Empty")]
+        public void Instance_AccessTokenDefaultsToGuidEmpty()
+        {
+            var page = new FormPage();
+            Assert.Equal(Guid.Empty, page.AccessToken);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Repository/Form/DataFormRepository.cs` | 84.2% | 22 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor.cs` | 0.0% | 7 |
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor.cs` | 0.0% | 7 |
| `src/Bee.Web.Blazor.Server/Components/DynamicGrid.razor.cs` | 0.0% | 13 |
| `src/Bee.Web.Blazor.Wasm/Components/DynamicGrid.razor.cs` | 0.0% | 13 |

### 補強內容說明

- **DataFormRepository**：建構子 null 引數驗證（6 個）、`GetNewData()` 行為測試（4 個）、私有 static 方法 `DefaultSortForPaging` / `ConvertDefaultValue` / `TryCoerceToGuid` 透過 Reflection 測試（12 個）
- **FormPage（Server & Wasm）**：元件型別繼承、`[Parameter]` / `[EditorRequired]` / `[CascadingParameter]` / `[Inject]` attribute 驗證、預設值確認（各 7 個）
- **DynamicGrid（Server & Wasm）**：元件結構、`[Parameter]` 驗證、`EmptyText` 預設值，以及私有 static 方法 `TryGetRowId` / `FormatCell` / `BuildColumnStyle` 透過 Reflection 測試（各 13 個）

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Core/ClientInfo.cs` | 靜態類別，未覆蓋方法（`SetEndpoint`、`Initialize`、`InitializeConnect`）深度依賴 `ApiClientInfo`、`ApiConnectValidator` 等靜態全域狀態，無法在不污染 process-wide 狀態的情況下安全補測；需以 `[Collection]` 序列化保護，留待人工規劃 |
| `src/Bee.UI.Maui/Controls/DynamicForm.cs` | 私有 helper 方法（`NormalizeColumnCount`、`NormalizeSpans`、`BuildColumnDefinitions`）已由現有 `DynamicFormHelperTests.cs` 完整覆蓋；剩餘未覆蓋程式碼（`Rebuild`、`BuildSection`、`BuildFieldGrid`、`BuildInputControl` 等渲染方法）需要 MAUI UI 執行環境方可測試 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMThPpzhJx15YWJWDtxxpo)_