### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-05-28 00:30

### DIFF
--- a/tests/Bee.UI.Core.UnitTests/ClientInfoDefineAccessTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoDefineAccessTests.cs
@@ -1,0 +1,73 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Core.Messages.System;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.DefineAccess"/> getter 的覆蓋率：
+    /// 驗證快取行為（兩次存取回傳同一實例）以及
+    /// 當 AccessToken 變更時快取被清除（兩次存取回傳不同實例）。
+    /// 因修改靜態狀態，納入 <c>ClientInfoState</c> collection 確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoDefineAccessTests
+    {
+        private static readonly FieldInfo s_defineAccessField =
+            typeof(ClientInfo).GetField("_defineAccess", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly FieldInfo s_systemConnectorField =
+            typeof(ClientInfo).GetField("_systemConnector", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        [Fact]
+        [DisplayName("DefineAccess getter 多次存取應回傳同一快取實例")]
+        public void DefineAccess_AccessedTwice_ReturnsSameInstance()
+        {
+            var originalDefineAccess = s_defineAccessField.GetValue(null);
+            var originalSystemConnector = s_systemConnectorField.GetValue(null);
+            try
+            {
+                s_defineAccessField.SetValue(null, null);
+                s_systemConnectorField.SetValue(null, null);
+                var first = ClientInfo.DefineAccess;
+                var second = ClientInfo.DefineAccess;
+                Assert.Same(first, second);
+            }
+            finally
+            {
+                s_defineAccessField.SetValue(null, originalDefineAccess);
+                s_systemConnectorField.SetValue(null, originalSystemConnector);
+            }
+        }
+
+        [Fact]
+        [DisplayName("AccessToken 變更後 DefineAccess getter 應回傳新實例（快取已清除）")]
+        public void DefineAccess_AfterTokenChange_ReturnsNewInstance()
+        {
+            var originalDefineAccess = s_defineAccessField.GetValue(null);
+            var originalSystemConnector = s_systemConnectorField.GetValue(null);
+            try
+            {
+                s_defineAccessField.SetValue(null, null);
+                s_systemConnectorField.SetValue(null, null);
+                var firstAccess = ClientInfo.DefineAccess;
+
+                ClientInfo.ApplyLoginResult(new LoginResponse
+                {
+                    AccessToken = Guid.NewGuid(),
+                    UserId = "u_test",
+                    UserName = "Test"
+                });
+
+                var secondAccess = ClientInfo.DefineAccess;
+                Assert.NotSame(firstAccess, secondAccess);
+            }
+            finally
+            {
+                ClientInfo.ApplyLoginResult(new LoginResponse { AccessToken = Guid.Empty });
+                s_defineAccessField.SetValue(null, originalDefineAccess);
+                s_systemConnectorField.SetValue(null, originalSystemConnector);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Core/ClientInfo.cs` | 85.2% | 2 |

### 新增測試說明

**`tests/Bee.UI.Core.UnitTests/ClientInfoDefineAccessTests.cs`**

補強 `ClientInfo.DefineAccess` getter 兩條未覆蓋路徑：
- `DefineAccess_AccessedTwice_ReturnsSameInstance`：驗證 `??=` 快取語意，多次存取回傳同一實例
- `DefineAccess_AfterTokenChange_ReturnsNewInstance`：驗證 AccessToken 變更時 `_defineAccess = null` 被執行，後續存取回傳新實例

---

## 無法處理（4 筆）

| 檔案 | 未覆蓋行數 | 原因 |
|------|----------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | Blazor Razor 標記（markup）不含可 unit test 的 C# 邏輯 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | 同上 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 9 | 未覆蓋路徑（empty-token / success path）依賴 `SystemApiConnector.LoginAsync` 實際回傳結果；該方法非 virtual，無 mocking 框架下無法攔截 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 9 | 同上 |

https://claude.ai/code/session_01HZcsphQof22Seg6xvmPY58

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZcsphQof22Seg6xvmPY58)_