### PR TITLE
[AutoFix] SonarCloud Issues (4 issues) 2026-05-23 16:00

### DIFF
--- a/src/Bee.UI.Maui/Controls/DynamicGrid.cs
+++ b/src/Bee.UI.Maui/Controls/DynamicGrid.cs
@@ -156,17 +156,14 @@ namespace Bee.UI.Maui.Controls
 
         private static ColumnDefinitionCollection BuildColumnDefinitions(IList<LayoutColumn> columns)
         {
-            var defs = new ColumnDefinitionCollection();
-            foreach (var column in columns)
+            // LayoutColumn.Width is in CSS pixels on the Blazor side; treating it as
+            // device-independent units gives an equivalent column-width hint on MAUI.
+            return [.. columns.Select(c => new ColumnDefinition
             {
-                // LayoutColumn.Width is in CSS pixels on the Blazor side; treating it as
-                // device-independent units gives an equivalent column-width hint on MAUI.
-                var width = column.Width > 0
-                    ? new GridLength(column.Width, GridUnitType.Absolute)
-                    : GridLength.Star;
-                defs.Add(new ColumnDefinition { Width = width });
-            }
-            return defs;
+                Width = c.Width > 0
+                    ? new GridLength(c.Width, GridUnitType.Absolute)
+                    : GridLength.Star,
+            })];
         }
 
         private static Label BuildHeaderCell(string caption)

--- a/src/Bee.UI.Maui/Controls/FormPage.cs
+++ b/src/Bee.UI.Maui/Controls/FormPage.cs
@@ -74,7 +74,6 @@ namespace Bee.UI.Maui.Controls
         private readonly Label _loadingLabel;
         private readonly DynamicGrid _grid;
         private readonly DynamicForm _form;
-        private readonly VerticalStackLayout _body;
         private FormDataObject? _dataObject;
         private FormLayout? _formLayout;
         private LayoutGrid? _listLayout;
@@ -120,13 +119,11 @@ namespace Bee.UI.Maui.Controls
 
             _form = new DynamicForm();
 
-            _body = new VerticalStackLayout
+            Content = new VerticalStackLayout
             {
                 Spacing = 12,
                 Children = { _errorLabel, _loadingLabel, toolbar, _grid, _form },
             };
-
-            Content = _body;
         }
 
         /// <summary>

--- a/src/Bee.UI.Maui/Controls/FormPage.cs
+++ b/src/Bee.UI.Maui/Controls/FormPage.cs
@@ -1,7 +1,6 @@
 using Bee.Api.Client.Connectors;
 using Bee.Definition;
 using Bee.Definition.Forms;
-using Bee.Definition.Layouts;
 using Bee.UI.Core;
 using Bee.UI.Maui.DataObjects;
 
@@ -75,8 +74,6 @@ namespace Bee.UI.Maui.Controls
         private readonly DynamicGrid _grid;
         private readonly DynamicForm _form;
         private FormDataObject? _dataObject;
-        private FormLayout? _formLayout;
-        private LayoutGrid? _listLayout;
         private bool _isBusy;
         private bool _initialized;
         private bool _isInitializing;
@@ -253,13 +250,13 @@ namespace Bee.UI.Maui.Controls
                 ClearError();
                 _loadingLabel.IsVisible = false;
 
-                _formLayout = Schema.GetFormLayout();
-                _listLayout = Schema.GetListLayout();
+                var formLayout = Schema.GetFormLayout();
+                var listLayout = Schema.GetListLayout();
                 _dataObject = new FormDataObject(Schema, FormConnector);
 
-                _form.FormLayout = _formLayout;
+                _form.FormLayout = formLayout;
                 _form.DataObject = _dataObject;
-                _grid.ListLayout = _listLayout;
+                _grid.ListLayout = listLayout;
 
                 _initialized = true;
                 await ReloadListAsync().ConfigureAwait(true);


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ5TBynwqJQ-O8gWpgGZ | csharpsquid:S3267 | `src/Bee.UI.Maui/Controls/DynamicGrid.cs` | `BuildColumnDefinitions` 的 `foreach + Add` 迴圈改為 `columns.Select` + collection expression，消除 Loop should be simplified code smell |
| AZ5TByk9qJQ-O8gWpgGW | csharpsquid:S1450 | `src/Bee.UI.Maui/Controls/FormPage.cs` | 移除 `_body` instance field，建構子直接設定 `Content`，不需保留為物件狀態 |
| AZ5TByk9qJQ-O8gWpgGX | csharpsquid:S1450 | `src/Bee.UI.Maui/Controls/FormPage.cs` | 移除 `_formLayout` instance field，改為 `InitializeAsync` 內的 `var formLayout` 區域變數，同步移除不再使用的 `using Bee.Definition.Layouts` |
| AZ5TByk9qJQ-O8gWpgGY | csharpsquid:S1450 | `src/Bee.UI.Maui/Controls/FormPage.cs` | 移除 `_listLayout` instance field，改為 `InitializeAsync` 內的 `var listLayout` 區域變數 |

## 無法處理

| Issue Key | Rule | 原因 |
|-----------|------|------|
| AZ5TLI4dXSDqH0Ac3wEv | csharpsquid:S3776 | Cognitive Complexity 屬重構判斷題，依 `.claude/rules/sonarcloud.md` 政策不納入自動修正；需人工評估後手動重構 |

## 備註

本 PR 亦包含 MAUI 控制項功能提交（`659ed75`、`d4c7cf0`、`da8abe1`）及 Repository 重構（`4576d37`），這些為 SonarCloud 分析到上述 issue 所在程式碼的必要前置提交，合併後 SonarCloud 將重新分析並關閉對應 issue。

---
_Generated by [Claude Code](https://claude.ai/code/session_01MM43uMBBJV9yE4tGCYZ6Wu)_