### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-05-31 08:30

### DIFF
--- a/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
+++ b/tests/Bee.Business.UnitTests/DefaultFormBoTypeResolverTests.cs
@@ -26,5 +26,16 @@ namespace Bee.Business.UnitTests
 
             Assert.Equal(typeof(FormBusinessObject), resolver.Resolve(string.Empty));
         }
+
+        [Fact]
+        [DisplayName("IFormBoTypeResolver 預設 Resolve(customizeId, progId) 委派 Resolve(progId) 應回傳 FormBusinessObject 型別")]
+        public void Resolve_WithCustomizeId_DefaultMethodDelegatesToBaseResolve()
+        {
+            IFormBoTypeResolver resolver = new DefaultFormBoTypeResolver();
+
+            Type result = resolver.Resolve("acme", "AnyProgId");
+
+            Assert.Equal(typeof(FormBusinessObject), result);
+        }
     }
 }

--- a/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodsTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodsTests.cs
@@ -1,0 +1,130 @@
+using System.ComponentModel;
+using Bee.Definition.Language;
+
+namespace Bee.Definition.UnitTests.Language
+{
+    /// <summary>
+    /// 補強 <see cref="ILanguageService"/> 四個 default interface methods 的覆蓋率。
+    /// 這四個 default methods 在任何未 override 它們的實作中生效，此處透過最小 stub 驗證
+    /// 它們正確委派至對應的基底多載（忽略 customizeId 參數）。
+    /// </summary>
+    public class ILanguageServiceDefaultMethodsTests
+    {
+        // ---- Minimal stub — 實作所有抽象成員，不 override 任何 default method ---
+
+        private sealed class StubLanguageService : ILanguageService
+        {
+            private readonly Dictionary<string, string> _texts = new();
+            private readonly Dictionary<string, LanguageEnum?> _enums = new();
+
+            public void AddText(string lang, string ns, string subKey, string value)
+                => _texts[$"{lang}.{ns}.{subKey}"] = value;
+
+            public void AddEnum(string lang, string ns, string enumName, LanguageEnum langEnum)
+                => _enums[$"{lang}.{ns}.{enumName}"] = langEnum;
+
+            public string GetLangText(string lang, string fullKey)
+            {
+                int dot = fullKey.IndexOf('.');
+                if (dot < 0) return fullKey;
+                return GetLangText(lang, fullKey[..dot], fullKey[(dot + 1)..]);
+            }
+
+            public string GetLangText(string lang, string @namespace, string subKey)
+                => _texts.TryGetValue($"{lang}.{@namespace}.{subKey}", out var v)
+                    ? v
+                    : $"{@namespace}.{subKey}";
+
+            public bool TryGetLangText(string lang, string fullKey, out string text)
+            {
+                int dot = fullKey.IndexOf('.');
+                if (dot < 0) { text = string.Empty; return false; }
+                return TryGetLangText(lang, fullKey[..dot], fullKey[(dot + 1)..], out text);
+            }
+
+            public bool TryGetLangText(string lang, string @namespace, string subKey, out string text)
+            {
+                if (_texts.TryGetValue($"{lang}.{@namespace}.{subKey}", out var v))
+                {
+                    text = v;
+                    return true;
+                }
+                text = string.Empty;
+                return false;
+            }
+
+            public LanguageEnum? GetLangEnum(string lang, string fullName)
+            {
+                int dot = fullName.IndexOf('.');
+                if (dot < 0) return null;
+                return GetLangEnum(lang, fullName[..dot], fullName[(dot + 1)..]);
+            }
+
+            public LanguageEnum? GetLangEnum(string lang, string @namespace, string enumName)
+                => _enums.TryGetValue($"{lang}.{@namespace}.{enumName}", out var e) ? e : null;
+
+            public string? GetLangEnumText(string lang, string fullName, string code)
+                => GetLangEnum(lang, fullName)?.GetText(code);
+        }
+
+        // ---- Tests ---
+
+        [Fact]
+        [DisplayName("ILanguageService 預設 GetLangText(customizeId,...) 忽略 customizeId 委派 GetLangText(lang,ns,subKey)")]
+        public void GetLangText_DefaultMethod_IgnoresCustomizeIdDelegatesToBase()
+        {
+            var stub = new StubLanguageService();
+            stub.AddText("zh-TW", "Common", "OK", "確定");
+            ILanguageService svc = stub;
+
+            string result = svc.GetLangText("acme", "zh-TW", "Common", "OK");
+
+            Assert.Equal("確定", result);
+        }
+
+        [Fact]
+        [DisplayName("ILanguageService 預設 TryGetLangText(customizeId,...) 命中時回傳 true 並輸出正確文字")]
+        public void TryGetLangText_DefaultMethod_HitReturnsTextAndTrue()
+        {
+            var stub = new StubLanguageService();
+            stub.AddText("zh-TW", "Common", "Cancel", "取消");
+            ILanguageService svc = stub;
+
+            bool found = svc.TryGetLangText("acme", "zh-TW", "Common", "Cancel", out string text);
+
+            Assert.True(found);
+            Assert.Equal("取消", text);
+        }
+
+        [Fact]
+        [DisplayName("ILanguageService 預設 GetLangEnum(customizeId,...) 委派 GetLangEnum(lang,ns,enumName) 並回傳正確 enum")]
+        public void GetLangEnum_DefaultMethod_DelegatesToBase()
+        {
+            var langEnum = new LanguageEnum { Name = "Gender" };
+            langEnum.Entries.Add("M", "男");
+            var stub = new StubLanguageService();
+            stub.AddEnum("zh-TW", "Common", "Gender", langEnum);
+            ILanguageService svc = stub;
+
+            var result = svc.GetLangEnum("acme", "zh-TW", "Common", "Gender");
+
+            Assert.NotNull(result);
+            Assert.Equal("男", result!.GetText("M"));
+        }
+
+        [Fact]
+        [DisplayName("ILanguageService 預設 GetLangEnumText(customizeId,...) 委派 GetLangEnumText(lang,fullName,code) 並回傳正確文字")]
+        public void GetLangEnumText_DefaultMethod_DelegatesToBase()
+        {
+            var langEnum = new LanguageEnum { Name = "Gender" };
+            langEnum.Entries.Add("F", "女");
+            var stub = new StubLanguageService();
+            stub.AddEnum("zh-TW", "Common", "Gender", langEnum);
+            ILanguageService svc = stub;
+
+            string? result = svc.GetLangEnumText("acme", "zh-TW", "Common.Gender", "F");
+
+            Assert.Equal("女", result);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodsTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodsTests.cs
@@ -14,8 +14,8 @@ namespace Bee.Definition.UnitTests.Language
 
         private sealed class StubLanguageService : ILanguageService
         {
-            private readonly Dictionary<string, string> _texts = new();
-            private readonly Dictionary<string, LanguageEnum?> _enums = new();
+            private readonly Dictionary<string, string> _texts = [];
+            private readonly Dictionary<string, LanguageEnum?> _enums = [];
 
             public void AddText(string lang, string ns, string subKey, string value)
                 => _texts[$"{lang}.{ns}.{subKey}"] = value;

--- a/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using Bee.Base.Serialization;
+using Bee.Definition.Database;
 using Bee.Definition.Forms;
 using Bee.Definition.Language;
 using Bee.Definition.Layouts;
@@ -101,6 +102,20 @@ namespace Bee.Definition.UnitTests.Storage
             Assert.Throws<NotSupportedException>(() => storage.SaveFormLayout(new FormLayout()));
             Assert.Throws<NotSupportedException>(() => storage.SaveLanguage(new LanguageResource()));
             Assert.Throws<NotSupportedException>(() => storage.SaveFormSchema(new FormSchema()));
+        }
+
+        [Fact]
+        [DisplayName("SaveDbCategorySettings 應拋出 NotSupportedException（嚴格只讀）")]
+        public void SaveDbCategorySettings_ThrowsNotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveDbCategorySettings(new DbCategorySettings()));
+        }
+
+        [Fact]
+        [DisplayName("SaveTableSchema 應拋出 NotSupportedException（嚴格只讀）")]
+        public void SaveTableSchema_ThrowsNotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveTableSchema("common", new TableSchema()));
         }
 
         [Fact]


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Language/ILanguageService.cs` | 0% (4 uncovered) | 4 |
| `src/Bee.Definition/Storage/CustomizeOnlyStorage.cs` | 89.5% (2 uncovered) | 2 |
| `src/Bee.Business/IFormBoTypeResolver.cs` | 50% (1 uncovered) | 1 |

### 測試說明

**ILanguageService（新增 `ILanguageServiceDefaultMethodsTests.cs`）**
- 透過不 override default methods 的最小 stub，驗證 `GetLangText(customizeId,...)`、`TryGetLangText(customizeId,...)`、`GetLangEnum(customizeId,...)`、`GetLangEnumText(customizeId,...)` 四個 default interface methods 正確忽略 `customizeId` 並委派至對應的基底多載。

**CustomizeOnlyStorage（補強既有測試檔）**
- 補 `SaveDbCategorySettings` → 應拋出 `NotSupportedException`
- 補 `SaveTableSchema` → 應拋出 `NotSupportedException`

**IFormBoTypeResolver（補強既有 DefaultFormBoTypeResolverTests.cs）**
- 補 default interface method `Resolve(customizeId, progId)`：透過 `IFormBoTypeResolver` 介面引用，驗證委派至 `Resolve(progId)` 並回傳 `FormBusinessObject`。

### 無法處理

| 檔案 | uncovered | 原因 |
|------|-----------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | Blazor .razor 元件，需要 bunit |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | Blazor .razor 元件，需要 bunit |
| `src/Bee.UI.Core/ClientInfo.cs` | 12 | 靜態類別，依賴 network / 伺服器，不可自動測試 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 8 | Blazor code-behind，需要 bunit |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 8 | Blazor code-behind，需要 bunit |

https://claude.ai/code/session_017k9Nhko3rPuERfMTZvR1ix

---
_Generated by [Claude Code](https://claude.ai/code/session_017k9Nhko3rPuERfMTZvR1ix)_