### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-27 08:30

### DIFF
--- a/tests/Bee.ObjectCaching.UnitTests/LanguageResourceCacheTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/LanguageResourceCacheTests.cs
@@ -1,0 +1,126 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Language;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.ObjectCaching.Define;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    public class LanguageResourceCacheTests
+    {
+        private sealed class StubDefineStorage : IDefineStorage
+        {
+            private readonly LanguageResource? _resource;
+
+            public StubDefineStorage(LanguageResource? resource = null) => _resource = resource;
+
+            public LanguageResource? GetLanguage(string lang, string ns) => _resource;
+            public void SaveLanguage(LanguageResource resource) => throw new NotImplementedException();
+            public DbCategorySettings? GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema? GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema? GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout? GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+        }
+
+        private static readonly PathOptions s_emptyPaths = new();
+
+        private sealed class TestableLanguageResourceCache : LanguageResourceCache
+        {
+            public TestableLanguageResourceCache(IDefineStorage storage, string cachePrefix = "")
+                : base(storage, s_emptyPaths, cachePrefix) { }
+
+            public CacheItemPolicy GetCachePolicy(string key) => GetPolicy(key);
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null storage 應拋出 ArgumentNullException")]
+        public void Constructor_NullStorage_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new LanguageResourceCache(null!, s_emptyPaths));
+        }
+
+        [Fact]
+        [DisplayName("建構子傳入 null paths 應拋出 ArgumentNullException")]
+        public void Constructor_NullPaths_ThrowsArgumentNullException()
+        {
+            var stub = new StubDefineStorage();
+            Assert.Throws<ArgumentNullException>(() => new LanguageResourceCache(stub, null!));
+        }
+
+        [Fact]
+        [DisplayName("GetPolicy 使用 FileDefineStorage 時應設定 ChangeMonitorFilePaths")]
+        public void GetPolicy_FileDefineStorage_SetsChangeMonitorFilePaths()
+        {
+            var storage = new FileDefineStorage(new PathOptions());
+            var cache = new TestableLanguageResourceCache(storage);
+
+            var policy = cache.GetCachePolicy("zh-TW.Common");
+
+            Assert.NotNull(policy.ChangeMonitorFilePaths);
+            Assert.Single(policy.ChangeMonitorFilePaths);
+        }
+
+        [Fact]
+        [DisplayName("GetPolicy 非 FileDefineStorage 時 ChangeMonitorFilePaths 應為 null")]
+        public void GetPolicy_NonFileDefineStorage_NoChangeMonitorFilePaths()
+        {
+            var stub = new StubDefineStorage();
+            var cache = new TestableLanguageResourceCache(stub);
+
+            var policy = cache.GetCachePolicy("zh-TW.Common");
+
+            Assert.Null(policy.ChangeMonitorFilePaths);
+        }
+
+        [Fact]
+        [DisplayName("Get 應呼叫 storage.GetLanguage 並回傳同一語言資源物件")]
+        public void Get_StorageReturnsResource_ReturnsSameResource()
+        {
+            string prefix = Guid.NewGuid().ToString("N");
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+            var stub = new StubDefineStorage(resource);
+            var cache = new LanguageResourceCache(stub, s_emptyPaths, prefix);
+
+            var result = cache.Get("zh-TW", "Common");
+
+            Assert.Same(resource, result);
+            cache.Remove("zh-TW", "Common");
+        }
+
+        [Fact]
+        [DisplayName("Get 當 storage.GetLanguage 回傳 null 時應回傳 null")]
+        public void Get_StorageReturnsNull_ReturnsNull()
+        {
+            string prefix = Guid.NewGuid().ToString("N");
+            var stub = new StubDefineStorage();
+            var cache = new LanguageResourceCache(stub, s_emptyPaths, prefix);
+
+            var result = cache.Get("en-US", "NonExistent");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("Remove 應清除語言資源快取且不拋例外")]
+        public void Remove_CachedEntry_DoesNotThrow()
+        {
+            string prefix = Guid.NewGuid().ToString("N");
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "System" };
+            var stub = new StubDefineStorage(resource);
+            var cache = new LanguageResourceCache(stub, s_emptyPaths, prefix);
+
+            cache.Get("zh-TW", "System");
+
+            var exception = Record.Exception(() => cache.Remove("zh-TW", "System"));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessSaveTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessSaveTests.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel;
+using Bee.Base.Serialization;
 using Bee.Definition;
 using Bee.Definition.Database;
 using Bee.Definition.Forms;
+using Bee.Definition.Language;
 using Bee.Definition.Layouts;
 using Bee.Definition.Settings;
 using Bee.Definition.Storage;
@@ -21,6 +23,8 @@ namespace Bee.ObjectCaching.UnitTests
     public class LocalDefineAccessSaveTests
     {
         private static readonly string[] DbViaDefineKeys = { "db_via_define" };
+        private static readonly string[] s_formLayoutKey = { "L_GetTest" };
+        private static readonly string[] s_languageKeys = { "zh-TW", "Common" };
 
         private static LocalDefineAccess CreateAccess(PathOptions paths)
             => new LocalDefineAccess(new FileDefineStorage(paths), paths);
@@ -197,6 +201,120 @@ namespace Bee.ObjectCaching.UnitTests
             var layout = new FormLayout { LayoutId = "L_via_define" };
             access.SaveDefine(DefineType.FormLayout, layout);
             Assert.True(File.Exists(temp.Options.GetFormLayoutFilePath("L_via_define")));
+        }
+
+        [Fact]
+        [DisplayName("SaveLanguage 應寫入以 Namespace 命名的 Language xml")]
+        public void SaveLanguage_WritesFile()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+
+            access.SaveLanguage(resource);
+
+            Assert.True(File.Exists(temp.Options.GetLanguageFilePath("zh-TW", "Common")));
+        }
+
+        [Fact]
+        [DisplayName("SaveLanguage 傳入 null 應拋 ArgumentNullException")]
+        public void SaveLanguage_NullResource_ThrowsArgumentNullException()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+
+            Assert.Throws<ArgumentNullException>(() => access.SaveLanguage(null!));
+        }
+
+        [Fact]
+        [DisplayName("SaveDefine(Language) 應委派至 SaveLanguage 寫入 Language xml")]
+        public void SaveDefine_Language_DelegatesToSaveLanguage()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            var resource = new LanguageResource { Lang = "en-US", Namespace = "Messages" };
+
+            access.SaveDefine(DefineType.Language, resource);
+
+            Assert.True(File.Exists(temp.Options.GetLanguageFilePath("en-US", "Messages")));
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(ProgramSettings) 應回傳 ProgramSettings 實例")]
+        public void GetDefine_ProgramSettings_ReturnsProgramSettings()
+        {
+            using var temp = TempDir.Create();
+            XmlCodec.SerializeToFile(new ProgramSettings(), temp.Options.GetProgramSettingsFilePath());
+            var access = CreateAccess(temp.Options);
+
+            var result = access.GetDefine(DefineType.ProgramSettings);
+
+            Assert.IsType<ProgramSettings>(result);
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(FormLayout) 帶正確 key 應回傳 FormLayout 實例")]
+        public void GetDefine_FormLayout_WithCorrectKey_ReturnsFormLayout()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            access.SaveFormLayout(new FormLayout { LayoutId = "L_GetTest" });
+
+            var result = access.GetDefine(DefineType.FormLayout, s_formLayoutKey);
+
+            Assert.IsType<FormLayout>(result);
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(Language) 帶兩個正確 keys 應回傳 LanguageResource 實例")]
+        public void GetDefine_Language_WithCorrectKeys_ReturnsLanguageResource()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            access.SaveLanguage(new LanguageResource { Lang = "zh-TW", Namespace = "Common" });
+
+            var result = access.GetDefine(DefineType.Language, s_languageKeys);
+
+            Assert.IsType<LanguageResource>(result);
+        }
+
+        [Fact]
+        [DisplayName("GetProgramSettings 於檔案存在時應回傳 ProgramSettings 實例")]
+        public void GetProgramSettings_FileExists_ReturnsInstance()
+        {
+            using var temp = TempDir.Create();
+            XmlCodec.SerializeToFile(new ProgramSettings(), temp.Options.GetProgramSettingsFilePath());
+            var access = CreateAccess(temp.Options);
+
+            var result = access.GetProgramSettings();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [DisplayName("GetFormLayout 於 FormLayout 檔案存在時應回傳 FormLayout 實例")]
+        public void GetFormLayout_FileExists_ReturnsFormLayout()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            access.SaveFormLayout(new FormLayout { LayoutId = "L_Exist" });
+
+            var result = access.GetFormLayout("L_Exist");
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [DisplayName("GetLanguage 於 Language 檔案存在時應回傳 LanguageResource 實例")]
+        public void GetLanguage_FileExists_ReturnsLanguageResource()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            access.SaveLanguage(new LanguageResource { Lang = "zh-TW", Namespace = "System" });
+
+            var result = access.GetLanguage("zh-TW", "System");
+
+            Assert.NotNull(result);
         }
 
         private sealed class TempDir : IDisposable


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.ObjectCaching/Define/LanguageResourceCache.cs` | 25.0% | 7 |
| `src/Bee.ObjectCaching/LocalDefineAccess.cs` | 84.1% | 9 |

## 測試說明

### LanguageResourceCache（新增 `LanguageResourceCacheTests.cs`，7 個測試）
- 建構子 null 驗證（storage / paths）
- `GetPolicy` 使用 `FileDefineStorage` 時應設定 `ChangeMonitorFilePaths`
- `GetPolicy` 使用非 `FileDefineStorage` 時 `ChangeMonitorFilePaths` 為 null
- `Get` 回傳 storage 提供的物件
- `Get` storage 回傳 null 時回傳 null
- `Remove` 清除快取不拋例外

### LocalDefineAccess（補充 `LocalDefineAccessSaveTests.cs`，9 個測試）
- `SaveLanguage` 寫入檔案
- `SaveLanguage` null 引數拋 `ArgumentNullException`
- `SaveDefine(Language)` 委派至 `SaveLanguage`
- `GetDefine(ProgramSettings)` switch case 路徑
- `GetDefine(FormLayout)` switch case 路徑
- `GetDefine(Language)` switch case 路徑
- `GetProgramSettings` 直接呼叫
- `GetFormLayout` 直接呼叫
- `GetLanguage` 直接呼叫

## 無法處理

| 檔案 | 未覆蓋行 | 原因 |
|------|---------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | 純 Razor markup template，需要 bUnit 框架才能測試，目前專案無 Blazor 測試基礎建設 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | 同上（與 Wasm 版本內容相同） |
| `src/Bee.UI.Core/ClientInfo.cs` | 12 | 未覆蓋行涵蓋：`ParseCommandLineArgs` 的 `key=value` 解析路徑（`Environment.GetCommandLineArgs()` 不可注入）、`SetEndpoint` 的 `EndpointStorage.SaveEndpoint`（需要執行中的 API 服務）、`InitializeConnect` 的 `return true`（需要執行中的 API 服務）|

---
_Generated by [Claude Code](https://claude.ai/code/session_01H6QtestQhWTHsVbqY1wjDa)_