### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-05-25 09:00

### DIFF
--- a/tests/Bee.Repository.UnitTests/DataFormRepositoryAdditionalTests.cs
+++ b/tests/Bee.Repository.UnitTests/DataFormRepositoryAdditionalTests.cs
@@ -1,0 +1,240 @@
+using System.ComponentModel;
+using System.Data;
+using System.Data.Common;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Db;
+using Bee.Db.Manager;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.Repository.Form;
+
+namespace Bee.Repository.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="DataFormRepository"/> 中尚未覆蓋的私有靜態方法
+    /// （<c>DefaultSortForPaging</c>、<c>ExtractMasterRowId</c>）
+    /// 以及 <see cref="DataFormRepository.GetNewData"/> 的 Detail 資料表與預設值路徑。
+    /// 不需資料庫連線。
+    /// </summary>
+    public class DataFormRepositoryAdditionalTests
+    {
+        #region Stubs
+
+        private sealed class StubDefineAccess : IDefineAccess
+        {
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class StubConnectionManager : IDbConnectionManager
+        {
+            public DbConnectionInfo GetConnectionInfo(string databaseId) => throw new NotImplementedException();
+            public DbConnection CreateConnection(string databaseId) => throw new NotImplementedException();
+            public bool Remove(string databaseId) => false;
+            public void Clear() { }
+            public bool Contains(string databaseId) => false;
+            public int Count => 0;
+        }
+
+        private static readonly Type[] s_formSchemaParam = [typeof(FormSchema)];
+        private static readonly Type[] s_extractMasterRowIdParams = [typeof(DataSet), typeof(string)];
+
+        private static DataFormRepository CreateRepository(FormSchema schema)
+        {
+            return new DataFormRepository(
+                schema.ProgId,
+                schema,
+                new StubDefineAccess(),
+                new StubDbAccessFactory(),
+                new StubConnectionManager(),
+                "testdb");
+        }
+
+        #endregion
+
+        #region DefaultSortForPaging（私有靜態方法）
+
+        [Fact]
+        [DisplayName("DefaultSortForPaging 傳入無 MasterTable 的 Schema 應拋 InvalidOperationException")]
+        public void DefaultSortForPaging_SchemaWithoutMasterTable_ThrowsInvalidOperationException()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "DefaultSortForPaging",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_formSchemaParam,
+                null);
+            Assert.NotNull(method);
+            var schema = new FormSchema("NoMaster", "NoMaster");
+            var ex = Record.Exception(() => method!.Invoke(null, new object[] { schema }));
+            var innerEx = Assert.IsType<TargetInvocationException>(ex).InnerException;
+            Assert.IsType<InvalidOperationException>(innerEx);
+        }
+
+        [Fact]
+        [DisplayName("DefaultSortForPaging MasterTable 不含 sys_no 欄位時應拋 InvalidOperationException")]
+        public void DefaultSortForPaging_MasterTableWithoutSysNoField_ThrowsInvalidOperationException()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "DefaultSortForPaging",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_formSchemaParam,
+                null);
+            Assert.NotNull(method);
+            var schema = new FormSchema("Employee", "Employee");
+            schema.Tables!.Add("Employee", "Employee");
+            var ex = Record.Exception(() => method!.Invoke(null, new object[] { schema }));
+            var innerEx = Assert.IsType<TargetInvocationException>(ex).InnerException;
+            Assert.IsType<InvalidOperationException>(innerEx);
+        }
+
+        [Fact]
+        [DisplayName("DefaultSortForPaging MasterTable 含 sys_no 欄位時應回傳 SortFieldCollection")]
+        public void DefaultSortForPaging_MasterTableWithSysNoField_ReturnsSortFieldCollection()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "DefaultSortForPaging",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_formSchemaParam,
+                null);
+            Assert.NotNull(method);
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add(SysFields.No, "No", FieldDbType.Integer);
+            var result = method!.Invoke(null, new object[] { schema });
+            Assert.NotNull(result);
+        }
+
+        #endregion
+
+        #region ExtractMasterRowId（私有靜態方法）
+
+        [Fact]
+        [DisplayName("ExtractMasterRowId DataSet 不含指定資料表時應回傳 null")]
+        public void ExtractMasterRowId_DataSetWithoutMasterTable_ReturnsNull()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "ExtractMasterRowId",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_extractMasterRowIdParams,
+                null);
+            Assert.NotNull(method);
+            var dataSet = new DataSet("Test");
+            var result = method!.Invoke(null, new object[] { dataSet, "Employee" });
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("ExtractMasterRowId 資料表含有效 sys_rowid 的列時應回傳對應 Guid")]
+        public void ExtractMasterRowId_MasterTableWithValidRowId_ReturnsGuid()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "ExtractMasterRowId",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_extractMasterRowIdParams,
+                null);
+            Assert.NotNull(method);
+            var dataSet = new DataSet("Test");
+            var table = dataSet.Tables.Add("Employee");
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var expectedId = Guid.NewGuid();
+            var row = table.NewRow();
+            row[SysFields.RowId] = expectedId;
+            table.Rows.Add(row);
+            var result = method!.Invoke(null, new object[] { dataSet, "Employee" });
+            Assert.Equal(expectedId, (Guid)result!);
+        }
+
+        [Fact]
+        [DisplayName("ExtractMasterRowId 資料表只含 Deleted 列時應回傳 null")]
+        public void ExtractMasterRowId_OnlyDeletedRows_ReturnsNull()
+        {
+            var method = typeof(DataFormRepository).GetMethod(
+                "ExtractMasterRowId",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_extractMasterRowIdParams,
+                null);
+            Assert.NotNull(method);
+            var dataSet = new DataSet("Test");
+            var table = dataSet.Tables.Add("Employee");
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = Guid.NewGuid();
+            table.Rows.Add(row);
+            table.AcceptChanges();
+            row.Delete();
+            var result = method!.Invoke(null, new object[] { dataSet, "Employee" });
+            Assert.Null(result);
+        }
+
+        #endregion
+
+        #region GetNewData（補強路徑）
+
+        [Fact]
+        [DisplayName("GetNewData Schema 含 Detail 資料表時 DataSet 應包含該 Detail 資料表")]
+        public void GetNewData_SchemaWithDetailTable_DataSetContainsDetailTable()
+        {
+            var schema = new FormSchema("Order", "Order");
+            var master = schema.Tables!.Add("Order", "Order");
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            var detail = schema.Tables.Add("OrderItem", "OrderItem");
+            detail.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            detail.Fields.Add(SysFields.MasterRowId, "Master Row Id", FieldDbType.Guid);
+
+            var repo = CreateRepository(schema);
+            var dataSet = repo.GetNewData();
+
+            Assert.True(dataSet.Tables.Contains("Order"));
+            Assert.True(dataSet.Tables.Contains("OrderItem"));
+        }
+
+        [Fact]
+        [DisplayName("GetNewData 欄位有字串預設值時 master 列應套用該預設值")]
+        public void GetNewData_FieldWithStringDefaultValue_AppliesDefault()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            var nameField = master.Fields.Add("emp_status", "Status", FieldDbType.String);
+            nameField.DefaultValue = "Active";
+
+            var repo = CreateRepository(schema);
+            var dataSet = repo.GetNewData();
+
+            var masterRow = dataSet.Tables["Employee"]!.Rows[0];
+            Assert.Equal("Active", masterRow["emp_status"]);
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoAdditionalTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoAdditionalTests.cs
@@ -5,8 +5,11 @@ namespace Bee.UI.Core.UnitTests
 {
     /// <summary>
     /// 補強 <see cref="ClientInfo"/> 中尚未被覆蓋的非修改路徑。
-    /// 測試僅呼叫不改變可觀測公開靜態狀態的方法，無需 collection 序列化保護。
+    /// <c>ClientInfoCoverageTests</c> 中的 <c>ClientInfoConnectorTests</c> 會透過反射將
+    /// <c>_systemConnector</c> 靜態欄位設為 null，與此處的快取驗證測試存在競態風險，
+    /// 因此須納入同一 collection 串行執行。
     /// </summary>
+    [Collection("ClientInfoState")]
     public class ClientInfoReadOnlyTests
     {
         [Fact]

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoCoverageTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoCoverageTests.cs
@@ -1,0 +1,149 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Client;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.ParseCommandLineArgs"/> 私有方法的測試覆蓋率。
+    /// 此類別為純讀取操作，無需加入 ClientInfoState collection。
+    /// </summary>
+    public class ClientInfoParseArgsTests
+    {
+        [Fact]
+        [DisplayName("ParseCommandLineArgs 透過反射呼叫應回傳非 null 的字典")]
+        public void ParseCommandLineArgs_InvokedViaReflection_ReturnsNonNull()
+        {
+            var method = typeof(ClientInfo).GetMethod(
+                "ParseCommandLineArgs",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var result = method!.Invoke(null, null);
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [DisplayName("ParseCommandLineArgs 回傳的字典應支援大小寫不分的鍵查詢（OrdinalIgnoreCase）")]
+        public void ParseCommandLineArgs_Result_SupportsCaseInsensitiveKeys()
+        {
+            var method = typeof(ClientInfo).GetMethod(
+                "ParseCommandLineArgs",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var result = (Dictionary<string, string>)method!.Invoke(null, null)!;
+            result["TestKey"] = "value";
+            Assert.True(result.ContainsKey("testkey"));
+            Assert.True(result.ContainsKey("TESTKEY"));
+        }
+    }
+
+    /// <summary>
+    /// 補強 <see cref="ClientInfo"/> <c>SetConnectType</c> 私有方法與遠端連線快取路徑的測試覆蓋率。
+    /// 因修改靜態狀態，與 EndpointStorageTests 同屬 ClientInfoState collection，確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoConnectorTests
+    {
+        private static readonly Type[] s_setConnectTypeParams = [typeof(ConnectType), typeof(string)];
+
+        private static MethodInfo GetSetConnectTypeMethod()
+        {
+            var method = typeof(ClientInfo).GetMethod(
+                "SetConnectType",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_setConnectTypeParams,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Fact]
+        [DisplayName("SetConnectType Local 應將 ApiClientInfo.ConnectType 設為 Local")]
+        public void SetConnectType_LocalEndpoint_SetsConnectTypeToLocal()
+        {
+            var method = GetSetConnectTypeMethod();
+            var originalType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            try
+            {
+                object[] args = [ConnectType.Local, string.Empty];
+                method.Invoke(null, args);
+                Assert.Equal(ConnectType.Local, ApiClientInfo.ConnectType);
+                Assert.Equal(string.Empty, ApiClientInfo.Endpoint);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+            }
+        }
+
+        [Fact]
+        [DisplayName("SetConnectType Remote 應將 ApiClientInfo.ConnectType 設為 Remote 並更新 Endpoint")]
+        public void SetConnectType_RemoteEndpoint_SetsConnectTypeAndEndpoint()
+        {
+            var method = GetSetConnectTypeMethod();
+            var originalType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            try
+            {
+                object[] args = [ConnectType.Remote, "http://remote.example.com"];
+                method.Invoke(null, args);
+                Assert.Equal(ConnectType.Remote, ApiClientInfo.ConnectType);
+                Assert.Equal("http://remote.example.com", ApiClientInfo.Endpoint);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+            }
+        }
+
+        [Fact]
+        [DisplayName("CreateFormApiConnector Remote 連線類型應回傳非 null 的 FormApiConnector")]
+        public void CreateFormApiConnector_RemoteConnectType_ReturnsNonNullConnector()
+        {
+            var originalType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            try
+            {
+                ApiClientInfo.ConnectType = ConnectType.Remote;
+                ApiClientInfo.Endpoint = "http://remote.example.com";
+                var connector = ClientInfo.CreateFormApiConnector("TestProg");
+                Assert.NotNull(connector);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+            }
+        }
+
+        [Fact]
+        [DisplayName("SystemApiConnector getter Remote 連線類型應建立並回傳非 null 的遠端 Connector")]
+        public void SystemApiConnector_RemoteConnectType_ReturnsNonNullConnector()
+        {
+            var originalType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            var sysConnField = typeof(ClientInfo).GetField(
+                "_systemConnector", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(sysConnField);
+            var originalConnector = sysConnField!.GetValue(null);
+            try
+            {
+                ApiClientInfo.ConnectType = ConnectType.Remote;
+                ApiClientInfo.Endpoint = "http://remote.example.com";
+                sysConnField.SetValue(null, null);
+                var connector = ClientInfo.SystemApiConnector;
+                Assert.NotNull(connector);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+                sysConnField.SetValue(null, originalConnector);
+            }
+        }
+    }
+}

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoCoverageTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoCoverageTests.cs
@@ -46,6 +46,7 @@ namespace Bee.UI.Core.UnitTests
     {
         private static readonly Type[] s_setConnectTypeParams = [typeof(ConnectType), typeof(string)];
         private static readonly object[] s_remoteConnectTypeArgs = [ConnectType.Remote, "http://remote.example.com"];
+        private static readonly object[] s_localConnectTypeArgs = [ConnectType.Local, string.Empty];
 
         private static MethodInfo GetSetConnectTypeMethod()
         {
@@ -68,8 +69,7 @@ namespace Bee.UI.Core.UnitTests
             var originalEndpoint = ApiClientInfo.Endpoint;
             try
             {
-                object[] args = [ConnectType.Local, string.Empty];
-                method.Invoke(null, args);
+                method.Invoke(null, s_localConnectTypeArgs);
                 Assert.Equal(ConnectType.Local, ApiClientInfo.ConnectType);
                 Assert.Equal(string.Empty, ApiClientInfo.Endpoint);
             }

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoCoverageTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoCoverageTests.cs
@@ -45,6 +45,7 @@ namespace Bee.UI.Core.UnitTests
     public class ClientInfoConnectorTests
     {
         private static readonly Type[] s_setConnectTypeParams = [typeof(ConnectType), typeof(string)];
+        private static readonly object[] s_remoteConnectTypeArgs = [ConnectType.Remote, "http://remote.example.com"];
 
         private static MethodInfo GetSetConnectTypeMethod()
         {
@@ -88,8 +89,7 @@ namespace Bee.UI.Core.UnitTests
             var originalEndpoint = ApiClientInfo.Endpoint;
             try
             {
-                object[] args = [ConnectType.Remote, "http://remote.example.com"];
-                method.Invoke(null, args);
+                method.Invoke(null, s_remoteConnectTypeArgs);
                 Assert.Equal(ConnectType.Remote, ApiClientInfo.ConnectType);
                 Assert.Equal("http://remote.example.com", ApiClientInfo.Endpoint);
             }

--- a/tests/Bee.UI.Maui.UnitTests/Controls/DynamicFormCoverageTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/DynamicFormCoverageTests.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.UI.Maui.Controls;
+using Bee.UI.Maui.DataObjects;
+
+namespace Bee.UI.Maui.UnitTests.Controls
+{
+    /// <summary>
+    /// 補強 <see cref="DynamicForm.BuildInputControl"/> 中尚未覆蓋的控制項類型：
+    /// <see cref="ControlType.YearMonthEdit"/> 與 <see cref="ControlType.DropDownEdit"/>。
+    /// </summary>
+    public class DynamicFormCoverageTests
+    {
+        private static readonly Type[] s_buildInputParams = [typeof(LayoutField), typeof(string)];
+
+        private static FormSchema BuildSchema()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_id", "ID", FieldDbType.String);
+            return schema;
+        }
+
+        private static MethodInfo GetBuildInputControlMethod()
+        {
+            var method = typeof(DynamicForm).GetMethod(
+                "BuildInputControl",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                s_buildInputParams,
+                null);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Fact]
+        [DisplayName("BuildInputControl YearMonthEdit 欄位應建立 DatePicker 且不拋例外")]
+        public void BuildInputControl_YearMonthEditField_DoesNotThrow()
+        {
+            var schema = BuildSchema();
+            var component = new DynamicForm();
+            component.DataObject = new FormDataObject(schema);
+
+            var method = GetBuildInputControlMethod();
+            var field = new LayoutField { FieldName = "hire_month", ControlType = ControlType.YearMonthEdit };
+            string rawValue = "2024-03";
+            var ex = Record.Exception(() => method.Invoke(component, new object[] { field, rawValue }));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildInputControl DropDownEdit 欄位應建立 Picker 且不拋例外")]
+        public void BuildInputControl_DropDownEditField_DoesNotThrow()
+        {
+            var schema = BuildSchema();
+            var component = new DynamicForm();
+            component.DataObject = new FormDataObject(schema);
+
+            var method = GetBuildInputControlMethod();
+            var field = new LayoutField { FieldName = "status", ControlType = ControlType.DropDownEdit };
+            string rawValue = string.Empty;
+            var ex = Record.Exception(() => method.Invoke(component, new object[] { field, rawValue }));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/tests/Bee.UI.Maui.UnitTests/Controls/FormPageClientInfoTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/FormPageClientInfoTests.cs
@@ -71,7 +71,8 @@ namespace Bee.UI.Maui.UnitTests.Controls
                 GetDefineHandler = (type, keys) =>
                 {
                     Assert.Equal(DefineType.FormSchema, type);
-                    Assert.Equal(new[] { TestProgId }, keys);
+                    string[] expectedKeys = [TestProgId];
+                    Assert.Equal(expectedKeys, keys);
                     return schema;
                 },
             };
@@ -236,7 +237,8 @@ namespace Bee.UI.Maui.UnitTests.Controls
 
             var system = (SystemApiConnector?)resolveSystem!.Invoke(page, Array.Empty<object>());
             Assert.NotNull(system);
-            var form = (FormApiConnector)resolveForm!.Invoke(page, new object[] { TestProgId })!;
+            object[] resolveFormArgs = [TestProgId];
+            var form = (FormApiConnector)resolveForm!.Invoke(page, resolveFormArgs)!;
             Assert.Equal(TestProgId, form.ProgId);
             var token = (Guid)resolveToken!.Invoke(page, Array.Empty<object>())!;
             Assert.Equal(ClientInfo.AccessToken, token);

--- a/tests/Bee.UI.Maui.UnitTests/Controls/FormPageClientInfoTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/FormPageClientInfoTests.cs
@@ -32,6 +32,8 @@ namespace Bee.UI.Maui.UnitTests.Controls
     public class FormPageClientInfoTests
     {
         private const string TestProgId = "Employee";
+        private static readonly string[] s_testProgIdKeys = [TestProgId];
+        private static readonly object[] s_testProgIdArgs = [TestProgId];
 
         private static FormSchema BuildEmployeeSchema()
         {
@@ -71,8 +73,7 @@ namespace Bee.UI.Maui.UnitTests.Controls
                 GetDefineHandler = (type, keys) =>
                 {
                     Assert.Equal(DefineType.FormSchema, type);
-                    string[] expectedKeys = [TestProgId];
-                    Assert.Equal(expectedKeys, keys);
+                    Assert.Equal(s_testProgIdKeys, keys);
                     return schema;
                 },
             };
@@ -237,8 +238,7 @@ namespace Bee.UI.Maui.UnitTests.Controls
 
             var system = (SystemApiConnector?)resolveSystem!.Invoke(page, Array.Empty<object>());
             Assert.NotNull(system);
-            object[] resolveFormArgs = [TestProgId];
-            var form = (FormApiConnector)resolveForm!.Invoke(page, resolveFormArgs)!;
+            var form = (FormApiConnector)resolveForm!.Invoke(page, s_testProgIdArgs)!;
             Assert.Equal(TestProgId, form.ProgId);
             var token = (Guid)resolveToken!.Invoke(page, Array.Empty<object>())!;
             Assert.Equal(ClientInfo.AccessToken, token);

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageCoverageTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageCoverageTests.cs
@@ -47,7 +47,9 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
         [DisplayName("OnInitializedAsync ProgId 為空白字串時應設定錯誤訊息")]
         public async Task OnInitializedAsync_WhitespaceProgId_SetsErrorMessage()
         {
+#pragma warning disable BL0005
             var page = new FormPage { ProgId = "   " };
+#pragma warning restore BL0005
             var method = typeof(FormPage).GetMethod(
                 "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(method);

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageCoverageTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageCoverageTests.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Server.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage.OnInitializedAsync"/> 早期返回路徑的測試覆蓋率。
+    /// ProgId 為空時在存取 Factory 之前即提前返回，不需要 Blazor 渲染器支援。
+    /// </summary>
+    public class FormPageCoverageTests
+    {
+        private static FieldInfo GetErrorField() =>
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FieldInfo GetIsInitializingField() =>
+            typeof(FormPage).GetField("_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        [Fact]
+        [DisplayName("OnInitializedAsync ProgId 為空字串時應設定錯誤訊息")]
+        public async Task OnInitializedAsync_EmptyProgId_SetsErrorMessage()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+            var error = GetErrorField().GetValue(page) as string;
+            Assert.Equal("FormPage.ProgId must be set.", error);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync ProgId 為空字串時應將 _isInitializing 設為 false")]
+        public async Task OnInitializedAsync_EmptyProgId_SetsIsInitializingFalse()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+            Assert.False((bool)GetIsInitializingField().GetValue(page)!);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync ProgId 為空白字串時應設定錯誤訊息")]
+        public async Task OnInitializedAsync_WhitespaceProgId_SetsErrorMessage()
+        {
+            var page = new FormPage { ProgId = "   " };
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+            var error = GetErrorField().GetValue(page) as string;
+            Assert.Equal("FormPage.ProgId must be set.", error);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageCoverageTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageCoverageTests.cs
@@ -47,7 +47,9 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
         [DisplayName("OnInitializedAsync ProgId 為空白字串時應設定錯誤訊息")]
         public async Task OnInitializedAsync_WhitespaceProgId_SetsErrorMessage()
         {
+#pragma warning disable BL0005
             var page = new FormPage { ProgId = "   " };
+#pragma warning restore BL0005
             var method = typeof(FormPage).GetMethod(
                 "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.NotNull(method);

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageCoverageTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageCoverageTests.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Wasm.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage.OnInitializedAsync"/> 早期返回路徑的測試覆蓋率。
+    /// ProgId 為空時在存取 Factory 之前即提前返回，不需要 Blazor 渲染器支援。
+    /// </summary>
+    public class FormPageCoverageTests
+    {
+        private static FieldInfo GetErrorField() =>
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FieldInfo GetIsInitializingField() =>
+            typeof(FormPage).GetField("_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        [Fact]
+        [DisplayName("OnInitializedAsync ProgId 為空字串時應設定錯誤訊息")]
+        public async Task OnInitializedAsync_EmptyProgId_SetsErrorMessage()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+            var error = GetErrorField().GetValue(page) as string;
+            Assert.Equal("FormPage.ProgId must be set.", error);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync ProgId 為空字串時應將 _isInitializing 設為 false")]
+        public async Task OnInitializedAsync_EmptyProgId_SetsIsInitializingFalse()
+        {
+            var page = new FormPage();
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+            Assert.False((bool)GetIsInitializingField().GetValue(page)!);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync ProgId 為空白字串時應設定錯誤訊息")]
+        public async Task OnInitializedAsync_WhitespaceProgId_SetsErrorMessage()
+        {
+            var page = new FormPage { ProgId = "   " };
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+            var error = GetErrorField().GetValue(page) as string;
+            Assert.Equal("FormPage.ProgId must be set.", error);
+        }
+    }
+}


### PR DESCRIPTION
## 覆蓋率補強摘要

本 PR 由自動化 Coverage Fix Agent 產生，針對 SonarCloud 偵測到行覆蓋率低於 90% 的檔案新增單元測試。

## 處理檔案（5 個）

| 模組 | 目標檔案 | 修前覆蓋率 | 未覆蓋行數 | 新增測試數 |
|------|---------|-----------|-----------|-----------|
| `Bee.UI.Core` | `ClientInfo.cs` | 49.4% | 41 行 | 6 個 |
| `Bee.Web.Blazor.Wasm` | `Components/FormPage.razor.cs` | 37.5% | 35 行 | 3 個 |
| `Bee.Web.Blazor.Server` | `Components/FormPage.razor.cs` | 37.5% | 35 行 | 3 個 |
| `Bee.UI.Maui` | `Controls/DynamicForm.cs` | 81.3% | 27 行 | 2 個 |
| `Bee.Repository` | `Form/DataFormRepository.cs` | 88.5% | 24 行 | 8 個 |

## 新增測試檔案

- `tests/Bee.UI.Core.UnitTests/ClientInfoCoverageTests.cs`
  - `ParseCommandLineArgs`：反射呼叫回傳非 null 字典、大小寫不分鍵查詢
  - `SetConnectType`：Local / Remote 兩種連線類型設定
  - `CreateFormApiConnector`：Remote 連線類型回傳非 null Connector
  - `SystemApiConnector` getter：Remote 連線類型建立遠端 Connector

- `tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageCoverageTests.cs`
  - `OnInitializedAsync` 空字串 ProgId → 設定錯誤訊息、`_isInitializing = false`
  - `OnInitializedAsync` 空白字串 ProgId → 設定錯誤訊息

- `tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageCoverageTests.cs`
  - 同上，對應 Server 版 `FormPage`

- `tests/Bee.UI.Maui.UnitTests/Controls/DynamicFormCoverageTests.cs`
  - `BuildInputControl`：`YearMonthEdit` / `DropDownEdit` 兩種控制項類型

- `tests/Bee.Repository.UnitTests/DataFormRepositoryAdditionalTests.cs`
  - `DefaultSortForPaging`：無 MasterTable / 無 sys_no 欄位 → 拋 `InvalidOperationException`；含 sys_no → 回傳 SortFieldCollection
  - `ExtractMasterRowId`：無資料表 / 僅 Deleted 列 → null；有效 Guid → 回傳 Guid
  - `GetNewData`：含 Detail 資料表 / 欄位有預設值

## 規範遵循

- [x] S2699：所有 `[Fact]` 均含 `Assert.*`（含 `Record.Exception` 驗證無例外）
- [x] CA1861：反射參數型別陣列改用 `static readonly` 欄位
- [x] IDE0005：無未使用 `using`
- [x] 全域狀態：`ClientInfoConnectorTests` 加入 `[Collection("ClientInfoState")]` 與 try/finally 還原
- [x] 僅修改 `tests/` 目錄，未觸及 `src/`、`samples/`、`docs/` 或 `.github/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyoUubufA3TcpCRtp9jUmZ)_