### PR TITLE
[AutoFix] Coverage Fix (4 files) 2026-05-25 16:38

### DIFF
--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeLoginPanelInternalTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeLoginPanelInternalTests.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Server.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="BeeLoginPanel.OnSubmitAsync"/> 兩條可在無 DI 環境下觸發的路徑：
+    /// 1. _isBusy guard（直接返回，不觸碰 Factory）
+    /// 2. Factory 未注入時的 try-catch-finally 路徑（NRE 被 catch 接住）
+    /// </summary>
+    public class BeeLoginPanelInternalTests
+    {
+        private static FieldInfo GetBusyField() =>
+            typeof(BeeLoginPanel).GetField("_isBusy", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FieldInfo GetErrorField() =>
+            typeof(BeeLoginPanel).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static async Task InvokeOnSubmitAsync(BeeLoginPanel panel)
+        {
+            var method = typeof(BeeLoginPanel).GetMethod(
+                "OnSubmitAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(panel, null)!;
+            await task;
+        }
+
+        [Fact]
+        [DisplayName("OnSubmitAsync _isBusy 為 true 時應直接返回，不呼叫 Factory 且不拋例外")]
+        public async Task OnSubmitAsync_WhenBusy_ReturnsImmediatelyWithoutError()
+        {
+            var panel = new BeeLoginPanel();
+            var busyField = GetBusyField();
+            busyField.SetValue(panel, true);
+            var exception = await Record.ExceptionAsync(() => InvokeOnSubmitAsync(panel));
+            Assert.Null(exception);
+            Assert.True((bool)busyField.GetValue(panel)!);
+        }
+
+        [Fact]
+        [DisplayName("OnSubmitAsync Factory 未注入時應進入 catch 設定錯誤訊息，且 _isBusy 恢復 false")]
+        public async Task OnSubmitAsync_NullFactory_CatchesExceptionAndResetsBusy()
+        {
+            var panel = new BeeLoginPanel();
+            await InvokeOnSubmitAsync(panel);
+            Assert.False((bool)GetBusyField().GetValue(panel)!);
+            Assert.NotNull(GetErrorField().GetValue(panel) as string);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPagePathCoverageTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPagePathCoverageTests.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Server.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage.OnInitializedAsync"/> 有效 ProgId 路徑的覆蓋率。
+    /// Factory 未注入（null）時，try 區塊內拋出 NullReferenceException，
+    /// 由 catch 接住並設定 _error，finally 重設 _isInitializing，
+    /// 無需 Blazor 渲染器即可完整覆蓋 try-catch-finally 三個分支。
+    /// </summary>
+    public class FormPagePathCoverageTests
+    {
+        private static FieldInfo GetErrorField() =>
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FieldInfo GetIsInitializingField() =>
+            typeof(FormPage).GetField("_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static async Task InvokeOnInitializedAsync(FormPage page)
+        {
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+        }
+
+        private static FormPage CreatePageWithProgId(string progId)
+        {
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId",
+                BindingFlags.Public | BindingFlags.Instance)!.SetValue(page, progId);
+            return page;
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 未注入時應進入 catch 並設定錯誤訊息")]
+        public async Task OnInitializedAsync_ValidProgIdNullFactory_CatchesExceptionAndSetsError()
+        {
+            var page = CreatePageWithProgId("TestProg");
+            await InvokeOnInitializedAsync(page);
+            var error = GetErrorField().GetValue(page) as string;
+            Assert.NotNull(error);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 未注入時 finally 應將 _isInitializing 設為 false")]
+        public async Task OnInitializedAsync_ValidProgIdNullFactory_FinallyResetsIsInitializing()
+        {
+            var page = CreatePageWithProgId("TestProg");
+            await InvokeOnInitializedAsync(page);
+            Assert.False((bool)GetIsInitializingField().GetValue(page)!);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeLoginPanelInternalTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeLoginPanelInternalTests.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Wasm.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="BeeLoginPanel.OnSubmitAsync"/> 兩條可在無 DI 環境下觸發的路徑：
+    /// 1. _isBusy guard（直接返回，不觸碰 Factory）
+    /// 2. Factory 未注入時的 try-catch-finally 路徑（NRE 被 catch 接住）
+    /// </summary>
+    public class BeeLoginPanelInternalTests
+    {
+        private static FieldInfo GetBusyField() =>
+            typeof(BeeLoginPanel).GetField("_isBusy", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FieldInfo GetErrorField() =>
+            typeof(BeeLoginPanel).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static async Task InvokeOnSubmitAsync(BeeLoginPanel panel)
+        {
+            var method = typeof(BeeLoginPanel).GetMethod(
+                "OnSubmitAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(panel, null)!;
+            await task;
+        }
+
+        [Fact]
+        [DisplayName("OnSubmitAsync _isBusy 為 true 時應直接返回，不呼叫 Factory 且不拋例外")]
+        public async Task OnSubmitAsync_WhenBusy_ReturnsImmediatelyWithoutError()
+        {
+            var panel = new BeeLoginPanel();
+            var busyField = GetBusyField();
+            busyField.SetValue(panel, true);
+            var exception = await Record.ExceptionAsync(() => InvokeOnSubmitAsync(panel));
+            Assert.Null(exception);
+            Assert.True((bool)busyField.GetValue(panel)!);
+        }
+
+        [Fact]
+        [DisplayName("OnSubmitAsync Factory 未注入時應進入 catch 設定錯誤訊息，且 _isBusy 恢復 false")]
+        public async Task OnSubmitAsync_NullFactory_CatchesExceptionAndResetsBusy()
+        {
+            var panel = new BeeLoginPanel();
+            await InvokeOnSubmitAsync(panel);
+            Assert.False((bool)GetBusyField().GetValue(panel)!);
+            Assert.NotNull(GetErrorField().GetValue(panel) as string);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPagePathCoverageTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPagePathCoverageTests.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Wasm.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage.OnInitializedAsync"/> 有效 ProgId 路徑的覆蓋率。
+    /// Factory 未注入（null）時，try 區塊內拋出 NullReferenceException，
+    /// 由 catch 接住並設定 _error，finally 重設 _isInitializing，
+    /// 無需 Blazor 渲染器即可完整覆蓋 try-catch-finally 三個分支。
+    /// </summary>
+    public class FormPagePathCoverageTests
+    {
+        private static FieldInfo GetErrorField() =>
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FieldInfo GetIsInitializingField() =>
+            typeof(FormPage).GetField("_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static async Task InvokeOnInitializedAsync(FormPage page)
+        {
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+        }
+
+        private static FormPage CreatePageWithProgId(string progId)
+        {
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId",
+                BindingFlags.Public | BindingFlags.Instance)!.SetValue(page, progId);
+            return page;
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 未注入時應進入 catch 並設定錯誤訊息")]
+        public async Task OnInitializedAsync_ValidProgIdNullFactory_CatchesExceptionAndSetsError()
+        {
+            var page = CreatePageWithProgId("TestProg");
+            await InvokeOnInitializedAsync(page);
+            var error = GetErrorField().GetValue(page) as string;
+            Assert.NotNull(error);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 未注入時 finally 應將 _isInitializing 設為 false")]
+        public async Task OnInitializedAsync_ValidProgIdNullFactory_FinallyResetsIsInitializing()
+        {
+            var page = CreatePageWithProgId("TestProg");
+            await InvokeOnInitializedAsync(page);
+            Assert.False((bool)GetIsInitializingField().GetValue(page)!);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor.cs` | 46.4% | 2 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor.cs` | 46.4% | 2 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 26.9% | 2 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 26.9% | 2 |

### 補強說明

**FormPage（Wasm / Server）**：補強 `OnInitializedAsync` 有效 ProgId 路徑。Factory 未注入時 try 區塊拋出 NullReferenceException，由 catch 接住並設定 `_error`，finally 重設 `_isInitializing`，無需 Blazor 渲染器即可覆蓋 try-catch-finally 全路徑。

**BeeLoginPanel（Wasm / Server）**：補強 `OnSubmitAsync` 兩條路徑：
- `_isBusy = true` guard 提前返回（不觸碰 Factory）
- Factory 未注入時的 try-catch-finally 全路徑（NRE 被 catch 接住，`_isBusy` 恢復 false）

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Core/ClientInfo.cs` | 剩餘未覆蓋行（`SetEndpoint`、`InitializeConnect`、`Initialize(IUIViewService, …)`）均需網路連線或 IUIViewService DI，無法在純單元測試環境安全執行。 |

https://claude.ai/code/session_0197o1iaU6EQMKEqjEvQezSh

---
_Generated by [Claude Code](https://claude.ai/code/session_0197o1iaU6EQMKEqjEvQezSh)_