### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-05-30 16:30

### DIFF
--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeLoginPanelTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeLoginPanelTests.cs
@@ -77,5 +77,13 @@ namespace Bee.Web.Blazor.Server.UnitTests.Components
             Assert.Equal("Password", panel.PasswordLabel);
             Assert.Equal("Sign in", panel.SubmitLabel);
         }
+
+        [Fact]
+        [DisplayName("OnLoggedIn 預設狀態應無委派（HasDelegate 為 false）")]
+        public void OnLoggedIn_Default_HasNoDelegate()
+        {
+            var panel = new BeeLoginPanel();
+            Assert.False(panel.OnLoggedIn.HasDelegate);
+        }
     }
 }

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeLoginPanelTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeLoginPanelTests.cs
@@ -77,5 +77,13 @@ namespace Bee.Web.Blazor.Wasm.UnitTests.Components
             Assert.Equal("Password", panel.PasswordLabel);
             Assert.Equal("Sign in", panel.SubmitLabel);
         }
+
+        [Fact]
+        [DisplayName("OnLoggedIn 預設狀態應無委派（HasDelegate 為 false）")]
+        public void OnLoggedIn_Default_HasNoDelegate()
+        {
+            var panel = new BeeLoginPanel();
+            Assert.False(panel.OnLoggedIn.HasDelegate);
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 65.4% | 1 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 65.4% | 1 |

### 補強內容說明

兩個 `BeeLoginPanel` 元件均新增 `OnLoggedIn_Default_HasNoDelegate` 測試，直接存取 `OnLoggedIn` 屬性 getter（先前僅透過 reflection 取得 `PropertyInfo` 元資料，未觸發 getter 本身），覆蓋 SonarCloud 回報的 line 58。

---

### 無法處理（3 筆）

| 檔案 | 未覆蓋行數 | 無法處理原因 |
|------|-----------|------------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | Blazor 模板的 render cycle（`@if`、`@foreach`、`@onchange`）需 bUnit 渲染環境，純 xUnit 無法觸發 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | 同上（Server-side Blazor 版本） |
| `src/Bee.UI.Core/ClientInfo.cs` | 12 | 剩餘 12 行位於 `SetEndpoint`、`InitializeConnect`（需 `SyncExecutor.Run` 成功，即執行中的 API 伺服器）及 `ParseCommandLineArgs` 內部迴圈（需可控的命令列參數），CI 環境下無法在不啟動後端服務的情況下覆蓋 |

BeeLoginPanel 成功路徑（lines 71–83：`LoginAsync` 回應處理、`_password` 清除、`OnLoggedIn` 回呼）需要 `SystemApiConnector.LoginAsync` 可模擬（該方法非 virtual，且專案未引入 mock 框架），保留為後續人工規劃。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHnSZv8NoQKHpRjCdziQnk)_