### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-05-29 16:30

### DIFF
--- a/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
+++ b/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+using Bee.Business;
+using Bee.Business.Form;
+
+namespace Bee.Business.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="DefaultFormBoTypeResolver"/> 的測試覆蓋率。
+    /// 此 resolver 為最小化實作，任何 progId 皆回傳 <see cref="FormBusinessObject"/>。
+    /// </summary>
+    public class DefaultFormBoTypeResolverTests
+    {
+        [Fact]
+        [DisplayName("DefaultFormBoTypeResolver.Resolve 任何 progId 皆應回傳 FormBusinessObject 型別")]
+        public void Resolve_AnyProgId_ReturnsFormBusinessObjectType()
+        {
+            IFormBoTypeResolver resolver = new DefaultFormBoTypeResolver();
+
+            Assert.Equal(typeof(FormBusinessObject), resolver.Resolve("AnyProgId"));
+        }
+
+        [Fact]
+        [DisplayName("DefaultFormBoTypeResolver.Resolve 空字串 progId 應回傳 FormBusinessObject 型別")]
+        public void Resolve_EmptyProgId_ReturnsFormBusinessObjectType()
+        {
+            var resolver = new DefaultFormBoTypeResolver();
+
+            Assert.Equal(typeof(FormBusinessObject), resolver.Resolve(string.Empty));
+        }
+    }
+}

--- a/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
+++ b/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Bee.Business;
 using Bee.Business.Form;
 
 namespace Bee.Business.UnitTests

--- a/tests/Bee.Definition.UnitTests/Language/LanguageModelToStringTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/LanguageModelToStringTests.cs
@@ -1,0 +1,83 @@
+using System.ComponentModel;
+using Bee.Definition.Language;
+
+namespace Bee.Definition.UnitTests.Language
+{
+    /// <summary>
+    /// 補強語言模型型別 ToString() 方法與集合無參建構子的測試覆蓋率。
+    /// 涵蓋 LanguageEnum、LanguageEnumEntry、LanguageItem、LanguageResource，
+    /// 以及 LanguageEnumCollection、LanguageItemCollection、LanguageEnumEntryCollection
+    /// 的無參建構子路徑。
+    /// </summary>
+    public class LanguageModelToStringTests
+    {
+        [Fact]
+        [DisplayName("LanguageEnum.ToString 應回傳含名稱與 Entries 數的字串")]
+        public void LanguageEnum_ToString_ContainsNameAndEntryCount()
+        {
+            var langEnum = new LanguageEnum { Name = "Gender" };
+            langEnum.Entries.Add("M", "男");
+            langEnum.Entries.Add("F", "女");
+
+            Assert.Equal("Gender (2 entries)", langEnum.ToString());
+        }
+
+        [Fact]
+        [DisplayName("LanguageEnumEntry.ToString 應回傳 Code = Text 格式")]
+        public void LanguageEnumEntry_ToString_FormatsCodeAndText()
+        {
+            var entry = new LanguageEnumEntry { Code = "M", Text = "男" };
+
+            Assert.Equal("M = 男", entry.ToString());
+        }
+
+        [Fact]
+        [DisplayName("LanguageItem.ToString 應回傳 Key = Value 格式")]
+        public void LanguageItem_ToString_FormatsKeyAndValue()
+        {
+            var item = new LanguageItem { Key = "OK", Value = "確定" };
+
+            Assert.Equal("OK = 確定", item.ToString());
+        }
+
+        [Fact]
+        [DisplayName("LanguageResource.ToString 應包含 Namespace、Lang、Items 數與 Enums 數")]
+        public void LanguageResource_ToString_ContainsAllParts()
+        {
+            var resource = new LanguageResource { Namespace = "Common", Lang = "zh-TW" };
+            resource.Items.Add("OK", "確定");
+
+            Assert.Equal("Common [zh-TW] (1 items, 0 enums)", resource.ToString());
+        }
+
+        [Fact]
+        [DisplayName("LanguageEnumCollection 無參建構子應建立非 null 的空集合")]
+        public void LanguageEnumCollection_ParameterlessConstructor_CreatesEmptyCollection()
+        {
+            var collection = new LanguageEnumCollection();
+
+            Assert.NotNull(collection);
+            Assert.Empty(collection);
+        }
+
+        [Fact]
+        [DisplayName("LanguageItemCollection 無參建構子應建立非 null 的空集合")]
+        public void LanguageItemCollection_ParameterlessConstructor_CreatesEmptyCollection()
+        {
+            var collection = new LanguageItemCollection();
+
+            Assert.NotNull(collection);
+            Assert.Empty(collection);
+        }
+
+        [Fact]
+        [DisplayName("LanguageEnumEntryCollection 無參建構子應建立非 null 的空集合")]
+        public void LanguageEnumEntryCollection_ParameterlessConstructor_CreatesEmptyCollection()
+        {
+            var collection = new LanguageEnumEntryCollection();
+
+            Assert.NotNull(collection);
+            Assert.Empty(collection);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Language/LanguageServiceAdditionalTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/LanguageServiceAdditionalTests.cs
@@ -1,0 +1,124 @@
+using System.ComponentModel;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Language;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Definition.UnitTests.Language
+{
+    /// <summary>
+    /// 補強 <see cref="LanguageService"/> 邊界路徑的測試覆蓋率：
+    /// 建構子 null 防護、GetLangEnum 最終 return null 路徑（lang == defaultLang 或 defaultLang 為空）、
+    /// GetLangEnumText 當 langEnum 為 null 的空值傳播路徑、
+    /// TryGetLangText 當 resource 存在但 subKey 不存在的分支。
+    /// </summary>
+    public class LanguageServiceAdditionalTests
+    {
+        [Fact]
+        [DisplayName("LanguageService 建構子傳入 null 應拋 ArgumentNullException")]
+        public void Constructor_NullDefineAccess_ThrowsArgumentNullException()
+        {
+            var exception = Record.Exception(() => new LanguageService(null!));
+            Assert.NotNull(exception);
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum 當 lang == defaultLang 且 Enum 不存在時應回傳 null，不嘗試 fallback")]
+        public void GetLangEnum_LangEqualsDefaultLang_EnumMiss_ReturnsNull()
+        {
+            var defineAccess = new MinimalLangDefineAccess("zh-TW");
+            var svc = new LanguageService(defineAccess);
+
+            Assert.Null(svc.GetLangEnum("zh-TW", "Common", "Gender"));
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum 當 defaultLang 為空字串且 Enum 不存在時應回傳 null")]
+        public void GetLangEnum_EmptyDefaultLang_EnumMiss_ReturnsNull()
+        {
+            var defineAccess = new MinimalLangDefineAccess("");
+            var svc = new LanguageService(defineAccess);
+
+            Assert.Null(svc.GetLangEnum("zh-TW", "Common", "Gender"));
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnumText 當 GetLangEnum 回傳 null 時應回傳 null（空值傳播）")]
+        public void GetLangEnumText_NullLangEnum_ReturnsNull()
+        {
+            var defineAccess = new MinimalLangDefineAccess("en-US");
+            var svc = new LanguageService(defineAccess);
+
+            Assert.Null(svc.GetLangEnumText("zh-TW", "Common.NonExistentEnum", "M"));
+        }
+
+        [Fact]
+        [DisplayName("TryGetLangText 當 resource 存在但 subKey 不在 Items 時應回傳 false 與空字串")]
+        public void TryGetLangText_ResourceExistsButKeyMissing_ReturnsFalseAndEmpty()
+        {
+            var defineAccess = new MinimalLangDefineAccess("en-US");
+            defineAccess.AddResource("zh-TW", "Common", ("OK", "確定"));
+            var svc = new LanguageService(defineAccess);
+
+            bool result = svc.TryGetLangText("zh-TW", "Common", "Missing", out string text);
+
+            Assert.False(result);
+            Assert.Equal(string.Empty, text);
+        }
+
+        [Fact]
+        [DisplayName("GetLangText 當 defaultLang 為空且主語系未命中時應回傳 namespace.subKey 格式")]
+        public void GetLangText_EmptyDefaultLang_PrimaryMiss_ReturnsFallbackKey()
+        {
+            var defineAccess = new MinimalLangDefineAccess("");
+            var svc = new LanguageService(defineAccess);
+
+            Assert.Equal("Common.Missing", svc.GetLangText("zh-TW", "Common", "Missing"));
+        }
+
+        private sealed class MinimalLangDefineAccess : IDefineAccess
+        {
+            private readonly Dictionary<string, LanguageResource> _resources = [];
+            private readonly SystemSettings _systemSettings;
+
+            public MinimalLangDefineAccess(string defaultLang)
+            {
+                _systemSettings = new SystemSettings();
+                _systemSettings.CommonConfiguration.DefaultLang = defaultLang;
+            }
+
+            public void AddResource(string lang, string ns, params (string Key, string Value)[] items)
+            {
+                var resource = new LanguageResource { Namespace = ns, Lang = lang };
+                foreach (var (key, value) in items)
+                    resource.Items.Add(key, value);
+                _resources[$"{lang}.{ns}"] = resource;
+            }
+
+            public LanguageResource GetLanguage(string lang, string ns)
+                => _resources.TryGetValue($"{lang}.{ns}", out var r) ? r : null!;
+
+            public SystemSettings GetSystemSettings() => _systemSettings;
+
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+            public void SaveLanguage(LanguageResource resource) => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 | 備註 |
|------|------------|---------|------|
| `src/Bee.Definition/Language/LanguageService.cs` | 89.6% | 6 | LanguageServiceAdditionalTests.cs |
| `src/Bee.Definition/Language/LanguageEnum.cs` | 80.0% | 1 | LanguageModelToStringTests.cs |
| `src/Bee.Definition/Language/LanguageEnumCollection.cs` | 50.0% | 1 | LanguageModelToStringTests.cs |
| `src/Bee.UI.Core/ClientInfo.cs` | 85.2% | 0 | 無法處理（殘餘路徑需 API 服務支援） |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 0.0% | 0 | 無法處理（純 interface，無可執行程式碼） |

### 額外補強（同一 PR，非 top-5）

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Language/LanguageEnumEntry.cs` | 75.0% | 1 |
| `src/Bee.Definition/Language/LanguageItem.cs` | 75.0% | 1 |
| `src/Bee.Definition/Language/LanguageItemCollection.cs` | 80.0% | 1 |
| `src/Bee.Definition/Language/LanguageEnumEntryCollection.cs` | 80.0% | 1 |
| `src/Bee.Definition/Language/LanguageResource.cs` | 85.7% | 1 |
| `src/Bee.Business/IFormBoTypeResolver.cs` | 0.0% | 2 |

### 無法處理說明

- **`ClientInfo.cs`**：剩餘 12 行未覆蓋路徑（`InitializeConnect` 的 `return true`、`SetEndpoint` 的 `SaveEndpoint`、`Initialize(IUIViewService)` 的 `EndpointStorage.SetEndpoint`）皆需正常運行的 API server 才能執行，無法在 CI 環境補強。已有 7 個測試檔涵蓋其餘所有邏輯路徑。
- **`ITraceListener.cs`**：純 interface，無預設實作，SonarCloud 報告的 2 行為 interface 方法宣告，非可執行程式碼，無法以單元測試覆蓋。

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUz6eX6XEwjCB3aB8wvnbp)_