### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-28 16:30

### DIFF
--- a/tests/Bee.UI.Core.UnitTests/ClientInfoLoadSettingsTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoLoadSettingsTests.cs
@@ -47,6 +47,31 @@ namespace Bee.UI.Core.UnitTests
         }
 
         [Fact]
+        [DisplayName("LoadClientSettings 設定檔為空檔案時（反序列化回傳 null）應拋 InvalidOperationException")]
+        public void ClientSettings_EmptyFile_ThrowsInvalidOperationException()
+        {
+            string exeName = Assembly.GetEntryAssembly()?.GetName().Name ?? "Client";
+            string fileName = $"{exeName}.Settings.xml";
+            string filePath = Path.Combine(FileUtilities.GetAssemblyPath(), fileName);
+            var originalCached = s_clientSettingsField.GetValue(null);
+
+            // 空白檔案內容 → XmlCodec.Deserialize<T>("") 回傳 null → ?? throw InvalidOperationException
+            File.WriteAllText(filePath, string.Empty);
+            try
+            {
+                s_clientSettingsField.SetValue(null, null);
+                var exception = Record.Exception(() => _ = ClientInfo.ClientSettings);
+                Assert.NotNull(exception);
+                Assert.IsType<InvalidOperationException>(exception);
+            }
+            finally
+            {
+                s_clientSettingsField.SetValue(null, originalCached);
+                try { File.Delete(filePath); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
         [DisplayName("AccessToken setter 設定相同 Token 時不應重設 _systemConnector 快取")]
         public void AccessToken_SameTokenSetTwice_ConnectorCachePreserved()
         {

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormHelperTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormHelperTests.cs
@@ -1,8 +1,11 @@
 using System.ComponentModel;
 using System.Reflection;
+using Bee.Base.Data;
 using Bee.Definition.Collections;
+using Bee.Definition.Forms;
 using Bee.Definition.Layouts;
 using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DataObjects;
 
 namespace Bee.Web.Blazor.Server.UnitTests.Components
 {
@@ -140,6 +143,69 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
             var result = method!.Invoke(component, new object[] { field }) as IEnumerable<ListItem>;
             Assert.NotNull(result);
             Assert.Empty(result!);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle ColumnCount 為 0 時應修正為 1 欄並回傳對應 CSS grid 樣式")]
+        public void BuildGridStyle_ZeroColumnCount_DefaultsToOneColumn()
+        {
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new FormLayout { ColumnCount = 0 });
+            var method = typeof(DynamicForm).GetMethod("BuildGridStyle",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var result = method!.Invoke(component, null) as string;
+            Assert.Equal("display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions DataObject 有欄位但欄位名稱不存在時應回傳空集合")]
+        public void EnumerateOptions_DataObjectFieldNotFound_ReturnsEmpty()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            schema.Tables!.Add("Employee", "Employee");
+            var dataObject = new FormDataObject(schema);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, dataObject);
+
+            var field = new LayoutField { FieldName = "nonexistent_field" };
+            var method = typeof(DynamicForm).GetMethod("EnumerateOptions",
+                BindingFlags.NonPublic | BindingFlags.Instance, null, s_layoutFieldParam, null);
+            Assert.NotNull(method);
+            var result = method!.Invoke(component, new object[] { field }) as IEnumerable<ListItem>;
+            Assert.NotNull(result);
+            Assert.Empty(result!);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions DataObject 有欄位且欄位含 ListItems 時應回傳對應選項清單")]
+        public void EnumerateOptions_DataObjectFieldWithListItems_ReturnsItems()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            var schemaField = master.Fields!.Add("status", "Status", FieldDbType.String);
+            schemaField.ListItems!.Add("A", "Active");
+            schemaField.ListItems.Add("I", "Inactive");
+
+            var dataObject = new FormDataObject(schema);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, dataObject);
+
+            var layoutField = new LayoutField { FieldName = "status" };
+            var method = typeof(DynamicForm).GetMethod("EnumerateOptions",
+                BindingFlags.NonPublic | BindingFlags.Instance, null, s_layoutFieldParam, null);
+            Assert.NotNull(method);
+            var result = method!.Invoke(component, new object[] { layoutField }) as IEnumerable<ListItem>;
+            Assert.NotNull(result);
+            Assert.Equal(2, result!.Count());
         }
     }
 }

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormHelperTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormHelperTests.cs
@@ -1,8 +1,11 @@
 using System.ComponentModel;
 using System.Reflection;
+using Bee.Base.Data;
 using Bee.Definition.Collections;
+using Bee.Definition.Forms;
 using Bee.Definition.Layouts;
 using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DataObjects;
 
 namespace Bee.Web.Blazor.Wasm.UnitTests.Components
 {
@@ -140,6 +143,69 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
             var result = method!.Invoke(component, new object[] { field }) as IEnumerable<ListItem>;
             Assert.NotNull(result);
             Assert.Empty(result!);
+        }
+
+        [Fact]
+        [DisplayName("BuildGridStyle ColumnCount 為 0 時應修正為 1 欄並回傳對應 CSS grid 樣式")]
+        public void BuildGridStyle_ZeroColumnCount_DefaultsToOneColumn()
+        {
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new FormLayout { ColumnCount = 0 });
+            var method = typeof(DynamicForm).GetMethod("BuildGridStyle",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var result = method!.Invoke(component, null) as string;
+            Assert.Equal("display:grid;grid-template-columns:repeat(1,minmax(0,1fr));gap:8px", result);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions DataObject 有欄位但欄位名稱不存在時應回傳空集合")]
+        public void EnumerateOptions_DataObjectFieldNotFound_ReturnsEmpty()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            schema.Tables!.Add("Employee", "Employee");
+            var dataObject = new FormDataObject(schema);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, dataObject);
+
+            var field = new LayoutField { FieldName = "nonexistent_field" };
+            var method = typeof(DynamicForm).GetMethod("EnumerateOptions",
+                BindingFlags.NonPublic | BindingFlags.Instance, null, s_layoutFieldParam, null);
+            Assert.NotNull(method);
+            var result = method!.Invoke(component, new object[] { field }) as IEnumerable<ListItem>;
+            Assert.NotNull(result);
+            Assert.Empty(result!);
+        }
+
+        [Fact]
+        [DisplayName("EnumerateOptions DataObject 有欄位且欄位含 ListItems 時應回傳對應選項清單")]
+        public void EnumerateOptions_DataObjectFieldWithListItems_ReturnsItems()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            var schemaField = master.Fields!.Add("status", "Status", FieldDbType.String);
+            schemaField.ListItems!.Add("A", "Active");
+            schemaField.ListItems.Add("I", "Inactive");
+
+            var dataObject = new FormDataObject(schema);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, dataObject);
+
+            var layoutField = new LayoutField { FieldName = "status" };
+            var method = typeof(DynamicForm).GetMethod("EnumerateOptions",
+                BindingFlags.NonPublic | BindingFlags.Instance, null, s_layoutFieldParam, null);
+            Assert.NotNull(method);
+            var result = method!.Invoke(component, new object[] { layoutField }) as IEnumerable<ListItem>;
+            Assert.NotNull(result);
+            Assert.Equal(2, result!.Count());
         }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 0.0% | 3 |
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 0.0% | 3 |
| `src/Bee.UI.Core/ClientInfo.cs` | 85.2% | 1 |

### 補強說明

**DynamicForm（Server / Wasm）**
- `BuildGridStyle_ZeroColumnCount_DefaultsToOneColumn`：補強 `if (columns < 1) columns = 1;` 分支，當 `ColumnCount = 0` 時修正為 1 欄的路徑
- `EnumerateOptions_DataObjectFieldNotFound_ReturnsEmpty`：DataObject 不為 null 但欄位不存在時回傳空集合
- `EnumerateOptions_DataObjectFieldWithListItems_ReturnsItems`：DataObject 有欄位且含 ListItems 時回傳對應選項清單

**ClientInfo（Bee.UI.Core）**
- `ClientSettings_EmptyFile_ThrowsInvalidOperationException`：當設定檔為空白時 `DeserializeFromFile<ClientSettings>` 回傳 null，應拋出 `InvalidOperationException`（覆蓋 `?? throw` 分支）

---

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | `OnSubmitAsync` 主要路徑（lines 70–84）需 `LoginAsync` 回傳特定 `LoginResponse`，`SystemApiConnector.LoginAsync` 非 virtual，無法在無 API server 的 CI 環境下覆蓋 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上 |

---
_Generated by [Claude Code](https://claude.ai/code/session_0116Vw6yURQyJywzyGzGNJoV)_