### PR TITLE
[AutoFix] Coverage Fix (1 files) 2026-05-31 16:30

### DIFF
--- a/tests/Bee.UI.Core.UnitTests/ClientInfoResetDefineCacheTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoResetDefineCacheTests.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Client.DefineAccess;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.ResetDefineCache"/> 的測試覆蓋率。
+    /// 驗證 _defineAccess 為 null 時不拋例外（no-op），
+    /// 以及 _defineAccess 為 RemoteDefineAccess 時呼叫 ClearCache 不拋例外。
+    /// 因修改靜態狀態，納入 ClientInfoState collection 確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoResetDefineCacheTests
+    {
+        private static readonly FieldInfo s_defineAccessField =
+            typeof(ClientInfo).GetField("_defineAccess", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        [Fact]
+        [DisplayName("ResetDefineCache _defineAccess 為 null 時應直接回傳，不拋例外")]
+        public void ResetDefineCache_WhenDefineAccessIsNull_DoesNotThrow()
+        {
+            var original = s_defineAccessField.GetValue(null);
+            try
+            {
+                s_defineAccessField.SetValue(null, null);
+                var exception = Record.Exception(() => ClientInfo.ResetDefineCache());
+                Assert.Null(exception);
+            }
+            finally
+            {
+                s_defineAccessField.SetValue(null, original);
+            }
+        }
+
+        [Fact]
+        [DisplayName("ResetDefineCache _defineAccess 為 RemoteDefineAccess 時應呼叫 ClearCache 且不拋例外")]
+        public void ResetDefineCache_WhenDefineAccessIsRemoteDefineAccess_DoesNotThrow()
+        {
+            var original = s_defineAccessField.GetValue(null);
+            try
+            {
+                var connector = new SystemApiConnector(Guid.Empty);
+                var remoteAccess = new RemoteDefineAccess(connector);
+                s_defineAccessField.SetValue(null, remoteAccess);
+                var exception = Record.Exception(() => ClientInfo.ResetDefineCache());
+                Assert.Null(exception);
+            }
+            finally
+            {
+                s_defineAccessField.SetValue(null, original);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Core/ClientInfo.cs` | 83.1% | 2 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | Razor markup 生成的 `BuildRenderTree` 分支必須透過 bUnit 觸發渲染才能覆蓋，純反射無法執行 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 未覆蓋路徑（`LoginAsync` 成功後的 empty-token / success 分支）依賴真實 backend；`SystemApiConnector.LoginAsync` 非 virtual，無法在無 DI 環境下替換 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上 |

## 補強說明

`ClientInfo.ResetDefineCache` 方法自 `RemoteDefineAccess` 引入後從未被測試覆蓋。補強兩條路徑：
1. `_defineAccess` 為 `null` 時應直接回傳（null-conditional no-op）
2. `_defineAccess` 為 `RemoteDefineAccess` 實例時應呼叫 `ClearCache()` 且不拋例外

https://claude.ai/code/session_01Fbv4AeNRZLit3w39FVEEQm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fbv4AeNRZLit3w39FVEEQm)_