### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-06-01 08:49

### DIFF
--- a/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultImplTests.cs
+++ b/tests/Bee.Definition.UnitTests/Language/ILanguageServiceDefaultImplTests.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel;
+using Bee.Definition.Language;
+
+namespace Bee.Definition.UnitTests.Language
+{
+    /// <summary>
+    /// 驗證 <see cref="ILanguageService"/> 四個預設介面實作的委派行為。
+    /// 使用不覆寫這四個預設方法的最小實作類別，透過介面型別呼叫以觸發預設實作路徑。
+    /// </summary>
+    public class ILanguageServiceDefaultImplTests
+    {
+        private sealed class MinimalLanguageService : ILanguageService
+        {
+            public string GetLangText(string lang, string fullKey)
+                => $"{lang}:{fullKey}";
+
+            public string GetLangText(string lang, string @namespace, string subKey)
+                => $"{lang}:{@namespace}.{subKey}";
+
+            public bool TryGetLangText(string lang, string fullKey, out string text)
+            {
+                text = $"found:{fullKey}";
+                return true;
+            }
+
+            public bool TryGetLangText(string lang, string @namespace, string subKey, out string text)
+            {
+                text = $"found:{@namespace}.{subKey}";
+                return true;
+            }
+
+            public LanguageEnum? GetLangEnum(string lang, string fullName)
+                => new() { Name = fullName };
+
+            public LanguageEnum? GetLangEnum(string lang, string @namespace, string enumName)
+                => new() { Name = enumName };
+
+            public string? GetLangEnumText(string lang, string fullName, string code)
+                => $"{fullName}:{code}";
+        }
+
+        [Fact]
+        [DisplayName("ILanguageService 預設實作 GetLangText(4參數) 應委派給 GetLangText(3參數)")]
+        public void GetLangText_DefaultImpl4Args_DelegatesTo3ArgOverload()
+        {
+            ILanguageService svc = new MinimalLanguageService();
+            var result = svc.GetLangText("cust", "zh-TW", "Common", "OK");
+            Assert.Equal("zh-TW:Common.OK", result);
+        }
+
+        [Fact]
+        [DisplayName("ILanguageService 預設實作 TryGetLangText(5參數) 應委派給 TryGetLangText(4參數)")]
+        public void TryGetLangText_DefaultImpl5Args_DelegatesTo4ArgOverload()
+        {
+            ILanguageService svc = new MinimalLanguageService();
+            bool hit = svc.TryGetLangText("cust", "zh-TW", "Common", "OK", out string text);
+            Assert.True(hit);
+            Assert.Equal("found:Common.OK", text);
+        }
+
+        [Fact]
+        [DisplayName("ILanguageService 預設實作 GetLangEnum(4參數) 應委派給 GetLangEnum(3參數)")]
+        public void GetLangEnum_DefaultImpl4Args_DelegatesTo3ArgOverload()
+        {
+            ILanguageService svc = new MinimalLanguageService();
+            var result = svc.GetLangEnum("cust", "zh-TW", "Common", "Gender");
+            Assert.NotNull(result);
+            Assert.Equal("Gender", result!.Name);
+        }
+
+        [Fact]
+        [DisplayName("ILanguageService 預設實作 GetLangEnumText(4參數) 應委派給 GetLangEnumText(3參數)")]
+        public void GetLangEnumText_DefaultImpl4Args_DelegatesTo3ArgOverload()
+        {
+            ILanguageService svc = new MinimalLanguageService();
+            var result = svc.GetLangEnumText("cust", "zh-TW", "Common.Gender", "M");
+            Assert.Equal("Common.Gender:M", result);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Bee.Definition.Database;
 using Bee.Definition.Settings;
+using Bee.Definition.Storage;
 
 namespace Bee.Definition.UnitTests.Storage
 {

--- a/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/CustomizeOnlyStorageSaveTests.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel;
+using Bee.Definition.Database;
+using Bee.Definition.Settings;
+
+namespace Bee.Definition.UnitTests.Storage
+{
+    /// <summary>
+    /// 補強 <see cref="CustomizeOnlyStorage"/> 中尚未覆蓋的兩個只讀保護方法：
+    /// <see cref="CustomizeOnlyStorage.SaveDbCategorySettings"/> 與
+    /// <see cref="CustomizeOnlyStorage.SaveTableSchema"/>，均應拋 <see cref="NotSupportedException"/>。
+    /// </summary>
+    public sealed class CustomizeOnlyStorageSaveTests
+    {
+        private static CustomizeOnlyStorage CreateStorage()
+            => new(new CustomizeOnlyPathOptions(Path.GetTempPath(), "test-cust"));
+
+        [Fact]
+        [DisplayName("SaveDbCategorySettings 應拋出 NotSupportedException（override 層嚴格只讀）")]
+        public void SaveDbCategorySettings_ThrowsNotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveDbCategorySettings(new DbCategorySettings()));
+        }
+
+        [Fact]
+        [DisplayName("SaveTableSchema 應拋出 NotSupportedException（override 層嚴格只讀）")]
+        public void SaveTableSchema_ThrowsNotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() => CreateStorage().SaveTableSchema("common", new TableSchema()));
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Language/ILanguageService.cs` | 0% | 4 |
| `src/Bee.Definition/Storage/CustomizeOnlyStorage.cs` | 89.5% | 2 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Core/ClientInfo.cs` | 剩餘 12 行未覆蓋路徑（`EndpointStorage.SaveEndpoint`、`InitializeConnect return true`、`Arguments Endpoint arg` 分支）需要運行中的 API 伺服器或特定 process 命令列參數，已有 8 個測試檔案，CI 環境無法觸發 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 剩餘 8 行為 `SystemApiConnector.LoginAsync` 呼叫後的路徑，`LoginAsync` 非 virtual，無法透過子類別 mock，需要真實 API 伺服器 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上（與 Wasm 版本對稱，`LoginAsync` 非 virtual） |
| `src/Bee.UI.Maui/Storage/MauiPreferenceEndpointStorage.cs` | 使用 `Microsoft.Maui.Storage.Preferences.Default`，需要 MAUI 平台運行時（`net10.0` 測試環境無法初始化） |

## 變更說明

### `ILanguageServiceDefaultImplTests.cs`（新增）
測試 `ILanguageService` 介面的 4 個預設實作（default interface implementations）。因 `LanguageService` 覆寫了這 4 個方法，預設實作只能透過不覆寫它們的最小實作類別、以介面型別呼叫才能觸及。每個測試驗證預設實作正確委派給對應的 3/4 參數多載。

### `CustomizeOnlyStorageSaveTests.cs`（新增）
補強 `CustomizeOnlyStorage` 中現有測試 `SaveMethods_ThrowNotSupported` 遺漏的兩個方法：`SaveDbCategorySettings` 與 `SaveTableSchema`，均驗證拋出 `NotSupportedException`。

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC1cSGzCfQ7pysxZ9MioHW)_