### PR TITLE
[AutoFix] Coverage Fix (1 file) 2026-05-31 00:30

### DIFF
--- a/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
+++ b/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
@@ -26,5 +26,16 @@ namespace Bee.Business.UnitTests
 
             Assert.Equal(typeof(FormBusinessObject), resolver.Resolve(string.Empty));
         }
+
+        [Fact]
+        [DisplayName("IFormBoTypeResolver.Resolve(customizeId, progId) 預設方法應委派至 Resolve(progId)，customizeId 被忽略")]
+        public void Resolve_WithCustomizeIdAndProgId_DefaultDelegatesToBaseResolve()
+        {
+            IFormBoTypeResolver resolver = new DefaultFormBoTypeResolver();
+
+            var result = resolver.Resolve("acme", "AnyProgId");
+
+            Assert.Equal(typeof(FormBusinessObject), result);
+        }
     }
 }


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Business/IFormBoTypeResolver.cs` | 50.0% (1 uncovered) | 1 |

### 測試說明

**IFormBoTypeResolver — `Resolve(string customizeId, string progId)` 預設介面方法**

介面定義了一個帶 customizeId 的多載預設方法 `Resolve(string customizeId, string progId) => Resolve(progId)`，其作用是忽略 customizeId 並委派至單參數版本。

既有測試 `DefaultFormBoTypeResolverTests` 只呼叫 `Resolve(string progId)`，從未透過 `IFormBoTypeResolver` 介面引用呼叫 `Resolve(customizeId, progId)`，導致預設方法本體未被覆蓋。新增測試以 `DefaultFormBoTypeResolver`（未 override 此預設方法）透過介面引用觸發預設實作，確認委派行為正確。

---

### 無法處理（本次掃描前 5 高優先目標之外的剩餘未覆蓋檔案）

| 檔案 | Uncovered | 原因 |
|------|-----------|------|
| `src/Bee.Api.Client/ApiConnectValidator.cs` | 31 | 排除清單（Bee.Api.Client 結構性耦合） |
| `src/Bee.Api.Client/Connectors/FormApiConnector.cs` | 28 | 排除清單（Bee.Api.Client 結構性耦合） |
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | Blazor BuildRenderTree 需 bUnit 渲染器 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | Blazor BuildRenderTree 需 bUnit 渲染器 |
| `src/Bee.UI.Core/ClientInfo.cs` | 12 | 剩餘路徑均需實際執行中的 API 伺服器 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 8 | `SystemApiConnector.LoginAsync` 非 virtual，無法以 stub 攔截 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 8 | 同上 |
| `src/Bee.Web.Blazor.Wasm/Components/DynamicGrid.razor` | 8 | Blazor BuildRenderTree 需 bUnit 渲染器 |
| `src/Bee.Web.Blazor.Server/Components/DynamicGrid.razor` | 8 | Blazor BuildRenderTree 需 bUnit 渲染器 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor` | 5 | Blazor .razor 標記生成的 BuildRenderTree 需 bUnit |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor` | 5 | 同上 |
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor` | 4 | Blazor BuildRenderTree 需 bUnit 渲染器 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor` | 4 | 同上 |
| `src/Bee.UI.Maui/Storage/MauiPreferenceEndpointStorage.cs` | 3 | 依賴 `Microsoft.Maui.Storage.Preferences.Default` 平台實作，單元測試無法注入 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 2 | 純介面（無預設方法實作），SonarCloud 回報疑似測量誤差 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeAccessTokenProvider.razor` | 1 | Blazor .razor 標記生成的 BuildRenderTree 需 bUnit |
| `src/Bee.Web.Blazor.Server/Components/BeeAccessTokenProvider.razor` | 1 | 同上 |

已在 open PR #116 處理中的檔案（`ILanguageService.cs`、`CustomizeOnlyStorage.cs`、`IDefineAccess.cs`）不重複列入。

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLPoCjFtyW5A39YmptN4WC)_