### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-26 16:50

### DIFF
--- a/tests/Bee.UI.Core.UnitTests/ClientInfoLoadSettingsTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoLoadSettingsTests.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Client;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.System;
+using Bee.Base;
+using Bee.Base.Serialization;
+using Bee.Definition.Settings;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.LoadClientSettings"/> 檔案存在路徑的覆蓋率，
+    /// 以及 <c>AccessToken</c> setter 設定相同 Token 時不重設 connector 快取的行為。
+    /// 因修改靜態狀態，與其他 ClientInfoState 測試同屬 collection，確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoLoadSettingsTests
+    {
+        private static readonly FieldInfo s_clientSettingsField =
+            typeof(ClientInfo).GetField("_clientSettings", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly FieldInfo s_systemConnectorField =
+            typeof(ClientInfo).GetField("_systemConnector", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        [Fact]
+        [DisplayName("LoadClientSettings 設定檔存在時應成功反序列化並回傳非 null 的 ClientSettings")]
+        public void ClientSettings_FileExists_ReturnsDeserializedSettings()
+        {
+            string exeName = Assembly.GetEntryAssembly()?.GetName().Name ?? "Client";
+            string fileName = $"{exeName}.Settings.xml";
+            string filePath = Path.Combine(FileUtilities.GetAssemblyPath(), fileName);
+            var originalCached = s_clientSettingsField.GetValue(null);
+
+            XmlCodec.SerializeToFile(new ClientSettings(), filePath);
+            try
+            {
+                s_clientSettingsField.SetValue(null, null);
+                var result = ClientInfo.ClientSettings;
+                Assert.NotNull(result);
+            }
+            finally
+            {
+                s_clientSettingsField.SetValue(null, originalCached);
+                try { File.Delete(filePath); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        [DisplayName("AccessToken setter 設定相同 Token 時不應重設 _systemConnector 快取")]
+        public void AccessToken_SameTokenSetTwice_ConnectorCachePreserved()
+        {
+            var token = Guid.NewGuid();
+            var originalType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            var originalConnectorCached = s_systemConnectorField.GetValue(null);
+
+            try
+            {
+                ClientInfo.ApplyLoginResult(new LoginResponse
+                {
+                    AccessToken = token,
+                    UserId = "u1",
+                    UserName = "U1"
+                });
+
+                var connector = ClientInfo.SystemApiConnector;
+                Assert.NotNull(connector);
+
+                // 設定相同 Token，不應觸發 _systemConnector = null
+                ClientInfo.ApplyLoginResult(new LoginResponse
+                {
+                    AccessToken = token,
+                    UserId = "u1",
+                    UserName = "U1"
+                });
+
+                var connectorAfter = s_systemConnectorField.GetValue(null);
+                Assert.Same(connector, (SystemApiConnector?)connectorAfter);
+            }
+            finally
+            {
+                ClientInfo.ApplyLoginResult(new LoginResponse { AccessToken = Guid.Empty });
+                ApiClientInfo.ConnectType = originalType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+                s_systemConnectorField.SetValue(null, originalConnectorCached);
+            }
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageHappyPathTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageHappyPathTests.cs
@@ -1,0 +1,143 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Filters;
+using Bee.Definition.Forms;
+using Bee.Definition.Paging;
+using Bee.Definition.Sorting;
+using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DependencyInjection;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage.OnInitializedAsync"/> 有效 ProgId 且 Factory 正常運作時的覆蓋率。
+    /// 以 <see cref="FakeSystemConnector"/> 和 <see cref="FakeFormConnector"/> 模擬完整的
+    /// 初始化路徑，涵蓋 try 區塊內 schema 取得、layout 建立、DataObject 建立及 ReloadList 等行為。
+    /// </summary>
+    public class FormPageHappyPathTests
+    {
+        private sealed class FakeFormConnector : FormApiConnector
+        {
+            public FakeFormConnector() : base(Guid.Empty, "TestProg") { }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                FilterNode? filter = null,
+                SortFieldCollection? sortFields = null,
+                PagingOptions? paging = null)
+                => Task.FromResult(new GetListResponse { Table = new DataTable("FakeList") });
+        }
+
+        private sealed class FakeSystemConnector : SystemApiConnector
+        {
+            private readonly FormSchema _schema;
+
+            public FakeSystemConnector(FormSchema schema) : base(Guid.Empty)
+            {
+                _schema = schema;
+            }
+
+            public override Task<T> GetDefineAsync<T>(DefineType defineType, string[]? keys = null)
+            {
+                if (typeof(T) == typeof(FormSchema))
+                    return Task.FromResult((T)(object)_schema);
+
+                throw new NotSupportedException($"GetDefineAsync<{typeof(T).Name}> 未在 Fake 中支援。");
+            }
+        }
+
+        private sealed class FakeFactory : BeeApiConnectorFactory
+        {
+            private readonly FakeSystemConnector _systemConnector;
+
+            public FakeFactory(FormSchema schema)
+                : base(new BeeBlazorOptions().UseLocalProvider())
+            {
+                _systemConnector = new FakeSystemConnector(schema);
+            }
+
+            public override FormApiConnector CreateFormConnector(Guid accessToken, string progId)
+                => new FakeFormConnector();
+
+            public override SystemApiConnector CreateSystemConnector(Guid accessToken)
+                => _systemConnector;
+        }
+
+        private static FormSchema BuildSchema()
+        {
+            var schema = new FormSchema("TestProg", "TestProg");
+            var table = schema.Tables!.Add("TestProg", "TestProg");
+            table.Fields!.Add("id", "ID", FieldDbType.String);
+            table.Fields.Add("name", "名稱", FieldDbType.String);
+            return schema;
+        }
+
+        private static async Task InvokeOnInitializedAsync(FormPage page)
+        {
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 正常時應初始化完成不設定 _error")]
+        public async Task OnInitializedAsync_ValidProgIdAndWorkingFactory_CompletesWithoutError()
+        {
+            var schema = BuildSchema();
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory(schema));
+
+            await InvokeOnInitializedAsync(page);
+
+            var error = typeof(FormPage).GetField(
+                "_error", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(page) as string;
+            Assert.Null(error);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 正常時 _isInitializing 應設為 false")]
+        public async Task OnInitializedAsync_ValidProgIdAndWorkingFactory_SetsIsInitializingFalse()
+        {
+            var schema = BuildSchema();
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory(schema));
+
+            await InvokeOnInitializedAsync(page);
+
+            var isInitializing = (bool)typeof(FormPage).GetField(
+                "_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(page)!;
+            Assert.False(isInitializing);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 正常時 _dataObject 應設為非 null")]
+        public async Task OnInitializedAsync_ValidProgIdAndWorkingFactory_SetsDataObjectNonNull()
+        {
+            var schema = BuildSchema();
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory(schema));
+
+            await InvokeOnInitializedAsync(page);
+
+            var dataObject = typeof(FormPage).GetField(
+                "_dataObject", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(page);
+            Assert.NotNull(dataObject);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageHappyPathTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageHappyPathTests.cs
@@ -1,0 +1,143 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Filters;
+using Bee.Definition.Forms;
+using Bee.Definition.Paging;
+using Bee.Definition.Sorting;
+using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DependencyInjection;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage.OnInitializedAsync"/> 有效 ProgId 且 Factory 正常運作時的覆蓋率。
+    /// 以 <see cref="FakeSystemConnector"/> 和 <see cref="FakeFormConnector"/> 模擬完整的
+    /// 初始化路徑，涵蓋 try 區塊內 schema 取得、layout 建立、DataObject 建立及 ReloadList 等行為。
+    /// </summary>
+    public class FormPageHappyPathTests
+    {
+        private sealed class FakeFormConnector : FormApiConnector
+        {
+            public FakeFormConnector() : base(Guid.Empty, "TestProg") { }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                FilterNode? filter = null,
+                SortFieldCollection? sortFields = null,
+                PagingOptions? paging = null)
+                => Task.FromResult(new GetListResponse { Table = new DataTable("FakeList") });
+        }
+
+        private sealed class FakeSystemConnector : SystemApiConnector
+        {
+            private readonly FormSchema _schema;
+
+            public FakeSystemConnector(FormSchema schema) : base(Guid.Empty)
+            {
+                _schema = schema;
+            }
+
+            public override Task<T> GetDefineAsync<T>(DefineType defineType, string[]? keys = null)
+            {
+                if (typeof(T) == typeof(FormSchema))
+                    return Task.FromResult((T)(object)_schema);
+
+                throw new NotSupportedException($"GetDefineAsync<{typeof(T).Name}> 未在 Fake 中支援。");
+            }
+        }
+
+        private sealed class FakeFactory : BeeApiConnectorFactory
+        {
+            private readonly FakeSystemConnector _systemConnector;
+
+            public FakeFactory(FormSchema schema)
+                : base(new BeeBlazorOptions().UseRemoteProvider("http://fake-test-endpoint"))
+            {
+                _systemConnector = new FakeSystemConnector(schema);
+            }
+
+            public override FormApiConnector CreateFormConnector(Guid accessToken, string progId)
+                => new FakeFormConnector();
+
+            public override SystemApiConnector CreateSystemConnector(Guid accessToken)
+                => _systemConnector;
+        }
+
+        private static FormSchema BuildSchema()
+        {
+            var schema = new FormSchema("TestProg", "TestProg");
+            var table = schema.Tables!.Add("TestProg", "TestProg");
+            table.Fields!.Add("id", "ID", FieldDbType.String);
+            table.Fields.Add("name", "名稱", FieldDbType.String);
+            return schema;
+        }
+
+        private static async Task InvokeOnInitializedAsync(FormPage page)
+        {
+            var method = typeof(FormPage).GetMethod(
+                "OnInitializedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(page, null)!;
+            await task;
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 正常時應初始化完成不設定 _error")]
+        public async Task OnInitializedAsync_ValidProgIdAndWorkingFactory_CompletesWithoutError()
+        {
+            var schema = BuildSchema();
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory(schema));
+
+            await InvokeOnInitializedAsync(page);
+
+            var error = typeof(FormPage).GetField(
+                "_error", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(page) as string;
+            Assert.Null(error);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 正常時 _isInitializing 應設為 false")]
+        public async Task OnInitializedAsync_ValidProgIdAndWorkingFactory_SetsIsInitializingFalse()
+        {
+            var schema = BuildSchema();
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory(schema));
+
+            await InvokeOnInitializedAsync(page);
+
+            var isInitializing = (bool)typeof(FormPage).GetField(
+                "_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(page)!;
+            Assert.False(isInitializing);
+        }
+
+        [Fact]
+        [DisplayName("OnInitializedAsync 有效 ProgId 且 Factory 正常時 _dataObject 應設為非 null")]
+        public async Task OnInitializedAsync_ValidProgIdAndWorkingFactory_SetsDataObjectNonNull()
+        {
+            var schema = BuildSchema();
+            var page = new FormPage();
+            typeof(FormPage).GetProperty("ProgId", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(page, "TestProg");
+            typeof(FormPage).GetProperty("Factory", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(page, new FakeFactory(schema));
+
+            await InvokeOnInitializedAsync(page);
+
+            var dataObject = typeof(FormPage).GetField(
+                "_dataObject", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(page);
+            Assert.NotNull(dataObject);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Core/ClientInfo.cs` | 82.7% | 2 |
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor.cs` | 82.1% | 3 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor.cs` | 82.1% | 3 |

### 無法處理（需 bUnit 才能測試 Blazor 樣板渲染路徑）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | `.razor` 樣板的 `@if`/`@foreach` 渲染分支需要 bUnit 才能覆蓋，目前測試專案未引入 bUnit |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |

### 補強內容

**`ClientInfo.cs`（`Bee.UI.Core.UnitTests/ClientInfoLoadSettingsTests.cs`）**
- `LoadClientSettings_FileExists_ReturnsDeserializedSettings`：覆蓋設定檔存在時的反序列化路徑（lines 54-55）
- `AccessToken_SameTokenSetTwice_ConnectorCachePreserved`：覆蓋相同 Token 不重設 connector 快取的分支

**`FormPage.razor.cs`（Wasm & Server）**
- `OnInitializedAsync_ValidProgIdAndWorkingFactory_CompletesWithoutError`
- `OnInitializedAsync_ValidProgIdAndWorkingFactory_SetsIsInitializingFalse`
- `OnInitializedAsync_ValidProgIdAndWorkingFactory_SetsDataObjectNonNull`

以 `FakeSystemConnector`（覆寫 `GetDefineAsync<T>`）與 `FakeFormConnector`（覆寫 `GetListAsync`）
模擬完整 `OnInitializedAsync` 成功路徑，不需真實 API server。

---
_Generated by [Claude Code](https://claude.ai/code/session_01HowcLQMcF4TzSoT4mN52t6)_