### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-30 08:30

### DIFF
--- a/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodTests.cs
@@ -1,0 +1,103 @@
+using System.ComponentModel;
+using Bee.Definition.Language;
+
+namespace Bee.Definition.UnitTests.Language
+{
+    /// <summary>
+    /// 驗證 <see cref="ILanguageService"/> 四個含 customizeId 的預設介面方法
+    /// 確實委派至對應的基礎多載，而非空實作。
+    /// <c>MinimalLanguageService</c> 不 override 這四個方法，強制走 default interface method。
+    /// </summary>
+    public class ILanguageServiceDefaultMethodTests
+    {
+        private sealed class MinimalLanguageService : ILanguageService
+        {
+            public string GetLangText(string lang, string fullKey) => fullKey;
+
+            public string GetLangText(string lang, string @namespace, string subKey)
+                => $"{@namespace}.{subKey}";
+
+            public bool TryGetLangText(string lang, string fullKey, out string text)
+            {
+                text = fullKey;
+                return true;
+            }
+
+            public bool TryGetLangText(string lang, string @namespace, string subKey, out string text)
+            {
+                text = $"{@namespace}.{subKey}";
+                return true;
+            }
+
+            public LanguageEnum? GetLangEnum(string lang, string fullName)
+            {
+                int dot = fullName.IndexOf('.');
+                if (dot < 0) return null;
+                return GetLangEnum(lang, fullName[..dot], fullName[(dot + 1)..]);
+            }
+
+            public LanguageEnum? GetLangEnum(string lang, string @namespace, string enumName)
+            {
+                var e = new LanguageEnum { Name = enumName };
+                e.Entries.Add("M", "男");
+                return e;
+            }
+
+            public string? GetLangEnumText(string lang, string fullName, string code)
+            {
+                int dot = fullName.IndexOf('.');
+                if (dot < 0) return null;
+                var e = GetLangEnum(lang, fullName[..dot], fullName[(dot + 1)..]);
+                return e?.GetText(code);
+            }
+
+            // 不 override 以下四個 customizeId 多載 → 走 default interface method
+        }
+
+        [Fact]
+        [DisplayName("TryGetLangText 含 customizeId 預設介面實作應委派至不含 customizeId 的三參數多載")]
+        public void TryGetLangText_WithCustomizeId_DelegatesToBaseOverload()
+        {
+            ILanguageService service = new MinimalLanguageService();
+
+            bool result = service.TryGetLangText("acme", "zh-TW", "Common", "OK", out string text);
+
+            Assert.True(result);
+            Assert.Equal("Common.OK", text);
+        }
+
+        [Fact]
+        [DisplayName("GetLangText 含 customizeId 預設介面實作應委派至不含 customizeId 的三參數多載")]
+        public void GetLangText_WithCustomizeId_DelegatesToBaseOverload()
+        {
+            ILanguageService service = new MinimalLanguageService();
+
+            string result = service.GetLangText("acme", "zh-TW", "Common", "OK");
+
+            Assert.Equal("Common.OK", result);
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum 含 customizeId 預設介面實作應委派至不含 customizeId 的三參數多載")]
+        public void GetLangEnum_WithCustomizeId_DelegatesToBaseOverload()
+        {
+            ILanguageService service = new MinimalLanguageService();
+
+            LanguageEnum? result = service.GetLangEnum("acme", "zh-TW", "Common", "Gender");
+
+            Assert.NotNull(result);
+            Assert.Equal("Gender", result!.Name);
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnumText 含 customizeId 預設介面實作應委派至不含 customizeId 的基礎多載")]
+        public void GetLangEnumText_WithCustomizeId_DelegatesToBaseOverload()
+        {
+            ILanguageService service = new MinimalLanguageService();
+
+            string? result = service.GetLangEnumText("acme", "zh-TW", "Common.Gender", "M");
+
+            Assert.Equal("男", result);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageTests.cs
@@ -4,6 +4,7 @@ using Bee.Definition.Database;
 using Bee.Definition.Forms;
 using Bee.Definition.Language;
 using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
 using Bee.Definition.Storage;
 
 namespace Bee.Definition.UnitTests.Storage

--- a/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Bee.Base.Serialization;
+using Bee.Definition.Database;
 using Bee.Definition.Forms;
 using Bee.Definition.Language;
 using Bee.Definition.Layouts;
@@ -101,6 +102,20 @@ namespace Bee.Definition.UnitTests.Storage
             Assert.Throws<NotSupportedException>(() => storage.SaveFormLayout(new FormLayout()));
             Assert.Throws<NotSupportedException>(() => storage.SaveLanguage(new LanguageResource()));
             Assert.Throws<NotSupportedException>(() => storage.SaveFormSchema(new FormSchema()));
+        }
+
+        [Fact]
+        [DisplayName("SaveDbCategorySettings 應拋出 NotSupportedException（嚴格只讀）")]
+        public void SaveDbCategorySettings_ThrowsNotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveDbCategorySettings(new DbCategorySettings()));
+        }
+
+        [Fact]
+        [DisplayName("SaveTableSchema 應拋出 NotSupportedException（嚴格只讀）")]
+        public void SaveTableSchema_ThrowsNotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveTableSchema("common", new TableSchema()));
         }
 
         [Fact]

--- a/tests/Bee.Definition.UnitTests/Storage/IDefineAccessDefaultMethodTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/IDefineAccessDefaultMethodTests.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel;
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Language;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Definition.UnitTests.Storage
+{
+    /// <summary>
+    /// 驗證 <see cref="IDefineAccess.GetFormLayout(string, string)"/> 預設介面實作
+    /// 確實委派至 <see cref="IDefineAccess.GetFormLayout(string)"/>，而非空實作。
+    /// <c>MinimalDefineAccess</c> 不 override customizeId 多載，強制走 default interface method。
+    /// </summary>
+    public class IDefineAccessDefaultMethodTests
+    {
+        private sealed class MinimalDefineAccess : IDefineAccess
+        {
+            private readonly FormLayout _layout;
+
+            public MinimalDefineAccess(string layoutId)
+            {
+                _layout = new FormLayout { LayoutId = layoutId };
+            }
+
+            public FormLayout GetFormLayout(string layoutId) => _layout;
+
+            // 不 override GetFormLayout(string customizeId, string layoutId) → 走 default interface method
+
+            // 其他成員均不需呼叫，拋 NotImplementedException
+            public object GetDefine(DefineType defineType, string[]? keys = null) => throw new NotImplementedException();
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null) => throw new NotImplementedException();
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+            public LanguageResource GetLanguage(string lang, string ns) => throw new NotImplementedException();
+            public void SaveLanguage(LanguageResource resource) => throw new NotImplementedException();
+        }
+
+        [Fact]
+        [DisplayName("GetFormLayout 含 customizeId 預設介面實作應委派至不含 customizeId 的單參數多載，忽略 customizeId")]
+        public void GetFormLayout_WithCustomizeId_DelegatesToBaseOverload()
+        {
+            IDefineAccess access = new MinimalDefineAccess("EmployeeDefault");
+
+            FormLayout result = access.GetFormLayout("acme", "EmployeeDefault");
+
+            Assert.NotNull(result);
+            Assert.Equal("EmployeeDefault", result.LayoutId);
+        }
+
+        [Fact]
+        [DisplayName("GetFormLayout 含 customizeId 空字串時應同樣委派至基礎多載，回傳相同結果")]
+        public void GetFormLayout_WithEmptyCustomizeId_DelegatesToBaseOverload()
+        {
+            IDefineAccess access = new MinimalDefineAccess("SalesOrder");
+
+            FormLayout result = access.GetFormLayout(string.Empty, "SalesOrder");
+
+            Assert.NotNull(result);
+            Assert.Equal("SalesOrder", result.LayoutId);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Language/ILanguageService.cs` | 0.0% (4 uncovered) | 4 |
| `src/Bee.Definition/Storage/CustomizeOnlyStorage.cs` | 89.5% (2 uncovered) | 2 |
| `src/Bee.Definition/Storage/IDefineAccess.cs` | 0.0% (1 uncovered) | 2 |

### 測試說明

**ILanguageService — 4 個含 customizeId 的預設介面方法**
`LanguageService` 完整 override 這四個方法，導致介面中的 default 實作從未被執行。
以 `MinimalLanguageService` stub（不 override 這四個方法）觸發 default interface method，驗證其委派行為。

**CustomizeOnlyStorage — `SaveDbCategorySettings` 與 `SaveTableSchema`**
原 `SaveMethods_ThrowNotSupported` 只涵蓋三個 Save 方法，缺少這兩個。補上各自的測試。

**IDefineAccess — `GetFormLayout(string customizeId, string layoutId)` 預設方法**
`LocalDefineAccess` 有 override；`RemoteDefineAccess` 沒有，走 default 實作。
以 `MinimalDefineAccess` stub 驗證預設方法確實委派至 `GetFormLayout(layoutId)`。

---

### 無法處理（前 5 筆高優先目標）

| 檔案 | Uncovered | 原因 |
|------|-----------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | Blazor 渲染層，需 bUnit 驅動 BuildRenderTree |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | 同上 |
| `src/Bee.UI.Core/ClientInfo.cs` | 12 | 剩餘路徑（`return true;`、`SaveEndpoint` 成功路徑）均需實際執行中的 API 伺服器 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 9 | `SystemApiConnector.LoginAsync` 非 virtual，無法以 stub 攔截 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 9 | 同上 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01DZQWVkdv2uCJKCDxYtviiD)_