### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-05-25 00:41

### DIFF
--- a/tests/Bee.UI.Core.UnitTests/ClientInfoAdditionalTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoAdditionalTests.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel;
+using Bee.Api.Core.Messages.System;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo"/> 中尚未被覆蓋的非修改路徑。
+    /// 測試僅呼叫不改變可觀測公開靜態狀態的方法，無需 collection 序列化保護。
+    /// </summary>
+    public class ClientInfoReadOnlyTests
+    {
+        [Fact]
+        [DisplayName("GetEndpoint 應回傳字串，不拋例外")]
+        public void GetEndpoint_Default_ReturnsStringWithoutThrowing()
+        {
+            var result = ClientInfo.GetEndpoint();
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [DisplayName("SystemApiConnector getter 應以 Lazy 模式建立非 null 實例")]
+        public void SystemApiConnector_LocalConnectType_ReturnsNotNull()
+        {
+            var connector = ClientInfo.SystemApiConnector;
+            Assert.NotNull(connector);
+        }
+
+        [Fact]
+        [DisplayName("SystemApiConnector getter 多次存取應回傳同一實例（快取）")]
+        public void SystemApiConnector_AccessedTwice_ReturnsSameInstance()
+        {
+            var first = ClientInfo.SystemApiConnector;
+            var second = ClientInfo.SystemApiConnector;
+            Assert.Same(first, second);
+        }
+
+        [Fact]
+        [DisplayName("DefineAccess getter 應以 Lazy 模式建立非 null 的 IDefineAccess 實例")]
+        public void DefineAccess_LocalConnectType_ReturnsNotNull()
+        {
+            var access = ClientInfo.DefineAccess;
+            Assert.NotNull(access);
+        }
+
+        [Fact]
+        [DisplayName("CreateFormApiConnector 應回傳非 null 的 FormApiConnector 實例")]
+        public void CreateFormApiConnector_LocalConnectType_ReturnsNotNull()
+        {
+            var connector = ClientInfo.CreateFormApiConnector("TestProg");
+            Assert.NotNull(connector);
+        }
+    }
+
+    /// <summary>
+    /// 補強 <see cref="ClientInfo"/> 中會修改靜態狀態的路徑。
+    /// 與 <c>EndpointStorageTests</c> 同屬 <c>ClientInfoState</c> collection，確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoMutatingTests
+    {
+        [Fact]
+        [DisplayName("ApplyLoginResult 傳入有效 LoginResponse 應設定 AccessToken 與 UserInfo")]
+        public void ApplyLoginResult_ValidLoginResponse_SetsAccessTokenAndUserInfo()
+        {
+            var token = Guid.NewGuid();
+            var response = new LoginResponse
+            {
+                AccessToken = token,
+                UserId = "u001",
+                UserName = "測試使用者"
+            };
+            try
+            {
+                ClientInfo.ApplyLoginResult(response);
+                Assert.Equal(token, ClientInfo.AccessToken);
+                Assert.NotNull(ClientInfo.UserInfo);
+                Assert.Equal("u001", ClientInfo.UserInfo!.UserId);
+                Assert.Equal("測試使用者", ClientInfo.UserInfo.UserName);
+            }
+            finally
+            {
+                ClientInfo.ApplyLoginResult(new LoginResponse { AccessToken = Guid.Empty });
+            }
+        }
+
+        [Fact]
+        [DisplayName("ApplyLoginResult 以不同 Token 連續呼叫兩次，應以最後一次結果為準")]
+        public void ApplyLoginResult_CalledTwice_LastResultWins()
+        {
+            var tokenA = Guid.NewGuid();
+            var tokenB = Guid.NewGuid();
+            try
+            {
+                ClientInfo.ApplyLoginResult(new LoginResponse
+                {
+                    AccessToken = tokenA,
+                    UserId = "userA",
+                    UserName = "A"
+                });
+                ClientInfo.ApplyLoginResult(new LoginResponse
+                {
+                    AccessToken = tokenB,
+                    UserId = "userB",
+                    UserName = "B"
+                });
+                Assert.Equal(tokenB, ClientInfo.AccessToken);
+                Assert.Equal("userB", ClientInfo.UserInfo!.UserId);
+            }
+            finally
+            {
+                ClientInfo.ApplyLoginResult(new LoginResponse { AccessToken = Guid.Empty });
+            }
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
@@ -1,0 +1,312 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Server.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 結構與純邏輯測試，涵蓋 <see cref="DynamicGrid"/> 的靜態輔助方法
+    /// (<c>TryGetRowId</c>、<c>FormatCell</c>、<c>BuildColumnStyle</c>) 以及
+    /// 私有計算屬性 <c>VisibleColumns</c>。
+    /// 需要 Blazor 渲染器的 render cycle 測試留待 bUnit 整合測試覆蓋。
+    /// </summary>
+    public class DynamicGridTests
+    {
+        private static (bool Success, Guid RowId) InvokeTryGetRowId(DataRow row)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "TryGetRowId", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var args = new object?[] { row, Guid.Empty };
+            var success = (bool)method!.Invoke(null, args)!;
+            return (success, (Guid)args[1]!);
+        }
+
+        private static string InvokeFormatCell(DataRow row, LayoutColumn column)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "FormatCell", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null, new object[] { row, column })!;
+        }
+
+        private static string InvokeBuildColumnStyle(LayoutColumn column)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "BuildColumnStyle", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null, new object[] { column })!;
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // TryGetRowId
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("TryGetRowId 資料表無 sys_rowid 欄位時應回傳 false")]
+        public void TryGetRowId_NoRowIdColumn_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add("other_col", typeof(string));
+            var row = table.NewRow();
+            row["other_col"] = "value";
+            table.Rows.Add(row);
+            var (success, _) = InvokeTryGetRowId(row);
+            Assert.False(success);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 欄位值為 DBNull 時應回傳 false")]
+        public void TryGetRowId_DbNullValue_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(object));
+            var row = table.NewRow();
+            row[SysFields.RowId] = DBNull.Value;
+            table.Rows.Add(row);
+            var (success, _) = InvokeTryGetRowId(row);
+            Assert.False(success);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 欄位為 Guid 型別時應回傳 true 並輸出對應值")]
+        public void TryGetRowId_GuidValue_ReturnsTrueAndOutputsGuid()
+        {
+            var expected = Guid.NewGuid();
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected;
+            table.Rows.Add(row);
+            var (success, actual) = InvokeTryGetRowId(row);
+            Assert.True(success);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 為有效 Guid 字串時應回傳 true 並輸出對應值")]
+        public void TryGetRowId_ValidGuidString_ReturnsTrueAndOutputsGuid()
+        {
+            var expected = Guid.NewGuid();
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected.ToString();
+            table.Rows.Add(row);
+            var (success, actual) = InvokeTryGetRowId(row);
+            Assert.True(success);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 為無效 Guid 字串時應回傳 false")]
+        public void TryGetRowId_InvalidGuidString_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = "not-a-guid";
+            table.Rows.Add(row);
+            var (success, rowId) = InvokeTryGetRowId(row);
+            Assert.False(success);
+            Assert.Equal(Guid.Empty, rowId);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // FormatCell
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("FormatCell 資料表無對應欄位時應回傳空字串")]
+        public void FormatCell_MissingColumn_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            var row = table.NewRow();
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "missing_col" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位值為 DBNull 時應回傳空字串")]
+        public void FormatCell_DbNullValue_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = DBNull.Value;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "name" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 無時間部分時應格式化為 yyyy-MM-dd")]
+        public void FormatCell_DateTimeWithNoTime_ReturnsDateOnly()
+        {
+            var table = new DataTable();
+            table.Columns.Add("hire_date", typeof(DateTime));
+            var row = table.NewRow();
+            row["hire_date"] = new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "hire_date" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("2024-03-15", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 含時間部分時應格式化為 yyyy-MM-dd HH:mm:ss")]
+        public void FormatCell_DateTimeWithTime_ReturnsDateTimeFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("created_at", typeof(DateTime));
+            var row = table.NewRow();
+            row["created_at"] = new DateTime(2024, 3, 15, 14, 30, 45, DateTimeKind.Utc);
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "created_at" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("2024-03-15 14:30:45", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位為字串型別時應回傳原始字串值")]
+        public void FormatCell_StringValue_ReturnsRawString()
+        {
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = "Alice";
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "name" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("Alice", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 設定 DisplayFormat 時應優先使用 DisplayFormat 格式化值")]
+        public void FormatCell_WithDisplayFormat_UsesDisplayFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("amount", typeof(double));
+            var row = table.NewRow();
+            row["amount"] = 3.14;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "amount", DisplayFormat = "F2" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("3.14", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 設定 NumberFormat 時應使用 NumberFormat 格式化數值")]
+        public void FormatCell_WithNumberFormat_UsesNumberFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("price", typeof(double));
+            var row = table.NewRow();
+            row["price"] = 0.5;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "price", NumberFormat = "F1" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("0.5", result);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // BuildColumnStyle
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("BuildColumnStyle Width 為 0 時應回傳空字串")]
+        public void BuildColumnStyle_ZeroWidth_ReturnsEmpty()
+        {
+            var column = new LayoutColumn { Width = 0 };
+            var result = InvokeBuildColumnStyle(column);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("BuildColumnStyle Width 為正值時應回傳含寬度的 CSS 樣式字串")]
+        public void BuildColumnStyle_PositiveWidth_ReturnsWidthStyle()
+        {
+            var column = new LayoutColumn { Width = 120 };
+            var result = InvokeBuildColumnStyle(column);
+            Assert.Equal("width:120px", result);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // VisibleColumns (private computed property)
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("VisibleColumns Layout 為 null 時應回傳空序列")]
+        public void VisibleColumns_NullLayout_ReturnsEmpty()
+        {
+            var component = new DynamicGrid();
+            var prop = typeof(DynamicGrid).GetProperty(
+                "VisibleColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(prop);
+            var result = prop!.GetValue(component) as IEnumerable<LayoutColumn>;
+            Assert.NotNull(result);
+            Assert.Empty(result!);
+        }
+
+        [Fact]
+        [DisplayName("VisibleColumns 應只回傳 Visible 為 true 的欄位")]
+        public void VisibleColumns_MixedVisibility_ReturnsOnlyVisible()
+        {
+            var component = new DynamicGrid();
+            var layout = new LayoutGrid();
+            layout.Columns!.Add(new LayoutColumn { FieldName = "col_visible", Visible = true });
+            layout.Columns.Add(new LayoutColumn { FieldName = "col_hidden", Visible = false });
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            var prop = typeof(DynamicGrid).GetProperty(
+                "VisibleColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(prop);
+            var result = prop!.GetValue(component) as IEnumerable<LayoutColumn>;
+            Assert.NotNull(result);
+            var list = result!.ToList();
+            Assert.Single(list);
+            Assert.Equal("col_visible", list[0].FieldName);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // Component surface
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("DynamicGrid 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(DynamicGrid)));
+        }
+
+        [Fact]
+        [DisplayName("EmptyText 預設值為 'No data.'")]
+        public void EmptyText_Default_IsNoData()
+        {
+            var component = new DynamicGrid();
+            Assert.Equal("No data.", component.EmptyText);
+        }
+
+        [Theory]
+        [InlineData(nameof(DynamicGrid.Layout))]
+        [InlineData(nameof(DynamicGrid.Rows))]
+        [InlineData(nameof(DynamicGrid.OnRowSelected))]
+        [InlineData(nameof(DynamicGrid.EmptyText))]
+        [DisplayName("公開屬性皆標有 [Parameter]")]
+        public void PublicProperties_AreMarkedAsParameters(string name)
+        {
+            var property = typeof(DynamicGrid).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            Assert.NotNull(property!.GetCustomAttribute<ParameterAttribute>());
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageInternalTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageInternalTests.cs
@@ -1,0 +1,159 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Server.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> 私有方法的覆蓋率。
+    /// 測試範圍：<c>RunGuardedAsync</c> 的三種路徑（成功、拋例外、Busy Guard），
+    /// 以及四個 Action handler 在 <c>_dataObject</c> 為 null 時的提前返回行為。
+    /// 需要 Blazor 渲染器或 API connector 的 lifecycle 測試留待 bUnit 整合測試覆蓋。
+    /// </summary>
+    public class FormPageInternalTests
+    {
+        private static MethodInfo GetRunGuardedAsync()
+        {
+            var method = typeof(FormPage).GetMethod(
+                "RunGuardedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static FieldInfo GetErrorField()
+        {
+            var field = typeof(FormPage).GetField(
+                "_error", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return field!;
+        }
+
+        private static FieldInfo GetBusyField()
+        {
+            var field = typeof(FormPage).GetField(
+                "_isBusy", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return field!;
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // RunGuardedAsync
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("RunGuardedAsync 執行成功的 action 後 _isBusy 應恢復為 false")]
+        public async Task RunGuardedAsync_SuccessfulAction_ExecutesAndResetsBusy()
+        {
+            var page = new FormPage();
+            var method = GetRunGuardedAsync();
+            var busyField = GetBusyField();
+            bool executed = false;
+            Func<Task> action = () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            };
+            var task = (Task)method.Invoke(page, new object[] { action })!;
+            await task;
+            Assert.True(executed);
+            Assert.False((bool)busyField.GetValue(page)!);
+        }
+
+        [Fact]
+        [DisplayName("RunGuardedAsync 執行拋例外的 action 後 _error 應被設定，_isBusy 應恢復 false")]
+        public async Task RunGuardedAsync_ThrowingAction_SetsErrorAndResetsBusy()
+        {
+            var page = new FormPage();
+            var method = GetRunGuardedAsync();
+            var errorField = GetErrorField();
+            var busyField = GetBusyField();
+            Func<Task> action = () => throw new InvalidOperationException("test error");
+            var task = (Task)method.Invoke(page, new object[] { action })!;
+            await task;
+            Assert.Equal("test error", errorField.GetValue(page) as string);
+            Assert.False((bool)busyField.GetValue(page)!);
+        }
+
+        [Fact]
+        [DisplayName("RunGuardedAsync 在 _isBusy=true 時呼叫應跳過 action 不執行")]
+        public async Task RunGuardedAsync_WhenBusy_SkipsAction()
+        {
+            var page = new FormPage();
+            var method = GetRunGuardedAsync();
+            var busyField = GetBusyField();
+            busyField.SetValue(page, true);
+            bool executed = false;
+            Func<Task> action = () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            };
+            try
+            {
+                var task = (Task)method.Invoke(page, new object[] { action })!;
+                await task;
+                Assert.False(executed);
+            }
+            finally
+            {
+                busyField.SetValue(page, false);
+            }
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // Null _dataObject guard（私有 Action handler 提前返回）
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("OnRowSelectedAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnRowSelectedAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnRowSelectedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, new object[] { Guid.NewGuid() })!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnNewAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnNewAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnNewAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnSaveAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnSaveAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnSaveAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnDeleteAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnDeleteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
@@ -1,0 +1,312 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Wasm.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 結構與純邏輯測試，涵蓋 <see cref="DynamicGrid"/> 的靜態輔助方法
+    /// (<c>TryGetRowId</c>、<c>FormatCell</c>、<c>BuildColumnStyle</c>) 以及
+    /// 私有計算屬性 <c>VisibleColumns</c>。
+    /// 需要 Blazor 渲染器的 render cycle 測試留待 bUnit 整合測試覆蓋。
+    /// </summary>
+    public class DynamicGridTests
+    {
+        private static (bool Success, Guid RowId) InvokeTryGetRowId(DataRow row)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "TryGetRowId", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var args = new object?[] { row, Guid.Empty };
+            var success = (bool)method!.Invoke(null, args)!;
+            return (success, (Guid)args[1]!);
+        }
+
+        private static string InvokeFormatCell(DataRow row, LayoutColumn column)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "FormatCell", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null, new object[] { row, column })!;
+        }
+
+        private static string InvokeBuildColumnStyle(LayoutColumn column)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "BuildColumnStyle", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null, new object[] { column })!;
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // TryGetRowId
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("TryGetRowId 資料表無 sys_rowid 欄位時應回傳 false")]
+        public void TryGetRowId_NoRowIdColumn_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add("other_col", typeof(string));
+            var row = table.NewRow();
+            row["other_col"] = "value";
+            table.Rows.Add(row);
+            var (success, _) = InvokeTryGetRowId(row);
+            Assert.False(success);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 欄位值為 DBNull 時應回傳 false")]
+        public void TryGetRowId_DbNullValue_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(object));
+            var row = table.NewRow();
+            row[SysFields.RowId] = DBNull.Value;
+            table.Rows.Add(row);
+            var (success, _) = InvokeTryGetRowId(row);
+            Assert.False(success);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 欄位為 Guid 型別時應回傳 true 並輸出對應值")]
+        public void TryGetRowId_GuidValue_ReturnsTrueAndOutputsGuid()
+        {
+            var expected = Guid.NewGuid();
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected;
+            table.Rows.Add(row);
+            var (success, actual) = InvokeTryGetRowId(row);
+            Assert.True(success);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 為有效 Guid 字串時應回傳 true 並輸出對應值")]
+        public void TryGetRowId_ValidGuidString_ReturnsTrueAndOutputsGuid()
+        {
+            var expected = Guid.NewGuid();
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected.ToString();
+            table.Rows.Add(row);
+            var (success, actual) = InvokeTryGetRowId(row);
+            Assert.True(success);
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId sys_rowid 為無效 Guid 字串時應回傳 false")]
+        public void TryGetRowId_InvalidGuidString_ReturnsFalse()
+        {
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            var row = table.NewRow();
+            row[SysFields.RowId] = "not-a-guid";
+            table.Rows.Add(row);
+            var (success, rowId) = InvokeTryGetRowId(row);
+            Assert.False(success);
+            Assert.Equal(Guid.Empty, rowId);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // FormatCell
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("FormatCell 資料表無對應欄位時應回傳空字串")]
+        public void FormatCell_MissingColumn_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            var row = table.NewRow();
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "missing_col" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位值為 DBNull 時應回傳空字串")]
+        public void FormatCell_DbNullValue_ReturnsEmpty()
+        {
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = DBNull.Value;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "name" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 無時間部分時應格式化為 yyyy-MM-dd")]
+        public void FormatCell_DateTimeWithNoTime_ReturnsDateOnly()
+        {
+            var table = new DataTable();
+            table.Columns.Add("hire_date", typeof(DateTime));
+            var row = table.NewRow();
+            row["hire_date"] = new DateTime(2024, 3, 15, 0, 0, 0, DateTimeKind.Utc);
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "hire_date" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("2024-03-15", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell DateTime 含時間部分時應格式化為 yyyy-MM-dd HH:mm:ss")]
+        public void FormatCell_DateTimeWithTime_ReturnsDateTimeFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("created_at", typeof(DateTime));
+            var row = table.NewRow();
+            row["created_at"] = new DateTime(2024, 3, 15, 14, 30, 45, DateTimeKind.Utc);
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "created_at" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("2024-03-15 14:30:45", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位為字串型別時應回傳原始字串值")]
+        public void FormatCell_StringValue_ReturnsRawString()
+        {
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = "Alice";
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "name" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("Alice", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 設定 DisplayFormat 時應優先使用 DisplayFormat 格式化值")]
+        public void FormatCell_WithDisplayFormat_UsesDisplayFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("amount", typeof(double));
+            var row = table.NewRow();
+            row["amount"] = 3.14;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "amount", DisplayFormat = "F2" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("3.14", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 設定 NumberFormat 時應使用 NumberFormat 格式化數值")]
+        public void FormatCell_WithNumberFormat_UsesNumberFormat()
+        {
+            var table = new DataTable();
+            table.Columns.Add("price", typeof(double));
+            var row = table.NewRow();
+            row["price"] = 0.5;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "price", NumberFormat = "F1" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("0.5", result);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // BuildColumnStyle
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("BuildColumnStyle Width 為 0 時應回傳空字串")]
+        public void BuildColumnStyle_ZeroWidth_ReturnsEmpty()
+        {
+            var column = new LayoutColumn { Width = 0 };
+            var result = InvokeBuildColumnStyle(column);
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("BuildColumnStyle Width 為正值時應回傳含寬度的 CSS 樣式字串")]
+        public void BuildColumnStyle_PositiveWidth_ReturnsWidthStyle()
+        {
+            var column = new LayoutColumn { Width = 120 };
+            var result = InvokeBuildColumnStyle(column);
+            Assert.Equal("width:120px", result);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // VisibleColumns (private computed property)
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("VisibleColumns Layout 為 null 時應回傳空序列")]
+        public void VisibleColumns_NullLayout_ReturnsEmpty()
+        {
+            var component = new DynamicGrid();
+            var prop = typeof(DynamicGrid).GetProperty(
+                "VisibleColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(prop);
+            var result = prop!.GetValue(component) as IEnumerable<LayoutColumn>;
+            Assert.NotNull(result);
+            Assert.Empty(result!);
+        }
+
+        [Fact]
+        [DisplayName("VisibleColumns 應只回傳 Visible 為 true 的欄位")]
+        public void VisibleColumns_MixedVisibility_ReturnsOnlyVisible()
+        {
+            var component = new DynamicGrid();
+            var layout = new LayoutGrid();
+            layout.Columns!.Add(new LayoutColumn { FieldName = "col_visible", Visible = true });
+            layout.Columns.Add(new LayoutColumn { FieldName = "col_hidden", Visible = false });
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            var prop = typeof(DynamicGrid).GetProperty(
+                "VisibleColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(prop);
+            var result = prop!.GetValue(component) as IEnumerable<LayoutColumn>;
+            Assert.NotNull(result);
+            var list = result!.ToList();
+            Assert.Single(list);
+            Assert.Equal("col_visible", list[0].FieldName);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // Component surface
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("DynamicGrid 為 Blazor ComponentBase 子類別")]
+        public void Type_IsComponentBaseSubclass()
+        {
+            Assert.True(typeof(ComponentBase).IsAssignableFrom(typeof(DynamicGrid)));
+        }
+
+        [Fact]
+        [DisplayName("EmptyText 預設值為 'No data.'")]
+        public void EmptyText_Default_IsNoData()
+        {
+            var component = new DynamicGrid();
+            Assert.Equal("No data.", component.EmptyText);
+        }
+
+        [Theory]
+        [InlineData(nameof(DynamicGrid.Layout))]
+        [InlineData(nameof(DynamicGrid.Rows))]
+        [InlineData(nameof(DynamicGrid.OnRowSelected))]
+        [InlineData(nameof(DynamicGrid.EmptyText))]
+        [DisplayName("公開屬性皆標有 [Parameter]")]
+        public void PublicProperties_AreMarkedAsParameters(string name)
+        {
+            var property = typeof(DynamicGrid).GetProperty(
+                name, BindingFlags.Public | BindingFlags.Instance);
+            Assert.NotNull(property);
+            Assert.NotNull(property!.GetCustomAttribute<ParameterAttribute>());
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageInternalTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageInternalTests.cs
@@ -1,0 +1,159 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Wasm.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> 私有方法的覆蓋率。
+    /// 測試範圍：<c>RunGuardedAsync</c> 的三種路徑（成功、拋例外、Busy Guard），
+    /// 以及四個 Action handler 在 <c>_dataObject</c> 為 null 時的提前返回行為。
+    /// 需要 Blazor 渲染器或 API connector 的 lifecycle 測試留待 bUnit 整合測試覆蓋。
+    /// </summary>
+    public class FormPageInternalTests
+    {
+        private static MethodInfo GetRunGuardedAsync()
+        {
+            var method = typeof(FormPage).GetMethod(
+                "RunGuardedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        private static FieldInfo GetErrorField()
+        {
+            var field = typeof(FormPage).GetField(
+                "_error", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return field!;
+        }
+
+        private static FieldInfo GetBusyField()
+        {
+            var field = typeof(FormPage).GetField(
+                "_isBusy", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return field!;
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // RunGuardedAsync
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("RunGuardedAsync 執行成功的 action 後 _isBusy 應恢復為 false")]
+        public async Task RunGuardedAsync_SuccessfulAction_ExecutesAndResetsBusy()
+        {
+            var page = new FormPage();
+            var method = GetRunGuardedAsync();
+            var busyField = GetBusyField();
+            bool executed = false;
+            Func<Task> action = () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            };
+            var task = (Task)method.Invoke(page, new object[] { action })!;
+            await task;
+            Assert.True(executed);
+            Assert.False((bool)busyField.GetValue(page)!);
+        }
+
+        [Fact]
+        [DisplayName("RunGuardedAsync 執行拋例外的 action 後 _error 應被設定，_isBusy 應恢復 false")]
+        public async Task RunGuardedAsync_ThrowingAction_SetsErrorAndResetsBusy()
+        {
+            var page = new FormPage();
+            var method = GetRunGuardedAsync();
+            var errorField = GetErrorField();
+            var busyField = GetBusyField();
+            Func<Task> action = () => throw new InvalidOperationException("test error");
+            var task = (Task)method.Invoke(page, new object[] { action })!;
+            await task;
+            Assert.Equal("test error", errorField.GetValue(page) as string);
+            Assert.False((bool)busyField.GetValue(page)!);
+        }
+
+        [Fact]
+        [DisplayName("RunGuardedAsync 在 _isBusy=true 時呼叫應跳過 action 不執行")]
+        public async Task RunGuardedAsync_WhenBusy_SkipsAction()
+        {
+            var page = new FormPage();
+            var method = GetRunGuardedAsync();
+            var busyField = GetBusyField();
+            busyField.SetValue(page, true);
+            bool executed = false;
+            Func<Task> action = () =>
+            {
+                executed = true;
+                return Task.CompletedTask;
+            };
+            try
+            {
+                var task = (Task)method.Invoke(page, new object[] { action })!;
+                await task;
+                Assert.False(executed);
+            }
+            finally
+            {
+                busyField.SetValue(page, false);
+            }
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // Null _dataObject guard（私有 Action handler 提前返回）
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("OnRowSelectedAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnRowSelectedAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnRowSelectedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, new object[] { Guid.NewGuid() })!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnNewAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnNewAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnNewAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnSaveAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnSaveAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnSaveAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteAsync _dataObject 為 null 時應提前返回，不拋例外")]
+        public async Task OnDeleteAsync_NullDataObject_ReturnsWithoutError()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnDeleteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            var exception = await Record.ExceptionAsync(() => task);
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Core/ClientInfo.cs` | 30.9% | 7 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor.cs` | 5.4% | 7 |
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor.cs` | 5.4% | 7 |
| `src/Bee.Web.Blazor.Server/Components/DynamicGrid.razor.cs` | 0.0% | 19 |
| `src/Bee.Web.Blazor.Wasm/Components/DynamicGrid.razor.cs` | 0.0% | 19 |

### 測試策略

**ClientInfo**：非修改路徑（`GetEndpoint`、`SystemApiConnector`、`DefineAccess`、`CreateFormApiConnector`）加入 `ClientInfoReadOnlyTests`；`ApplyLoginResult` 有效輸入路徑加入 `[Collection("ClientInfoState")]` 的 `ClientInfoMutatingTests`，確保與 `EndpointStorageTests` 串行。

**FormPage（Server & Wasm）**：透過 reflection 測試 `RunGuardedAsync` 三條路徑（成功執行、拋例外捕捉、Busy Guard 提前返回），以及四個 Action handler（`OnRowSelectedAsync / OnNewAsync / OnSaveAsync / OnDeleteAsync`）在 `_dataObject` 為 null 時的提前返回行為。

**DynamicGrid（Server & Wasm）**：透過 reflection 測試私有靜態方法 `TryGetRowId`（5 案例）、`FormatCell`（7 案例）、`BuildColumnStyle`（2 案例），以及私有計算屬性 `VisibleColumns`（2 案例）和元件公開介面（3 案例），共 19 個測試。

### 無法處理

（無）—— 全部 5 個目標檔案皆已補測。

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXZbUYTzG1QMgMgFePKud3)_