### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-28 08:30

### DIFF
--- a/tests/Bee.Definition.UnitTests/Language/LanguageServiceEdgeCaseTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/LanguageServiceEdgeCaseTests.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Language;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Definition.UnitTests.Language
+{
+    /// <summary>
+    /// 補強 <see cref="LanguageService"/> 邊界路徑：
+    /// <c>SplitFullKey</c> 無 '.' 分支，以及 <see cref="LanguageService.GetLangEnum(string,string,string)"/>
+    /// 的空白 namespace / enumName 守衛（line 89）。
+    /// </summary>
+    public class LanguageServiceEdgeCaseTests
+    {
+        [Fact]
+        [DisplayName("GetLangText fullKey 無 '.' 時應以整個 key 作 namespace，subKey 為空字串，最終回傳 'key.'")]
+        public void GetLangText_KeyWithoutDot_ReturnsKeyWithTrailingDot()
+        {
+            var defineAccess = new MinimalDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+            Assert.Equal("NoDot.", svc.GetLangText("zh-TW", "NoDot"));
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum fullName 無 '.' 時 enumName 為空字串，應回傳 null")]
+        public void GetLangEnum_FullNameWithoutDot_ReturnsNull()
+        {
+            var defineAccess = new MinimalDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+            Assert.Null(svc.GetLangEnum("zh-TW", "GenderEnum"));
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum namespace 為空字串時應立即回傳 null")]
+        public void GetLangEnum_BlankNamespace_ReturnsNull()
+        {
+            var defineAccess = new MinimalDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+            Assert.Null(svc.GetLangEnum("zh-TW", "", "Gender"));
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum enumName 為空字串時應立即回傳 null")]
+        public void GetLangEnum_BlankEnumName_ReturnsNull()
+        {
+            var defineAccess = new MinimalDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+            Assert.Null(svc.GetLangEnum("zh-TW", "Common", ""));
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // Minimal stub — implements only GetLanguage and GetSystemSettings;
+        // all other members throw NotImplementedException because these
+        // tests never invoke the corresponding code paths.
+        // ──────────────────────────────────────────────────────────────
+        private sealed class MinimalDefineAccess : IDefineAccess
+        {
+            private readonly SystemSettings _settings;
+
+            public MinimalDefineAccess(string defaultLang)
+            {
+                _settings = new SystemSettings();
+                _settings.CommonConfiguration.DefaultLang = defaultLang;
+            }
+
+            public LanguageResource GetLanguage(string lang, string ns) => null!;
+            public SystemSettings GetSystemSettings() => _settings;
+
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+            public void SaveLanguage(LanguageResource resource) => throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridOnRowClickTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridOnRowClickTests.cs
@@ -1,0 +1,103 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Server.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="DynamicGrid.OnRowClickAsync"/> 私有方法的三條路徑：
+    /// 無委派直接返回、委派已設但無 RowId、委派已設且成功觸發；
+    /// 額外補強 <c>FormatCell</c> 的 <c>_ =&gt;</c> fallback 分支（非 IFormattable 值）。
+    /// </summary>
+    public class DynamicGridOnRowClickTests
+    {
+        private static async Task InvokeOnRowClickAsync(DynamicGrid component, DataRow row)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(component, new object[] { row })!;
+            await task;
+        }
+
+        private static string InvokeFormatCell(DataRow row, LayoutColumn column)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "FormatCell", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null, new object[] { row, column })!;
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync OnRowSelected 未設定委派時應直接返回，不拋例外")]
+        public async Task OnRowClickAsync_NoDelegate_DoesNotThrow()
+        {
+            var component = new DynamicGrid();
+            var table = new DataTable();
+            table.Columns.Add("col", typeof(string));
+            var row = table.NewRow();
+            table.Rows.Add(row);
+            var exception = await Record.ExceptionAsync(() => InvokeOnRowClickAsync(component, row));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync 委派已設定但資料列無 sys_rowid 欄位時，不應觸發委派")]
+        public async Task OnRowClickAsync_DelegateSet_RowWithoutRowId_DoesNotInvokeCallback()
+        {
+            var component = new DynamicGrid();
+            var invoked = false;
+            Action<Guid> handler = _ => { invoked = true; };
+            var callback = new EventCallback<Guid>(null, handler);
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, callback);
+            var table = new DataTable();
+            table.Columns.Add("other", typeof(string));
+            var row = table.NewRow();
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.False(invoked);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync 委派已設定且資料列含有效 sys_rowid 時，應觸發委派並傳入正確 Guid")]
+        public async Task OnRowClickAsync_DelegateSet_ValidRowId_InvokesCallbackWithExpectedGuid()
+        {
+            var expected = Guid.NewGuid();
+            var component = new DynamicGrid();
+            var receivedId = Guid.Empty;
+            Action<Guid> handler = id => { receivedId = id; };
+            var callback = new EventCallback<Guid>(null, handler);
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, callback);
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected;
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.Equal(expected, receivedId);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位值為非 IFormattable 型別時應回傳 ToString() 結果")]
+        public void FormatCell_NonFormattableValue_ReturnsToStringResult()
+        {
+            var table = new DataTable();
+            table.Columns.Add("data", typeof(object));
+            var bytes = new byte[] { 1, 2, 3 };
+            var row = table.NewRow();
+            row["data"] = bytes;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "data" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal(bytes.ToString()!, result);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridOnRowClickTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridOnRowClickTests.cs
@@ -1,0 +1,103 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Wasm.Components;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="DynamicGrid.OnRowClickAsync"/> 私有方法的三條路徑：
+    /// 無委派直接返回、委派已設但無 RowId、委派已設且成功觸發；
+    /// 額外補強 <c>FormatCell</c> 的 <c>_ =&gt;</c> fallback 分支（非 IFormattable 值）。
+    /// </summary>
+    public class DynamicGridOnRowClickTests
+    {
+        private static async Task InvokeOnRowClickAsync(DynamicGrid component, DataRow row)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task)method!.Invoke(component, new object[] { row })!;
+            await task;
+        }
+
+        private static string InvokeFormatCell(DataRow row, LayoutColumn column)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "FormatCell", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null, new object[] { row, column })!;
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync OnRowSelected 未設定委派時應直接返回，不拋例外")]
+        public async Task OnRowClickAsync_NoDelegate_DoesNotThrow()
+        {
+            var component = new DynamicGrid();
+            var table = new DataTable();
+            table.Columns.Add("col", typeof(string));
+            var row = table.NewRow();
+            table.Rows.Add(row);
+            var exception = await Record.ExceptionAsync(() => InvokeOnRowClickAsync(component, row));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync 委派已設定但資料列無 sys_rowid 欄位時，不應觸發委派")]
+        public async Task OnRowClickAsync_DelegateSet_RowWithoutRowId_DoesNotInvokeCallback()
+        {
+            var component = new DynamicGrid();
+            var invoked = false;
+            Action<Guid> handler = _ => { invoked = true; };
+            var callback = new EventCallback<Guid>(null, handler);
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, callback);
+            var table = new DataTable();
+            table.Columns.Add("other", typeof(string));
+            var row = table.NewRow();
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.False(invoked);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync 委派已設定且資料列含有效 sys_rowid 時，應觸發委派並傳入正確 Guid")]
+        public async Task OnRowClickAsync_DelegateSet_ValidRowId_InvokesCallbackWithExpectedGuid()
+        {
+            var expected = Guid.NewGuid();
+            var component = new DynamicGrid();
+            var receivedId = Guid.Empty;
+            Action<Guid> handler = id => { receivedId = id; };
+            var callback = new EventCallback<Guid>(null, handler);
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, callback);
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expected;
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.Equal(expected, receivedId);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell 欄位值為非 IFormattable 型別時應回傳 ToString() 結果")]
+        public void FormatCell_NonFormattableValue_ReturnsToStringResult()
+        {
+            var table = new DataTable();
+            table.Columns.Add("data", typeof(object));
+            var bytes = new byte[] { 1, 2, 3 };
+            var row = table.NewRow();
+            row["data"] = bytes;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "data" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal(bytes.ToString()!, result);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicGrid.razor.cs` | 78.8% | 4 |
| `src/Bee.Web.Blazor.Server/Components/DynamicGrid.razor.cs` | 78.8% | 4 |
| `src/Bee.Definition/Language/LanguageService.cs` | 89.6% | 4 |

### 補強內容

**DynamicGrid（Wasm & Server）**
- `OnRowClickAsync_NoDelegate_DoesNotThrow`：無委派直接返回路徑
- `OnRowClickAsync_DelegateSet_RowWithoutRowId_DoesNotInvokeCallback`：委派已設但無 sys_rowid 路徑
- `OnRowClickAsync_DelegateSet_ValidRowId_InvokesCallbackWithExpectedGuid`：委派觸發路徑
- `FormatCell_NonFormattableValue_ReturnsToStringResult`：`_ =>` fallback 分支（非 IFormattable 值）

**LanguageService**
- `GetLangText_KeyWithoutDot_ReturnsKeyWithTrailingDot`：`SplitFullKey` 無 '.' 路徑
- `GetLangEnum_FullNameWithoutDot_ReturnsNull`：fullName 無 '.' 導致 enumName 空白 → null
- `GetLangEnum_BlankNamespace_ReturnsNull`：空白 namespace 守衛
- `GetLangEnum_BlankEnumName_ReturnsNull`：空白 enumName 守衛

### 無法處理（3 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Core/ClientInfo.cs` | 靜態類別深度耦合外部端點（`SetEndpoint`、`Initialize`、`InitializeConnect` 需真實網路連線），既有測試已達 827+ 行，剩餘 12 行須架構層調整才能覆蓋 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | `OnSubmitAsync` 剩餘路徑需 mock `BeeApiConnectorFactory`（具體類別，無虛方法），以及 `SystemApiConnector.LoginAsync` 的真實網路回應 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ch7FWfmDcHVicEBAHVQzug)_