### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-26 00:30

### DIFF
--- a/tests/Bee.UI.Core.UnitTests/ClientInfoInitializeTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoInitializeTests.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Client;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.Initialize(IUIViewService,SupportedConnectTypes)"/> 的覆蓋率。
+    /// 此方法在端點無效時會呼叫 <see cref="IUIViewService.ShowApiConnect"/>；
+    /// 以輕量 fake 取代真實 UI 服務，無需啟動後端即可覆蓋 try-catch 路徑。
+    /// 與其他修改靜態狀態的測試同屬 <c>ClientInfoState</c> collection，確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoInitializeTests
+    {
+        private sealed class FakeUIViewService : IUIViewService
+        {
+            private readonly bool _result;
+            public FakeUIViewService(bool result) { _result = result; }
+            public bool ShowApiConnect() => _result;
+        }
+
+        private static readonly PropertyInfo s_uiViewServiceProp =
+            typeof(ClientInfo).GetProperty("UIViewService",
+                BindingFlags.Public | BindingFlags.Static)!;
+
+        private static readonly PropertyInfo s_argumentsProp =
+            typeof(ClientInfo).GetProperty("Arguments",
+                BindingFlags.Public | BindingFlags.Static)!;
+
+        private static void RestoreState(
+            SupportedConnectTypes originalSupportedTypes,
+            IUIViewService? originalViewService,
+            Dictionary<string, string>? originalArgs)
+        {
+            ApiClientInfo.SupportedConnectTypes = originalSupportedTypes;
+            s_uiViewServiceProp.GetSetMethod(nonPublic: true)?.Invoke(null, new object?[] { originalViewService });
+            s_argumentsProp.GetSetMethod(nonPublic: true)?.Invoke(null, new object?[] { originalArgs });
+        }
+
+        [Fact]
+        [DisplayName("Initialize(IUIViewService) ShowApiConnect 回傳 false 時應回傳 false")]
+        public void Initialize_ShowApiConnectReturnsFalse_ReturnsFalse()
+        {
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            var originalViewService = ClientInfo.UIViewService;
+            var originalArgs = ClientInfo.Arguments;
+            try
+            {
+                var result = ClientInfo.Initialize(new FakeUIViewService(false), SupportedConnectTypes.Both);
+                Assert.False(result);
+            }
+            finally
+            {
+                RestoreState(originalSupportedTypes, originalViewService, originalArgs);
+            }
+        }
+
+        [Fact]
+        [DisplayName("Initialize(IUIViewService) ShowApiConnect 回傳 true 時應回傳 true")]
+        public void Initialize_ShowApiConnectReturnsTrue_ReturnsTrue()
+        {
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            var originalViewService = ClientInfo.UIViewService;
+            var originalArgs = ClientInfo.Arguments;
+            try
+            {
+                var result = ClientInfo.Initialize(new FakeUIViewService(true), SupportedConnectTypes.Both);
+                Assert.True(result);
+            }
+            finally
+            {
+                RestoreState(originalSupportedTypes, originalViewService, originalArgs);
+            }
+        }
+
+        [Fact]
+        [DisplayName("Initialize(IUIViewService) 呼叫後 UIViewService 應設為傳入的 service 實例")]
+        public void Initialize_SetsUIViewServiceToPassedInstance()
+        {
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            var originalViewService = ClientInfo.UIViewService;
+            var originalArgs = ClientInfo.Arguments;
+            try
+            {
+                var service = new FakeUIViewService(true);
+                ClientInfo.Initialize(service, SupportedConnectTypes.Both);
+                Assert.Same(service, ClientInfo.UIViewService);
+            }
+            finally
+            {
+                RestoreState(originalSupportedTypes, originalViewService, originalArgs);
+            }
+        }
+
+        [Fact]
+        [DisplayName("Initialize(IUIViewService) 呼叫後 Arguments 應為非 null 字典")]
+        public void Initialize_SetsArgumentsToNonNull()
+        {
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            var originalViewService = ClientInfo.UIViewService;
+            var originalArgs = ClientInfo.Arguments;
+            try
+            {
+                ClientInfo.Initialize(new FakeUIViewService(true), SupportedConnectTypes.Both);
+                Assert.NotNull(ClientInfo.Arguments);
+            }
+            finally
+            {
+                RestoreState(originalSupportedTypes, originalViewService, originalArgs);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.Initialize(string)"/> 的覆蓋率。
+    /// 空字串端點會在 <see cref="ApiConnectValidator.Validate"/> 前即失敗，
+    /// 不修改任何靜態狀態，無需加入序列化 collection。
+    /// </summary>
+    public class ClientInfoStringEndpointTests
+    {
+        [Fact]
+        [DisplayName("Initialize(string) 空字串端點應拋 ArgumentException")]
+        public void Initialize_EmptyStringEndpoint_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => ClientInfo.Initialize(string.Empty));
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageNonNullDataObjectTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageNonNullDataObjectTests.cs
@@ -1,0 +1,135 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Definition.Filters;
+using Bee.Definition.Forms;
+using Bee.Definition.Paging;
+using Bee.Definition.Sorting;
+using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DataObjects;
+using Bee.Web.Blazor.Server.DependencyInjection;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> 四個 Action handler 在 <c>_dataObject</c> 非 null 時
+    /// 的覆蓋率，以及 <c>ReloadListAsync</c> 的覆蓋率。
+    /// Action handler 以無 connector 的 <see cref="FormDataObject"/> 觸發例外，
+    /// 例外由 <c>RunGuardedAsync</c> 捕捉並設定 <c>_error</c>；
+    /// <c>ReloadListAsync</c> 由注入的 <see cref="FakeFactory"/> 驅動完整路徑。
+    /// </summary>
+    public class FormPageNonNullDataObjectTests
+    {
+        private sealed class FakeFormConnector : FormApiConnector
+        {
+            public FakeFormConnector() : base(Guid.Empty, "TestProg") { }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                FilterNode? filter = null,
+                SortFieldCollection? sortFields = null,
+                PagingOptions? paging = null)
+                => Task.FromResult(new GetListResponse { Table = new DataTable("Test") });
+        }
+
+        private sealed class FakeFactory : BeeApiConnectorFactory
+        {
+            public FakeFactory()
+                : base(new BeeBlazorOptions().UseLocalProvider()) { }
+
+            public override FormApiConnector CreateFormConnector(Guid accessToken, string progId)
+                => new FakeFormConnector();
+
+            public override SystemApiConnector CreateSystemConnector(Guid accessToken)
+                => throw new InvalidOperationException("SystemApiConnector not needed in this test.");
+        }
+
+        private static readonly FieldInfo s_dataObjectField =
+            typeof(FormPage).GetField("_dataObject", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_errorField =
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_listRowsField =
+            typeof(FormPage).GetField("_listRows", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FormDataObject CreateDataObjectWithoutConnector()
+        {
+            var schema = new FormSchema("Test", "Test");
+            return new FormDataObject(schema);
+        }
+
+        private static async Task InvokeMethodAsync(FormPage page, string methodName, object[]? args = null)
+        {
+            var method = typeof(FormPage).GetMethod(
+                methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, args)!;
+            await task;
+        }
+
+        private static FormPage CreatePageWithDataObject()
+        {
+            var page = new FormPage();
+            s_dataObjectField.SetValue(page, CreateDataObjectWithoutConnector());
+            return page;
+        }
+
+        [Fact]
+        [DisplayName("OnRowSelectedAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnRowSelectedAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnRowSelectedAsync", new object[] { Guid.NewGuid() });
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("OnNewAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnNewAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnNewAsync", null);
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("OnSaveAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnSaveAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnSaveAsync", null);
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnDeleteAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnDeleteAsync", null);
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("ReloadListAsync 使用 FakeFactory 應成功設定 _listRows 為非 null DataTable")]
+        public async Task ReloadListAsync_WithFakeFactory_SetsListRows()
+        {
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory());
+
+            var method = typeof(FormPage).GetMethod(
+                "ReloadListAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+
+            Assert.NotNull(s_listRowsField.GetValue(page) as DataTable);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageNonNullDataObjectTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageNonNullDataObjectTests.cs
@@ -1,0 +1,135 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Definition.Filters;
+using Bee.Definition.Forms;
+using Bee.Definition.Paging;
+using Bee.Definition.Sorting;
+using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DataObjects;
+using Bee.Web.Blazor.Wasm.DependencyInjection;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> 四個 Action handler 在 <c>_dataObject</c> 非 null 時
+    /// 的覆蓋率，以及 <c>ReloadListAsync</c> 的覆蓋率。
+    /// Action handler 以無 connector 的 <see cref="FormDataObject"/> 觸發例外，
+    /// 例外由 <c>RunGuardedAsync</c> 捕捉並設定 <c>_error</c>；
+    /// <c>ReloadListAsync</c> 由注入的 <see cref="FakeFactory"/> 驅動完整路徑。
+    /// </summary>
+    public class FormPageNonNullDataObjectTests
+    {
+        private sealed class FakeFormConnector : FormApiConnector
+        {
+            public FakeFormConnector() : base(Guid.Empty, "TestProg") { }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                FilterNode? filter = null,
+                SortFieldCollection? sortFields = null,
+                PagingOptions? paging = null)
+                => Task.FromResult(new GetListResponse { Table = new DataTable("Test") });
+        }
+
+        private sealed class FakeFactory : BeeApiConnectorFactory
+        {
+            public FakeFactory()
+                : base(new BeeBlazorOptions().UseRemoteProvider("http://test-endpoint")) { }
+
+            public override FormApiConnector CreateFormConnector(Guid accessToken, string progId)
+                => new FakeFormConnector();
+
+            public override SystemApiConnector CreateSystemConnector(Guid accessToken)
+                => throw new InvalidOperationException("SystemApiConnector not needed in this test.");
+        }
+
+        private static readonly FieldInfo s_dataObjectField =
+            typeof(FormPage).GetField("_dataObject", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_errorField =
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_listRowsField =
+            typeof(FormPage).GetField("_listRows", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static FormDataObject CreateDataObjectWithoutConnector()
+        {
+            var schema = new FormSchema("Test", "Test");
+            return new FormDataObject(schema);
+        }
+
+        private static async Task InvokeMethodAsync(FormPage page, string methodName, object[]? args = null)
+        {
+            var method = typeof(FormPage).GetMethod(
+                methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, args)!;
+            await task;
+        }
+
+        private static FormPage CreatePageWithDataObject()
+        {
+            var page = new FormPage();
+            s_dataObjectField.SetValue(page, CreateDataObjectWithoutConnector());
+            return page;
+        }
+
+        [Fact]
+        [DisplayName("OnRowSelectedAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnRowSelectedAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnRowSelectedAsync", new object[] { Guid.NewGuid() });
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("OnNewAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnNewAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnNewAsync", null);
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("OnSaveAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnSaveAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnSaveAsync", null);
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteAsync _dataObject 非 null 且無 connector 時應透過 RunGuardedAsync 捕捉例外並設定 _error")]
+        public async Task OnDeleteAsync_NonNullDataObjectNoConnector_SetsError()
+        {
+            var page = CreatePageWithDataObject();
+            await InvokeMethodAsync(page, "OnDeleteAsync", null);
+            Assert.NotNull(s_errorField.GetValue(page) as string);
+        }
+
+        [Fact]
+        [DisplayName("ReloadListAsync 使用 FakeFactory 應成功設定 _listRows 為非 null DataTable")]
+        public async Task ReloadListAsync_WithFakeFactory_SetsListRows()
+        {
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory());
+
+            var method = typeof(FormPage).GetMethod(
+                "ReloadListAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+
+            Assert.NotNull(s_listRowsField.GetValue(page) as DataTable);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Core/ClientInfo.cs` | 65.4% | 5 |
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor.cs` | 57.1% | 5 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor.cs` | 57.1% | 5 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | Razor 模板生成的渲染程式碼，需要 bUnit 才能覆蓋 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |

## 補強說明

### `ClientInfo.Initialize` 測試（`ClientInfoInitializeTests.cs`）
- 以輕量 `FakeUIViewService` 模擬 `ShowApiConnect` 回傳 true/false 兩種情境
- 覆蓋 `Initialize(IUIViewService, SupportedConnectTypes)` 的完整分支：`UIViewService` 設定、`Arguments` 設定、`InitializeConnect` try-catch 路徑
- 額外補 `Initialize(string)` 空字串拋 `ArgumentException` 的測試
- 全部加入 `[Collection("ClientInfoState")]` 確保靜態狀態串行安全

### `FormPage` 非 null `_dataObject` 路徑測試（Wasm / Server）
- 以 reflection 注入無 connector 的 `FormDataObject`，觸發 `RunGuardedAsync` 捕捉例外並設定 `_error`
- 覆蓋 `OnRowSelectedAsync` / `OnNewAsync` / `OnSaveAsync` / `OnDeleteAsync` 的非 null guard 路徑
- 以 `FakeFactory` + `FakeFormConnector`（override `GetListAsync` 返回空 DataTable）覆蓋 `ReloadListAsync` 完整執行路徑

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeE6czNHdZiSZmZjNx5hV1)_