### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-06-01 00:30

### DIFF
--- a/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultMethodTests.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel;
+using Bee.Definition.Language;
+
+namespace Bee.Definition.UnitTests.Language
+{
+    /// <summary>
+    /// 驗證 <see cref="ILanguageService"/> 四個帶 <c>customizeId</c> 參數的預設介面方法，
+    /// 在實作類別未覆寫時，正確委派至對應的不帶 <c>customizeId</c> 的多載。
+    /// 使用僅實作必要抽象成員的最小化 stub，使 default 方法路徑得以執行。
+    /// </summary>
+    public class ILanguageServiceDefaultMethodTests
+    {
+        private sealed class BaseOnlyLanguageService : ILanguageService
+        {
+            public string GetLangText(string lang, string fullKey) => $"fullkey:{fullKey}";
+            public string GetLangText(string lang, string @namespace, string subKey) => $"ns:{@namespace}.{subKey}";
+            public bool TryGetLangText(string lang, string fullKey, out string text) { text = $"try:{fullKey}"; return true; }
+            public bool TryGetLangText(string lang, string @namespace, string subKey, out string text) { text = $"try:{@namespace}.{subKey}"; return true; }
+            public LanguageEnum? GetLangEnum(string lang, string fullName) => null;
+            public LanguageEnum? GetLangEnum(string lang, string @namespace, string enumName) => null;
+            public string? GetLangEnumText(string lang, string fullName, string code) => $"enum:{code}";
+        }
+
+        [Fact]
+        [DisplayName("GetLangText 帶 customizeId 預設實作應委派至三參數多載")]
+        public void GetLangText_FourArgDefault_DelegatesToThreeArgOverload()
+        {
+            ILanguageService svc = new BaseOnlyLanguageService();
+            var result = svc.GetLangText("cust", "zh-TW", "Common", "OK");
+            Assert.Equal("ns:Common.OK", result);
+        }
+
+        [Fact]
+        [DisplayName("TryGetLangText 帶 customizeId 預設實作應委派至四參數多載")]
+        public void TryGetLangText_FiveArgDefault_DelegatesToFourArgOverload()
+        {
+            ILanguageService svc = new BaseOnlyLanguageService();
+            var hit = svc.TryGetLangText("cust", "zh-TW", "Common", "OK", out string text);
+            Assert.True(hit);
+            Assert.Equal("try:Common.OK", text);
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnum 帶 customizeId 預設實作應委派至三參數多載")]
+        public void GetLangEnum_FourArgDefault_DelegatesToThreeArgOverload()
+        {
+            ILanguageService svc = new BaseOnlyLanguageService();
+            var result = svc.GetLangEnum("cust", "zh-TW", "Common", "Gender");
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("GetLangEnumText 帶 customizeId 預設實作應委派至三參數多載")]
+        public void GetLangEnumText_FourArgDefault_DelegatesToThreeArgOverload()
+        {
+            ILanguageService svc = new BaseOnlyLanguageService();
+            var result = svc.GetLangEnumText("cust", "zh-TW", "Common.Gender", "M");
+            Assert.Equal("enum:M", result);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using Bee.Definition;
 using Bee.Definition.Database;
 using Bee.Definition.Settings;
 using Bee.Definition.Storage;

--- a/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Database;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Definition.UnitTests.Storage
+{
+    /// <summary>
+    /// 補強 <see cref="CustomizeOnlyStorage"/> 中尚未被覆蓋的兩個 Save 方法：
+    /// <c>SaveDbCategorySettings</c> 與 <c>SaveTableSchema</c>，均應拋出
+    /// <see cref="NotSupportedException"/>（覆蓋層嚴格只讀）。
+    /// </summary>
+    public sealed class CustomizeOnlyStorageSaveTests : IDisposable
+    {
+        private readonly string _root;
+        private const string CustomizeId = "acme";
+
+        public CustomizeOnlyStorageSaveTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), $"bee-custsave-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+
+        private CustomizeOnlyStorage CreateStorage()
+            => new(new CustomizeOnlyPathOptions(_root, CustomizeId));
+
+        [Fact]
+        [DisplayName("SaveDbCategorySettings 應拋出 NotSupportedException（嚴格只讀）")]
+        public void SaveDbCategorySettings_ThrowsNotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveDbCategorySettings(new DbCategorySettings()));
+        }
+
+        [Fact]
+        [DisplayName("SaveTableSchema 應拋出 NotSupportedException（嚴格只讀）")]
+        public void SaveTableSchema_ThrowsNotSupported()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveTableSchema("common", new TableSchema()));
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Language/ILanguageService.cs` | 0.0% | 4 |
| `src/Bee.Definition/Storage/CustomizeOnlyStorage.cs` | 89.5% | 2 |

### 補強內容說明

**`ILanguageService.cs`（4 個預設介面方法）**
新增 `ILanguageServiceDefaultMethodTests`：使用僅實作必要抽象成員的 `BaseOnlyLanguageService` stub，呼叫四個帶 `customizeId` 參數的預設介面方法，驗證委派至對應的不帶 `customizeId` 多載的正確行為。

**`CustomizeOnlyStorage.cs`（2 個 Save 方法）**
新增 `CustomizeOnlyStorageSaveTests`：補 `SaveDbCategorySettings` 與 `SaveTableSchema` 兩個遺漏的 `NotSupportedException` 斷言（現有 `SaveMethods_ThrowNotSupported` 已測 `SaveFormLayout`、`SaveLanguage`、`SaveFormSchema`，但缺少這兩個）。

---

## 無法處理（本次 Top-5 均非可補項）

以下為依 `uncovered_lines` 排序後前 5 名，因結構性因素無法在 CI 單元測試中補強：

| 檔案 | 未覆蓋行數 | 無法處理原因 |
|------|----------|------------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 17 | `.razor` 模板，需要 bUnit 才能覆蓋 Razor 渲染路徑 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 17 | 同上 |
| `src/Bee.UI.Core/ClientInfo.cs` | 12 | 剩餘未覆蓋行依賴運行中的 API 伺服器（`SyncExecutor.Run → InitializeAsync`）或無法控制的命令列參數（`ParseCommandLineArgs` `KEY=VALUE` 路徑） |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 8 | `LoginAsync` 非 virtual，成功回應處理路徑需要運行中的伺服器或 mock 框架 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 8 | 同上 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeJWriXzA8xURkz5Yy8kcr)_