### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-05-23 17:04

### DIFF
--- a/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using Bee.Base.Data;

--- a/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/DataFormRepositoryTests.cs
@@ -1,0 +1,309 @@
+using System.ComponentModel;
+using System.Data;
+using System.Data.Common;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.Repository.Form;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="DataFormRepository"/> 建構子驗證、<see cref="DataFormRepository.GetNewData"/>
+    /// 及私有靜態輔助方法（<c>ConvertDefaultValue</c>、<c>TryCoerceToGuid</c>）的純邏輯測試，
+    /// 不需資料庫連線。
+    /// </summary>
+    public class DataFormRepositoryTests
+    {
+        #region Stubs
+
+        private sealed class StubDefineAccess : IDefineAccess
+        {
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class StubConnectionManager : IDbConnectionManager
+        {
+            public DbConnectionInfo GetConnectionInfo(string databaseId) => throw new NotImplementedException();
+            public DbConnection CreateConnection(string databaseId) => throw new NotImplementedException();
+            public bool Remove(string databaseId) => false;
+            public void Clear() { }
+            public bool Contains(string databaseId) => false;
+            public int Count => 0;
+        }
+
+        // CA1861: 所有 typeof() 陣列抽成 static readonly
+        private static readonly Type[] s_convertDefaultValueParams = [typeof(string), typeof(Type)];
+        private static readonly Type[] s_tryCoerceToGuidParams = [typeof(object)];
+
+        private static DataFormRepository CreateRepository(FormSchema? schema = null)
+        {
+            schema ??= BuildSchema();
+            return new DataFormRepository(
+                "Employee",
+                schema,
+                new StubDefineAccess(),
+                new StubDbAccessFactory(),
+                new StubConnectionManager(),
+                "testdb");
+        }
+
+        private static FormSchema BuildSchema()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("emp_name", "Name", FieldDbType.String);
+            return schema;
+        }
+
+        private static MethodInfo GetPrivateStaticMethod(string name, Type[] paramTypes)
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                name, BindingFlags.NonPublic | BindingFlags.Static, null, paramTypes, null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        #endregion
+
+        #region 建構子驗證
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子傳入 null progId 應拋 ArgumentNullException")]
+        public void Constructor_NullProgId_ThrowsArgumentNullException()
+        {
+            var schema = BuildSchema();
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository(null!, schema, new StubDefineAccess(),
+                    new StubDbAccessFactory(), new StubConnectionManager(), "testdb"));
+        }
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子傳入 null schema 應拋 ArgumentNullException")]
+        public void Constructor_NullSchema_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository("Employee", null!, new StubDefineAccess(),
+                    new StubDbAccessFactory(), new StubConnectionManager(), "testdb"));
+        }
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子傳入 null defineAccess 應拋 ArgumentNullException")]
+        public void Constructor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository("Employee", BuildSchema(), null!,
+                    new StubDbAccessFactory(), new StubConnectionManager(), "testdb"));
+        }
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository("Employee", BuildSchema(), new StubDefineAccess(),
+                    null!, new StubConnectionManager(), "testdb"));
+        }
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子傳入 null connectionManager 應拋 ArgumentNullException")]
+        public void Constructor_NullConnectionManager_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository("Employee", BuildSchema(), new StubDefineAccess(),
+                    new StubDbAccessFactory(), null!, "testdb"));
+        }
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子傳入 null databaseId 應拋 ArgumentNullException")]
+        public void Constructor_NullDatabaseId_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DataFormRepository("Employee", BuildSchema(), new StubDefineAccess(),
+                    new StubDbAccessFactory(), new StubConnectionManager(), null!));
+        }
+
+        [Fact]
+        [DisplayName("DataFormRepository 建構子正確設定 ProgId 屬性")]
+        public void Constructor_ValidArgs_SetsProgId()
+        {
+            var repo = CreateRepository();
+            Assert.Equal("Employee", repo.ProgId);
+        }
+
+        #endregion
+
+        #region GetNewData
+
+        [Fact]
+        [DisplayName("GetNewData Schema 含 MasterTable 應回傳含一列 master 資料的 DataSet")]
+        public void GetNewData_SchemaWithMasterTable_ReturnsDataSetWithOneRow()
+        {
+            var repo = CreateRepository();
+            var dataSet = repo.GetNewData();
+
+            Assert.NotNull(dataSet);
+            Assert.Equal("Employee", dataSet.DataSetName);
+            Assert.True(dataSet.Tables.Contains("Employee"));
+            Assert.Equal(1, dataSet.Tables["Employee"]!.Rows.Count);
+        }
+
+        [Fact]
+        [DisplayName("GetNewData master 列的 sys_rowid 應為非空 Guid")]
+        public void GetNewData_MasterRow_HasNonEmptyRowId()
+        {
+            var repo = CreateRepository();
+            var dataSet = repo.GetNewData();
+            var masterRow = dataSet.Tables["Employee"]!.Rows[0];
+            var rowId = (Guid)masterRow[SysFields.RowId];
+            Assert.NotEqual(Guid.Empty, rowId);
+        }
+
+        [Fact]
+        [DisplayName("GetNewData Schema 無 MasterTable 應拋 InvalidOperationException")]
+        public void GetNewData_SchemaWithoutMasterTable_ThrowsInvalidOperationException()
+        {
+            var schema = new FormSchema("NoMaster", "NoMaster");
+            var repo = CreateRepository(schema);
+            Assert.Throws<InvalidOperationException>(() => repo.GetNewData());
+        }
+
+        #endregion
+
+        #region ConvertDefaultValue（私有靜態方法）
+
+        [Theory]
+        [InlineData("hello world")]
+        [InlineData("")]
+        [DisplayName("ConvertDefaultValue string 型別應直接回傳原始字串")]
+        public void ConvertDefaultValue_StringType_ReturnsRawString(string rawValue)
+        {
+            var method = GetPrivateStaticMethod("ConvertDefaultValue", s_convertDefaultValueParams);
+            // rawValue 為變數，避免 CA1861（new object[] { variable, typeof(...) } 不觸發）
+            var result = method.Invoke(null, new object[] { rawValue, typeof(string) });
+            Assert.Equal(rawValue, result);
+        }
+
+        [Fact]
+        [DisplayName("ConvertDefaultValue Guid 型別傳入有效 Guid 字串應解析回傳")]
+        public void ConvertDefaultValue_GuidType_ValidString_ReturnsParsedGuid()
+        {
+            var method = GetPrivateStaticMethod("ConvertDefaultValue", s_convertDefaultValueParams);
+            var expected = Guid.NewGuid();
+            // expected.ToString() 為變數，避免 CA1861
+            var result = method.Invoke(null, new object[] { expected.ToString(), typeof(Guid) });
+            Assert.Equal(expected, (Guid)result!);
+        }
+
+        [Theory]
+        [InlineData("not-a-guid")]
+        [InlineData("12345")]
+        [DisplayName("ConvertDefaultValue Guid 型別傳入無效字串應回傳 Guid.Empty")]
+        public void ConvertDefaultValue_GuidType_InvalidString_ReturnsGuidEmpty(string invalidGuid)
+        {
+            var method = GetPrivateStaticMethod("ConvertDefaultValue", s_convertDefaultValueParams);
+            var result = method.Invoke(null, new object[] { invalidGuid, typeof(Guid) });
+            Assert.Equal(Guid.Empty, (Guid)result!);
+        }
+
+        [Theory]
+        [InlineData("42", 42)]
+        [InlineData("0", 0)]
+        [DisplayName("ConvertDefaultValue int 型別傳入有效數字字串應轉換回傳")]
+        public void ConvertDefaultValue_IntType_ValidString_ReturnsInt(string raw, int expected)
+        {
+            var method = GetPrivateStaticMethod("ConvertDefaultValue", s_convertDefaultValueParams);
+            var result = method.Invoke(null, new object[] { raw, typeof(int) });
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("not-a-number")]
+        [InlineData("abc")]
+        [DisplayName("ConvertDefaultValue int 型別傳入無效字串應回傳 DBNull.Value")]
+        public void ConvertDefaultValue_IntType_InvalidString_ReturnsDBNull(string invalidInt)
+        {
+            var method = GetPrivateStaticMethod("ConvertDefaultValue", s_convertDefaultValueParams);
+            var result = method.Invoke(null, new object[] { invalidInt, typeof(int) });
+            Assert.Same(DBNull.Value, result);
+        }
+
+        #endregion
+
+        #region TryCoerceToGuid（私有靜態方法）
+
+        [Fact]
+        [DisplayName("TryCoerceToGuid 傳入 Guid 應直接回傳相同 Guid")]
+        public void TryCoerceToGuid_GuidInput_ReturnsSameGuid()
+        {
+            var method = GetPrivateStaticMethod("TryCoerceToGuid", s_tryCoerceToGuidParams);
+            var expected = Guid.NewGuid();
+            // expected 為變數，不觸發 CA1861
+            var result = method.Invoke(null, new object?[] { expected });
+            Assert.Equal(expected, (Guid)result!);
+        }
+
+        [Fact]
+        [DisplayName("TryCoerceToGuid 傳入有效 Guid 字串應解析並回傳 Guid")]
+        public void TryCoerceToGuid_ValidGuidString_ReturnsParsedGuid()
+        {
+            var method = GetPrivateStaticMethod("TryCoerceToGuid", s_tryCoerceToGuidParams);
+            var expected = Guid.NewGuid();
+            // expected.ToString() 為變數，不觸發 CA1861
+            var result = method.Invoke(null, new object?[] { expected.ToString() });
+            Assert.Equal(expected, (Guid)result!);
+        }
+
+        [Theory]
+        [InlineData("not-a-guid")]
+        [InlineData("12345")]
+        [DisplayName("TryCoerceToGuid 傳入無效字串應回傳 null")]
+        public void TryCoerceToGuid_InvalidString_ReturnsNull(string invalidGuid)
+        {
+            var method = GetPrivateStaticMethod("TryCoerceToGuid", s_tryCoerceToGuidParams);
+            var result = method.Invoke(null, new object?[] { invalidGuid });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("TryCoerceToGuid 傳入 null 應回傳 null")]
+        public void TryCoerceToGuid_NullInput_ReturnsNull()
+        {
+            var method = GetPrivateStaticMethod("TryCoerceToGuid", s_tryCoerceToGuidParams);
+            // 使用本地變數 nullValue 避免 new object?[] { null } 觸發 CA1861
+            object? nullValue = null;
+            var result = method.Invoke(null, new object?[] { nullValue });
+            Assert.Null(result);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoTests.cs
@@ -36,5 +36,40 @@ namespace Bee.UI.Core.UnitTests
             var settings = ClientInfo.ClientSettings;
             Assert.NotNull(settings);
         }
+
+        [Fact]
+        [DisplayName("ClientInfo.UserInfo 未登入時預設為 null")]
+        public void UserInfo_Default_IsNull()
+        {
+            Assert.Null(ClientInfo.UserInfo);
+        }
+
+        [Fact]
+        [DisplayName("ClientInfo.AllowGenerateSettings 預設為 false")]
+        public void AllowGenerateSettings_Default_IsFalse()
+        {
+            Assert.False(ClientInfo.AllowGenerateSettings);
+        }
+
+        [Fact]
+        [DisplayName("ClientInfo.UIViewService 預設為 null")]
+        public void UIViewService_Default_IsNull()
+        {
+            Assert.Null(ClientInfo.UIViewService);
+        }
+
+        [Fact]
+        [DisplayName("ClientInfo.Arguments 預設為 null")]
+        public void Arguments_Default_IsNull()
+        {
+            Assert.Null(ClientInfo.Arguments);
+        }
+
+        [Fact]
+        [DisplayName("ClientInfo.ApplyLoginResult 傳入 null 應拋 ArgumentNullException")]
+        public void ApplyLoginResult_NullInput_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => ClientInfo.ApplyLoginResult(null!));
+        }
     }
 }

--- a/tests/Bee.UI.Maui.UnitTests/Controls/DynamicFormTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/DynamicFormTests.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Reflection;
 using Bee.Base.Data;
 using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
 using Bee.UI.Maui.Controls;
 using Bee.UI.Maui.DataObjects;
 
@@ -15,6 +16,8 @@ namespace Bee.UI.Maui.UnitTests.Controls
     /// </summary>
     public class DynamicFormTests
     {
+        private static readonly Type[] s_buildInputParams = [typeof(LayoutField), typeof(string)];
+
         private static FormSchema BuildSchema()
         {
             var schema = new FormSchema("Employee", "Employee");
@@ -87,6 +90,45 @@ namespace Bee.UI.Maui.UnitTests.Controls
                 Assert.NotNull(section.Fields);
                 Assert.NotEmpty(section.Fields!);
             });
+        }
+
+        [Fact]
+        [DisplayName("BuildInputControl DateEdit 欄位應建立 DatePicker 且不拋例外")]
+        public void BuildInputControl_DateEditField_DoesNotThrow()
+        {
+            var schema = BuildSchema();
+            var component = new DynamicForm();
+            // 只設 DataObject（FormLayout 仍為 null），令 Rebuild() 為 no-op，避免觸發完整 UI 建構。
+            component.DataObject = new FormDataObject(schema);
+
+            var method = typeof(DynamicForm).GetMethod(
+                "BuildInputControl",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null, s_buildInputParams, null);
+            Assert.NotNull(method);
+
+            var field = new LayoutField { FieldName = "created_at", ControlType = ControlType.DateEdit };
+            var ex = Record.Exception(() => method!.Invoke(component, new object[] { field, "2023-01-15" }));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildInputControl MemoEdit 欄位應建立 Editor 且不拋例外")]
+        public void BuildInputControl_MemoEditField_DoesNotThrow()
+        {
+            var schema = BuildSchema();
+            var component = new DynamicForm();
+            component.DataObject = new FormDataObject(schema);
+
+            var method = typeof(DynamicForm).GetMethod(
+                "BuildInputControl",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null, s_buildInputParams, null);
+            Assert.NotNull(method);
+
+            var field = new LayoutField { FieldName = "description", ControlType = ControlType.MemoEdit };
+            var ex = Record.Exception(() => method!.Invoke(component, new object[] { field, "some text" }));
+            Assert.Null(ex);
         }
     }
 }

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageTests.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DependencyInjection;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 針對 <see cref="FormPage"/> 的結構性 smoke 測試。
+    /// 確認公開參數屬性、CascadingParameter、[Inject] 注入與預設值等編譯期宣告正確；
+    /// OnInitializedAsync 等方法需 Blazor 渲染器驅動，留待 Phase 2 bUnit 整合測試覆蓋。
+    /// </summary>
+    public class FormPageTests
+    {
+        private static PropertyInfo GetPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        private static PropertyInfo GetNonPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        [Fact]
+        [DisplayName("FormPage 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(FormPage)));
+        }
+
+        [Fact]
+        [DisplayName("ProgId 屬性同時標有 [Parameter] 及 [EditorRequired]")]
+        public void ProgId_HasParameterAndEditorRequiredAttributes()
+        {
+            var property = GetPublicProperty(nameof(FormPage.ProgId));
+            Assert.NotNull(property.GetCustomAttribute<ParameterAttribute>());
+            Assert.NotNull(property.GetCustomAttribute<EditorRequiredAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("AccessToken 屬性標有 [CascadingParameter]")]
+        public void AccessToken_HasCascadingParameterAttribute()
+        {
+            var property = GetPublicProperty(nameof(FormPage.AccessToken));
+            Assert.NotNull(property.GetCustomAttribute<CascadingParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("Factory 私有屬性標有 [Inject] 且型別為 BeeApiConnectorFactory")]
+        public void Factory_IsInjectedBeeApiConnectorFactory()
+        {
+            var property = GetNonPublicProperty("Factory");
+            Assert.NotNull(property.GetCustomAttribute<InjectAttribute>());
+            Assert.Equal(typeof(BeeApiConnectorFactory), property.PropertyType);
+        }
+
+        [Fact]
+        [DisplayName("FormPage 預設 ProgId 為空字串")]
+        public void ProgId_Default_IsEmptyString()
+        {
+            var page = new FormPage();
+            Assert.Equal(string.Empty, page.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("FormPage 預設 AccessToken 為 Guid.Empty")]
+        public void AccessToken_Default_IsGuidEmpty()
+        {
+            var page = new FormPage();
+            Assert.Equal(Guid.Empty, page.AccessToken);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageTests.cs
@@ -1,0 +1,81 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DependencyInjection;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 針對 <see cref="FormPage"/> 的結構性 smoke 測試。
+    /// 確認公開參數屬性、CascadingParameter、[Inject] 注入與預設值等編譯期宣告正確；
+    /// OnInitializedAsync 等方法需 Blazor 渲染器驅動，留待 Phase 2 bUnit 整合測試覆蓋。
+    /// </summary>
+    public class FormPageTests
+    {
+        private static PropertyInfo GetPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        private static PropertyInfo GetNonPublicProperty(string name)
+        {
+            var property = typeof(FormPage).GetProperty(
+                name, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(property);
+            return property!;
+        }
+
+        [Fact]
+        [DisplayName("FormPage 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(FormPage)));
+        }
+
+        [Fact]
+        [DisplayName("ProgId 屬性同時標有 [Parameter] 及 [EditorRequired]")]
+        public void ProgId_HasParameterAndEditorRequiredAttributes()
+        {
+            var property = GetPublicProperty(nameof(FormPage.ProgId));
+            Assert.NotNull(property.GetCustomAttribute<ParameterAttribute>());
+            Assert.NotNull(property.GetCustomAttribute<EditorRequiredAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("AccessToken 屬性標有 [CascadingParameter]")]
+        public void AccessToken_HasCascadingParameterAttribute()
+        {
+            var property = GetPublicProperty(nameof(FormPage.AccessToken));
+            Assert.NotNull(property.GetCustomAttribute<CascadingParameterAttribute>());
+        }
+
+        [Fact]
+        [DisplayName("Factory 私有屬性標有 [Inject] 且型別為 BeeApiConnectorFactory")]
+        public void Factory_IsInjectedBeeApiConnectorFactory()
+        {
+            var property = GetNonPublicProperty("Factory");
+            Assert.NotNull(property.GetCustomAttribute<InjectAttribute>());
+            Assert.Equal(typeof(BeeApiConnectorFactory), property.PropertyType);
+        }
+
+        [Fact]
+        [DisplayName("FormPage 預設 ProgId 為空字串")]
+        public void ProgId_Default_IsEmptyString()
+        {
+            var page = new FormPage();
+            Assert.Equal(string.Empty, page.ProgId);
+        }
+
+        [Fact]
+        [DisplayName("FormPage 預設 AccessToken 為 Guid.Empty")]
+        public void AccessToken_Default_IsGuidEmpty()
+        {
+            var page = new FormPage();
+            Assert.Equal(Guid.Empty, page.AccessToken);
+        }
+    }
+}


### PR DESCRIPTION
## 覆蓋率補強摘要

本 PR 由 `bee-coverage-fix` 自動代理產生，針對 SonarCloud 回報覆蓋率不足的檔案補充單元測試。

## 處理檔案（5 筆）

| 檔案 | 測試類別 | 新增測試數 |
|------|----------|-----------|
| `src/Bee.UI.Core/ClientInfo.cs` | `ClientInfoTests` | 5 |
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor.cs` | `FormPageTests` | 6 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor.cs` | `FormPageTests` | 6 |
| `src/Bee.UI.Maui/Controls/DynamicForm.cs` | `DynamicFormTests` | 2 |
| `src/Bee.Repository/Form/DataFormRepository.cs` | `DataFormRepositoryTests` | 19 |

**合計新增測試：38 個**

## 測試說明

- **ClientInfo**：補齊 `UserInfo`、`AllowGenerateSettings`、`UIViewService`、`Arguments` 預設值及 `ApplyLoginResult(null)` 的 null guard 驗證
- **Blazor Wasm/Server FormPage**：結構性 smoke 測試，確認 `[Parameter]`、`[EditorRequired]`、`[CascadingParameter]`、`[Inject]` attribute 宣告正確，及 `ProgId`/`AccessToken` 預設值（`OnInitializedAsync` 等需 Blazor renderer 驅動，留 Phase 2 bUnit 整合測試補充）
- **DynamicForm**：補充 `BuildInputControl` 私有方法對 `DateEdit`→`DatePicker` 與 `MemoEdit`→`Editor` 的路徑測試
- **DataFormRepository**：涵蓋建構子 null guard（6 個參數）、`GetNewData` 正常路徑與 schema 缺失路徑、私有靜態輔助方法 `ConvertDefaultValue` 及 `TryCoerceToGuid` 全路徑（string/Guid/int/invalid/null）

## 無法處理（0 筆）

無。

## Analyzer 合規自查

- ✅ **IDE0005**：未使用的 `using` 已移除
- ✅ **CA1861**：所有 `typeof()` 陣列均以 `static readonly` 欄位宣告；`[Theory]` 參數為方法變數，不觸發常數陣列規則
- ✅ **S2699**：每個 `[Fact]`/`[Theory]` 均有 `Assert.*`；「不拋例外」路徑使用 `Record.Exception` + `Assert.Null`

https://claude.ai/code/session_01RphyPzqr2R7FtZ6LGBRbSJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RphyPzqr2R7FtZ6LGBRbSJ)_