### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-05-27 00:57

### DIFF
--- a/tests/Bee.UI.Core.UnitTests/ClientInfoLocalEndpointTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoLocalEndpointTests.cs
@@ -1,0 +1,99 @@
+using System.ComponentModel;
+using Bee.Api.Client;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo"/> 中以有效本機端點路徑觸發
+    /// <c>InitializeConnect</c> 與 <c>SetEndpoint</c> 深層路徑的測試覆蓋率。
+    /// <para>
+    /// 兩個方法在端點通過 <c>ApiConnectValidator.Validate</c> 驗證後才會呼叫
+    /// <c>SetConnectType</c> 與 <c>SyncExecutor.Run</c>；現有測試僅以空字串端點
+    /// 觸發驗證拋例外，因此那兩行至今未被執行。本測試以含 <c>SystemSettings.xml</c>
+    /// 的暫存目錄通過驗證，覆蓋該兩行（<c>SyncExecutor.Run</c> 在無本機 API 服務
+    /// 時仍會拋例外，但執行本身已完成；<c>return true;</c> 與 <c>SaveEndpoint</c>
+    /// 需要正常運行的 API 服務，保留為「無法在 CI 中覆蓋」）。
+    /// </para>
+    /// 因修改靜態狀態，與其他 ClientInfoState 測試同屬 collection，確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoLocalEndpointTests
+    {
+        private sealed class FakeEndpointStorage : IEndpointStorage
+        {
+            private readonly string _endpoint;
+            public FakeEndpointStorage(string endpoint) => _endpoint = endpoint;
+            public string LoadEndpoint() => _endpoint;
+            public void SetEndpoint(string endpoint) { }
+            public void SaveEndpoint(string endpoint) { }
+        }
+
+        private sealed class FakeUIViewService : IUIViewService
+        {
+            public bool ShowApiConnect() => false;
+        }
+
+        private static string CreateTempDefinePath()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"bee-ci-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            // ApiConnectValidator.ValidateLocal 僅檢查檔案是否存在，不驗證內容
+            File.WriteAllText(Path.Combine(tempDir, "SystemSettings.xml"), "<SystemSettings />");
+            return tempDir;
+        }
+
+        [Fact]
+        [DisplayName("Initialize(IUIViewService) 有效本機路徑通過驗證後應將 ConnectType 設為 Local")]
+        public void Initialize_ValidLocalPath_SetsConnectTypeToLocal()
+        {
+            var tempDir = CreateTempDefinePath();
+            var originalStorage = ClientInfo.EndpointStorage;
+            var originalConnectType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            try
+            {
+                ClientInfo.EndpointStorage = new FakeEndpointStorage(tempDir);
+                // InitializeConnect 會設定 SupportedConnectTypes = Both，Validate 通過後呼叫
+                // SetConnectType(Local, tempDir) 再呼叫 SyncExecutor.Run；
+                // 無本機 API 服務時 Run 拋例外，catch 捕捉並回傳 false。
+                ClientInfo.Initialize(new FakeUIViewService(), SupportedConnectTypes.Both);
+                Assert.Equal(ConnectType.Local, ApiClientInfo.ConnectType);
+            }
+            finally
+            {
+                ClientInfo.EndpointStorage = originalStorage;
+                ApiClientInfo.ConnectType = originalConnectType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+                ApiClientInfo.SupportedConnectTypes = originalSupportedTypes;
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        [DisplayName("SetEndpoint 有效本機路徑通過驗證後應將 ConnectType 設為 Local")]
+        public void SetEndpoint_ValidLocalPath_SetsConnectTypeToLocal()
+        {
+            var tempDir = CreateTempDefinePath();
+            var originalConnectType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            try
+            {
+                // SetEndpoint 自身不設定 SupportedConnectTypes，需在呼叫前確保 Local 受支援
+                ApiClientInfo.SupportedConnectTypes = SupportedConnectTypes.Both;
+                // Validate 通過後呼叫 SetConnectType(Local, tempDir)，再呼叫 SyncExecutor.Run；
+                // 無本機 API 服務時 Run 拋例外向上傳播，SaveEndpoint 不會被執行。
+                Record.Exception(() => ClientInfo.SetEndpoint(tempDir));
+                Assert.Equal(ConnectType.Local, ApiClientInfo.ConnectType);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalConnectType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+                ApiClientInfo.SupportedConnectTypes = originalSupportedTypes;
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Core/ClientInfo.cs` | 85.2% | 2 |

## 無法處理

以下 4 個檔案為本次前 5 名低覆蓋率清單，因結構性限制無法以純單元測試補強，列入此區段供人工評估：

| 檔案 | 未覆蓋行數 | 無法處理原因 |
|------|-----------|------------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | .razor markup 編譯產生的 `BuildRenderTree` 方法，需 bUnit 渲染環境才能覆蓋 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | 同上 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 9 | 未覆蓋路徑皆在 `OnSubmitAsync` 的 `LoginAsync` 回傳值處理；`LoginAsync` 非 `virtual`，無法在不啟動 API server 的情況下注入假回應 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 9 | 同上 |

## 補強說明

`ClientInfo.cs` 有兩條深層程式碼路徑（`InitializeConnect` 與 `SetEndpoint` 中的
`SetConnectType` 呼叫行與 `SyncExecutor.Run` 呼叫行），因現有測試只以空字串端點觸發
`ApiConnectValidator.Validate` 拋出例外，導致這兩行從未被執行。

新測試建立含 `SystemSettings.xml` 的暫存目錄，使 `Validate` 成功通過，讓執行流程
繼續進入 `SetConnectType` 與 `SyncExecutor.Run`，完成覆蓋。`SyncExecutor.Run` 在
無本機 API service 時仍會拋例外（由各自的 catch 或 caller 捕捉），但呼叫行本身
已被執行計入覆蓋；`return true;`（`InitializeConnect`）與 `SaveEndpoint`（`SetEndpoint`）
需要正常運行的 API service，保留為無法在 CI 中覆蓋。

https://claude.ai/code/session_01Qv4NKpQbmiLmjMgdPkJYVy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv4NKpQbmiLmjMgdPkJYVy)_