### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-05-29 00:30

### DIFF
--- a/tests/Bee.Definition.UnitTests/Language/LanguageServiceTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/LanguageServiceTests.cs
@@ -206,6 +206,45 @@ namespace Bee.Definition.UnitTests.Language
             Assert.Null(svc.GetLangEnumText("zh-TW", "Common.Gender", "X"));
         }
 
+        [Fact]
+        [DisplayName("GetLangText fullKey 無點號時整個字串視為 namespace，未命中時回傳 namespace. 格式")]
+        public void GetLangText_FullKeyWithNoDot_ReturnsFallbackKey()
+        {
+            var defineAccess = new StubDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+            var result = svc.GetLangText("zh-TW", "NoDotKey");
+            Assert.Equal("NoDotKey.", result);
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum namespace 為空白字串時應回傳 null，不做任何查詢")]
+        public void GetLangEnum_BlankNamespace_ReturnsNull()
+        {
+            var defineAccess = new StubDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+            Assert.Null(svc.GetLangEnum("zh-TW", "  ", "Gender"));
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum enumName 為空白字串時應回傳 null，不做任何查詢")]
+        public void GetLangEnum_BlankEnumName_ReturnsNull()
+        {
+            var defineAccess = new StubDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+            Assert.Null(svc.GetLangEnum("zh-TW", "Common", " "));
+        }
+
+        [Fact]
+        [DisplayName("GetLangText 系統預設語系為空字串時應跳過 fallback 查詢，直接回傳 fullKey")]
+        public void GetLangText_EmptyDefaultLang_ReturnsFallbackKeyWithoutFallbackLookup()
+        {
+            var defineAccess = new StubDefineAccess("");
+            var svc = new LanguageService(defineAccess);
+            var result = svc.GetLangText("zh-TW", "Common.OK");
+            Assert.Equal("Common.OK", result);
+            Assert.Equal(1, defineAccess.GetLanguageCallCount);
+        }
+
         private sealed class StubDefineAccess : IDefineAccess
         {
             private readonly Dictionary<string, LanguageResource> _resources = [];

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeAccessTokenProviderTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeAccessTokenProviderTests.cs
@@ -80,5 +80,21 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
             Assert.Null(exception);
             Assert.Equal(token, provider.AccessToken);
         }
+
+        [Fact]
+        [DisplayName("OnInitialized 呼叫後 _isAttached 應設為 true")]
+        public void OnInitialized_SetsIsAttachedToTrue()
+        {
+            var provider = new BeeAccessTokenProvider();
+            var isAttachedField = typeof(BeeAccessTokenProvider).GetField(
+                "_isAttached", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(isAttachedField);
+            Assert.False((bool)isAttachedField!.GetValue(provider)!);
+            var method = typeof(BeeAccessTokenProvider).GetMethod(
+                "OnInitialized", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            method!.Invoke(provider, null);
+            Assert.True((bool)isAttachedField.GetValue(provider)!);
+        }
     }
 }

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
@@ -308,5 +308,92 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
             Assert.NotNull(property);
             Assert.NotNull(property!.GetCustomAttribute<ParameterAttribute>());
         }
+
+        // ──────────────────────────────────────────────────────────────
+        // OnRowClickAsync
+        // ──────────────────────────────────────────────────────────────
+
+        private static Task InvokeOnRowClickAsync(DynamicGrid component, DataRow row)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (Task)method!.Invoke(component, new object[] { row })!;
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync OnRowSelected 無委派時應直接返回，不拋例外")]
+        public async Task OnRowClickAsync_NoDelegate_ReturnsWithoutError()
+        {
+            var component = new DynamicGrid();
+            var table = new DataTable();
+            table.Columns.Add("col", typeof(string));
+            var row = table.NewRow();
+            row["col"] = "value";
+            table.Rows.Add(row);
+            var exception = await Record.ExceptionAsync(() => InvokeOnRowClickAsync(component, row));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync row 無 sys_rowid 欄位時有委派也不呼叫 callback")]
+        public async Task OnRowClickAsync_HasDelegateButNoRowId_DoesNotInvokeCallback()
+        {
+            var invoked = false;
+            var component = new DynamicGrid();
+            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
+                new SyncEventHandler(),
+                (Guid _) => { invoked = true; });
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = "test";
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.False(invoked);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync row 含有效 sys_rowid 且有委派時應呼叫 callback 並傳入正確 Guid")]
+        public async Task OnRowClickAsync_ValidRowWithDelegate_InvokesCallbackWithRowId()
+        {
+            var expectedGuid = Guid.NewGuid();
+            var capturedGuid = Guid.Empty;
+            var component = new DynamicGrid();
+            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
+                new SyncEventHandler(),
+                (Guid g) => { capturedGuid = g; });
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expectedGuid;
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.Equal(expectedGuid, capturedGuid);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // FormatCell — IFormattable switch arm
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("FormatCell 整數值無格式設定時應使用 IFormattable 以 InvariantCulture 格式化")]
+        public void FormatCell_IntegerWithNoFormat_UsesIFormattableToString()
+        {
+            var table = new DataTable();
+            table.Columns.Add("count", typeof(int));
+            var row = table.NewRow();
+            row["count"] = 42;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "count" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("42", result);
+        }
+
+        private sealed class SyncEventHandler : IHandleEvent
+        {
+            public Task HandleEventAsync(EventCallbackWorkItem callback, object? arg)
+                => callback.InvokeAsync(arg);
+        }
     }
 }

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridTests.cs
@@ -341,9 +341,11 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
         {
             var invoked = false;
             var component = new DynamicGrid();
-            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
-                new SyncEventHandler(),
-                (Guid _) => { invoked = true; });
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, EventCallback.Factory.Create<Guid>(
+                    new SyncEventHandler(),
+                    (Guid _) => { invoked = true; }));
             var table = new DataTable();
             table.Columns.Add("name", typeof(string));
             var row = table.NewRow();
@@ -360,9 +362,11 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
             var expectedGuid = Guid.NewGuid();
             var capturedGuid = Guid.Empty;
             var component = new DynamicGrid();
-            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
-                new SyncEventHandler(),
-                (Guid g) => { capturedGuid = g; });
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, EventCallback.Factory.Create<Guid>(
+                    new SyncEventHandler(),
+                    (Guid g) => { capturedGuid = g; }));
             var table = new DataTable();
             table.Columns.Add(SysFields.RowId, typeof(Guid));
             var row = table.NewRow();

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeAccessTokenProviderTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeAccessTokenProviderTests.cs
@@ -80,5 +80,21 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
             Assert.Null(exception);
             Assert.Equal(token, provider.AccessToken);
         }
+
+        [Fact]
+        [DisplayName("OnInitialized 呼叫後 _isAttached 應設為 true")]
+        public void OnInitialized_SetsIsAttachedToTrue()
+        {
+            var provider = new BeeAccessTokenProvider();
+            var isAttachedField = typeof(BeeAccessTokenProvider).GetField(
+                "_isAttached", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(isAttachedField);
+            Assert.False((bool)isAttachedField!.GetValue(provider)!);
+            var method = typeof(BeeAccessTokenProvider).GetMethod(
+                "OnInitialized", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            method!.Invoke(provider, null);
+            Assert.True((bool)isAttachedField.GetValue(provider)!);
+        }
     }
 }

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
@@ -308,5 +308,92 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
             Assert.NotNull(property);
             Assert.NotNull(property!.GetCustomAttribute<ParameterAttribute>());
         }
+
+        // ──────────────────────────────────────────────────────────────
+        // OnRowClickAsync
+        // ──────────────────────────────────────────────────────────────
+
+        private static Task InvokeOnRowClickAsync(DynamicGrid component, DataRow row)
+        {
+            var method = typeof(DynamicGrid).GetMethod(
+                "OnRowClickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (Task)method!.Invoke(component, new object[] { row })!;
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync OnRowSelected 無委派時應直接返回，不拋例外")]
+        public async Task OnRowClickAsync_NoDelegate_ReturnsWithoutError()
+        {
+            var component = new DynamicGrid();
+            var table = new DataTable();
+            table.Columns.Add("col", typeof(string));
+            var row = table.NewRow();
+            row["col"] = "value";
+            table.Rows.Add(row);
+            var exception = await Record.ExceptionAsync(() => InvokeOnRowClickAsync(component, row));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync row 無 sys_rowid 欄位時有委派也不呼叫 callback")]
+        public async Task OnRowClickAsync_HasDelegateButNoRowId_DoesNotInvokeCallback()
+        {
+            var invoked = false;
+            var component = new DynamicGrid();
+            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
+                new SyncEventHandler(),
+                (Guid _) => { invoked = true; });
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            var row = table.NewRow();
+            row["name"] = "test";
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.False(invoked);
+        }
+
+        [Fact]
+        [DisplayName("OnRowClickAsync row 含有效 sys_rowid 且有委派時應呼叫 callback 並傳入正確 Guid")]
+        public async Task OnRowClickAsync_ValidRowWithDelegate_InvokesCallbackWithRowId()
+        {
+            var expectedGuid = Guid.NewGuid();
+            var capturedGuid = Guid.Empty;
+            var component = new DynamicGrid();
+            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
+                new SyncEventHandler(),
+                (Guid g) => { capturedGuid = g; });
+            var table = new DataTable();
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            var row = table.NewRow();
+            row[SysFields.RowId] = expectedGuid;
+            table.Rows.Add(row);
+            await InvokeOnRowClickAsync(component, row);
+            Assert.Equal(expectedGuid, capturedGuid);
+        }
+
+        // ──────────────────────────────────────────────────────────────
+        // FormatCell — IFormattable switch arm
+        // ──────────────────────────────────────────────────────────────
+
+        [Fact]
+        [DisplayName("FormatCell 整數值無格式設定時應使用 IFormattable 以 InvariantCulture 格式化")]
+        public void FormatCell_IntegerWithNoFormat_UsesIFormattableToString()
+        {
+            var table = new DataTable();
+            table.Columns.Add("count", typeof(int));
+            var row = table.NewRow();
+            row["count"] = 42;
+            table.Rows.Add(row);
+            var column = new LayoutColumn { FieldName = "count" };
+            var result = InvokeFormatCell(row, column);
+            Assert.Equal("42", result);
+        }
+
+        private sealed class SyncEventHandler : IHandleEvent
+        {
+            public Task HandleEventAsync(EventCallbackWorkItem callback, object? arg)
+                => callback.InvokeAsync(arg);
+        }
     }
 }

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridTests.cs
@@ -341,9 +341,11 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
         {
             var invoked = false;
             var component = new DynamicGrid();
-            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
-                new SyncEventHandler(),
-                (Guid _) => { invoked = true; });
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, EventCallback.Factory.Create<Guid>(
+                    new SyncEventHandler(),
+                    (Guid _) => { invoked = true; }));
             var table = new DataTable();
             table.Columns.Add("name", typeof(string));
             var row = table.NewRow();
@@ -360,9 +362,11 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
             var expectedGuid = Guid.NewGuid();
             var capturedGuid = Guid.Empty;
             var component = new DynamicGrid();
-            component.OnRowSelected = EventCallback.Factory.Create<Guid>(
-                new SyncEventHandler(),
-                (Guid g) => { capturedGuid = g; });
+            typeof(DynamicGrid)
+                .GetProperty("OnRowSelected", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, EventCallback.Factory.Create<Guid>(
+                    new SyncEventHandler(),
+                    (Guid g) => { capturedGuid = g; }));
             var table = new DataTable();
             table.Columns.Add(SysFields.RowId, typeof(Guid));
             var row = table.NewRow();


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Language/LanguageService.cs` | 89.6% | 4 |
| `src/Bee.Web.Blazor.Wasm/Components/DynamicGrid.razor.cs` | 78.8% | 4 |
| `src/Bee.Web.Blazor.Server/Components/DynamicGrid.razor.cs` | 78.8% | 4 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeAccessTokenProvider.razor.cs` | 70.0% | 1 |
| `src/Bee.Web.Blazor.Server/Components/BeeAccessTokenProvider.razor.cs` | 70.0% | 1 |

### 測試補強重點

- **LanguageService**：`SplitFullKey` 無點號路徑（`dot < 0`）、`GetLangEnum` 空白 namespace/enumName 邊界回傳 null、`GetLangText` 空預設語系略過 fallback 查詢
- **DynamicGrid（Wasm & Server）**：`OnRowClickAsync` 三條路徑（無委派早返回、有委派但無 `sys_rowid` 早返回、有效 RowId 觸發回呼）；`FormatCell` IFormattable switch arm（整數值無格式）
- **BeeAccessTokenProvider（Wasm & Server）**：透過反射呼叫 `OnInitialized`，驗證 `_isAttached` 旗標設為 `true`

### 無法處理（共 5 筆）

| 檔案 | 補強前覆蓋率 | 原因 |
|------|------------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 0% | `.razor` 標記檔，無法進行單元測試 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 0% | `.razor` 標記檔，無法進行單元測試 |
| `src/Bee.UI.Core/ClientInfo.cs` | 85.2% | 剩餘未覆蓋行需要真實 API 伺服器（`SyncExecutor.Run` 成功執行及 `EndpointStorage.SaveEndpoint`） |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 65.4% | 成功登入路徑需要 mock `SystemApiConnector.LoginAsync`，但該方法為 non-virtual，無法在無後端的情況下覆蓋 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 65.4% | 同上 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2EQkdeLP7wsRuAYmjrSYE)_