### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-06-01 16:52

### DIFF
--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -4,7 +4,6 @@ using Bee.Db;
 using Bee.Definition.Database;
 using Bee.Hosting.CacheNotify;
 using Bee.ObjectCaching;
-using Bee.ObjectCaching.CacheNotify;
 using Bee.ObjectCaching.Database;
 using Bee.ObjectCaching.Define;
 
@@ -36,6 +35,7 @@ namespace Bee.Hosting.UnitTests
             public LanguageResourceCache LanguageResource => null!;
             public SessionInfoCache SessionInfo => null!;
             public CompanyInfoCache CompanyInfo => null!;
+            public bool TryEvict(string cacheKey) => false;
         }
 
         private static string InvokeNaiveNowCommandText(DatabaseType databaseType)
@@ -92,7 +92,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NegativeMarginSeconds_MarginClampedToZero()
         {
             var session = new CacheNotifyPollSession(
-                "test_db", new StubDbFactory(), new StubContainer(), new CacheNotifyRouter(), marginSeconds: -5);
+                "test_db", new StubDbFactory(), new StubContainer(), marginSeconds: -5);
             var marginField = typeof(CacheNotifyPollSession).GetField(
                 "_margin", BindingFlags.NonPublic | BindingFlags.Instance);
             var margin = (TimeSpan)marginField!.GetValue(session)!;

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -1,0 +1,102 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Db;
+using Bee.Definition.Database;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.CacheNotify;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 純單元測試：以 reflection 覆蓋 <see cref="CacheNotifyPollSession"/> 的
+    /// SQLite 路徑與不支援的資料庫類型分支，以及建構子 marginSeconds 負數 clamp 行為。
+    /// 不需要連接真實資料庫。
+    /// </summary>
+    public class CacheNotifyPollSessionUnitTests
+    {
+        private static readonly DatabaseType s_unsupportedDbType = (DatabaseType)99;
+
+        private sealed class StubDbFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new InvalidOperationException("stub");
+        }
+
+        private sealed class StubContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => null!;
+            public DatabaseSettingsCache DatabaseSettings => null!;
+            public ProgramSettingsCache ProgramSettings => null!;
+            public DbCategorySettingsCache DbCategorySettings => null!;
+            public TableSchemaCache TableSchema => null!;
+            public FormSchemaCache FormSchema => null!;
+            public FormLayoutCache FormLayout => null!;
+            public LanguageResourceCache LanguageResource => null!;
+            public SessionInfoCache SessionInfo => null!;
+            public CompanyInfoCache CompanyInfo => null!;
+        }
+
+        private static string InvokeNaiveNowCommandText(DatabaseType databaseType)
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "NaiveNowCommandText", BindingFlags.NonPublic | BindingFlags.Static);
+            return (string)method!.Invoke(null, new object[] { databaseType })!;
+        }
+
+        private static (string Format, string CastTemplate) InvokeThresholdBinding(DatabaseType databaseType)
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "ThresholdBinding", BindingFlags.NonPublic | BindingFlags.Static);
+            return ((string, string))method!.Invoke(null, new object[] { databaseType })!;
+        }
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText 對 SQLite 應回傳 SELECT CURRENT_TIMESTAMP")]
+        public void NaiveNowCommandText_SQLite_ReturnsSelectCurrentTimestamp()
+        {
+            var result = InvokeNaiveNowCommandText(DatabaseType.SQLite);
+            Assert.Equal("SELECT CURRENT_TIMESTAMP", result);
+        }
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText 對未支援的資料庫類型應拋 NotSupportedException")]
+        public void NaiveNowCommandText_UnsupportedDatabaseType_ThrowsNotSupportedException()
+        {
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                InvokeNaiveNowCommandText(s_unsupportedDbType));
+            Assert.IsType<NotSupportedException>(ex.InnerException);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding 對 SQLite 應回傳 'yyyy-MM-dd HH:mm:ss' 格式與 '{0}' cast 模板")]
+        public void ThresholdBinding_SQLite_ReturnsExpectedFormatAndCastTemplate()
+        {
+            var (format, castTemplate) = InvokeThresholdBinding(DatabaseType.SQLite);
+            Assert.Equal("yyyy-MM-dd HH:mm:ss", format);
+            Assert.Equal("{0}", castTemplate);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding 對未支援的資料庫類型應拋 NotSupportedException")]
+        public void ThresholdBinding_UnsupportedDatabaseType_ThrowsNotSupportedException()
+        {
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                InvokeThresholdBinding(s_unsupportedDbType));
+            Assert.IsType<NotSupportedException>(ex.InnerException);
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 建構子 marginSeconds 為負數時 _margin 應被 clamp 為 TimeSpan.Zero")]
+        public void Constructor_NegativeMarginSeconds_MarginClampedToZero()
+        {
+            var session = new CacheNotifyPollSession(
+                "test_db", new StubDbFactory(), new StubContainer(), new CacheNotifyRouter(), marginSeconds: -5);
+            var marginField = typeof(CacheNotifyPollSession).GetField(
+                "_margin", BindingFlags.NonPublic | BindingFlags.Instance);
+            var margin = (TimeSpan)marginField!.GetValue(session)!;
+            Assert.Equal(TimeSpan.Zero, margin);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -4,6 +4,7 @@ using Bee.Db;
 using Bee.Definition.Database;
 using Bee.Hosting.CacheNotify;
 using Bee.ObjectCaching;
+using Bee.ObjectCaching.CacheNotify;
 using Bee.ObjectCaching.Database;
 using Bee.ObjectCaching.Define;
 
@@ -35,7 +36,6 @@ namespace Bee.Hosting.UnitTests
             public LanguageResourceCache LanguageResource => null!;
             public SessionInfoCache SessionInfo => null!;
             public CompanyInfoCache CompanyInfo => null!;
-            public bool TryEvict(string cacheKey) => false;
         }
 
         private static string InvokeNaiveNowCommandText(DatabaseType databaseType)
@@ -92,7 +92,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NegativeMarginSeconds_MarginClampedToZero()
         {
             var session = new CacheNotifyPollSession(
-                "test_db", new StubDbFactory(), new StubContainer(), marginSeconds: -5);
+                "test_db", new StubDbFactory(), new StubContainer(), new CacheNotifyRouter(), marginSeconds: -5);
             var marginField = typeof(CacheNotifyPollSession).GetField(
                 "_margin", BindingFlags.NonPublic | BindingFlags.Instance);
             var margin = (TimeSpan)marginField!.GetValue(session)!;

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -9,6 +9,7 @@ using Bee.ObjectCaching.CacheNotify;
 using Bee.ObjectCaching.Database;
 using Bee.ObjectCaching.Define;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Bee.Hosting.UnitTests
 {

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -5,6 +5,7 @@ using Bee.Db;
 using Bee.Definition.Settings;
 using Bee.Hosting.CacheNotify;
 using Bee.ObjectCaching;
+using Bee.ObjectCaching.CacheNotify;
 using Bee.ObjectCaching.Database;
 using Bee.ObjectCaching.Define;
 using Microsoft.Extensions.Logging;
@@ -45,7 +46,12 @@ namespace Bee.Hosting.UnitTests
             public LanguageResourceCache LanguageResource => null!;
             public SessionInfoCache SessionInfo => null!;
             public CompanyInfoCache CompanyInfo => null!;
-            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private sealed class StubRouter : ICacheNotifyRouter
+        {
+            public void Register(string cacheGroup, Action<ICacheContainer, string> evict) { }
+            public bool TryInvoke(ICacheContainer container, string cacheKey) => false;
         }
 
         private sealed class TestDbException : DbException
@@ -58,7 +64,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(null!, new StubContainer(), s_options, s_logger));
+                new CacheNotifyPoller(null!, new StubContainer(), new StubRouter(), s_options, s_logger));
         }
 
         [Fact]
@@ -66,7 +72,15 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullContainer_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), null!, s_options, s_logger));
+                new CacheNotifyPoller(new StubDbFactory(), null!, new StubRouter(), s_options, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子傳入 null router 應拋 ArgumentNullException")]
+        public void Constructor_NullRouter_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), null!, s_options, s_logger));
         }
 
         [Fact]
@@ -74,7 +88,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullOptions_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), null!, s_logger));
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), null!, s_logger));
         }
 
         [Fact]
@@ -82,7 +96,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullLogger_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), s_options, null!));
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), s_options, null!));
         }
 
         private static Task RunExecuteAsync(CacheNotifyPoller poller, CancellationToken cancellationToken)
@@ -97,7 +111,7 @@ namespace Bee.Hosting.UnitTests
         public async Task ExecuteAsync_SafePollThrowsDbException_ExceptionSwallowed()
         {
             var factory = new ThrowingDbFactory(new TestDbException("db error"));
-            var poller = new CacheNotifyPoller(factory, new StubContainer(), s_options, s_logger);
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));
@@ -109,7 +123,7 @@ namespace Bee.Hosting.UnitTests
         public async Task ExecuteAsync_SafePollThrowsInvalidOperationException_ExceptionSwallowed()
         {
             var factory = new ThrowingDbFactory(new InvalidOperationException("invalid op"));
-            var poller = new CacheNotifyPoller(factory, new StubContainer(), s_options, s_logger);
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -5,7 +5,6 @@ using Bee.Db;
 using Bee.Definition.Settings;
 using Bee.Hosting.CacheNotify;
 using Bee.ObjectCaching;
-using Bee.ObjectCaching.CacheNotify;
 using Bee.ObjectCaching.Database;
 using Bee.ObjectCaching.Define;
 using Microsoft.Extensions.Logging;
@@ -46,12 +45,7 @@ namespace Bee.Hosting.UnitTests
             public LanguageResourceCache LanguageResource => null!;
             public SessionInfoCache SessionInfo => null!;
             public CompanyInfoCache CompanyInfo => null!;
-        }
-
-        private sealed class StubRouter : ICacheNotifyRouter
-        {
-            public void Register(string cacheGroup, Action<ICacheContainer, string> evict) { }
-            public bool TryInvoke(ICacheContainer container, string cacheKey) => false;
+            public bool TryEvict(string cacheKey) => false;
         }
 
         private sealed class TestDbException : DbException
@@ -64,7 +58,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(null!, new StubContainer(), new StubRouter(), s_options, s_logger));
+                new CacheNotifyPoller(null!, new StubContainer(), s_options, s_logger));
         }
 
         [Fact]
@@ -72,15 +66,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullContainer_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), null!, new StubRouter(), s_options, s_logger));
-        }
-
-        [Fact]
-        [DisplayName("CacheNotifyPoller 建構子傳入 null router 應拋 ArgumentNullException")]
-        public void Constructor_NullRouter_ThrowsArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), null!, s_options, s_logger));
+                new CacheNotifyPoller(new StubDbFactory(), null!, s_options, s_logger));
         }
 
         [Fact]
@@ -88,7 +74,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullOptions_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), null!, s_logger));
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), null!, s_logger));
         }
 
         [Fact]
@@ -96,7 +82,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullLogger_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), s_options, null!));
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), s_options, null!));
         }
 
         private static Task RunExecuteAsync(CacheNotifyPoller poller, CancellationToken cancellationToken)
@@ -111,7 +97,7 @@ namespace Bee.Hosting.UnitTests
         public async Task ExecuteAsync_SafePollThrowsDbException_ExceptionSwallowed()
         {
             var factory = new ThrowingDbFactory(new TestDbException("db error"));
-            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), s_options, s_logger);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));
@@ -123,7 +109,7 @@ namespace Bee.Hosting.UnitTests
         public async Task ExecuteAsync_SafePollThrowsInvalidOperationException_ExceptionSwallowed()
         {
             var factory = new ThrowingDbFactory(new InvalidOperationException("invalid op"));
-            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), s_options, s_logger);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -1,0 +1,132 @@
+using System.ComponentModel;
+using System.Data.Common;
+using System.Reflection;
+using Bee.Db;
+using Bee.Definition.Settings;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.CacheNotify;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Microsoft.Extensions.Logging;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 純單元測試：覆蓋 <see cref="CacheNotifyPoller"/> 建構子 null 檢查
+    /// 與 <c>SafePoll</c> 例外吞噬行為，無需連接真實資料庫。
+    /// </summary>
+    public class CacheNotifyPollerUnitTests
+    {
+        private static readonly CacheNotifyOptions s_options = new() { IntervalSeconds = 1 };
+        private static readonly ILogger<CacheNotifyPoller> s_logger = NullLogger<CacheNotifyPoller>.Instance;
+
+        private sealed class StubDbFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new InvalidOperationException("stub");
+        }
+
+        private sealed class ThrowingDbFactory : IDbAccessFactory
+        {
+            private readonly Exception _exception;
+            public ThrowingDbFactory(Exception exception) => _exception = exception;
+            public DbAccess Create(string databaseId) => throw _exception;
+        }
+
+        private sealed class StubRouter : ICacheNotifyRouter
+        {
+            public void Register(string cacheGroup, Action<ICacheContainer, string> evict) { }
+            public bool TryInvoke(ICacheContainer container, string cacheKey) => false;
+        }
+
+        private sealed class StubContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => null!;
+            public DatabaseSettingsCache DatabaseSettings => null!;
+            public ProgramSettingsCache ProgramSettings => null!;
+            public DbCategorySettingsCache DbCategorySettings => null!;
+            public TableSchemaCache TableSchema => null!;
+            public FormSchemaCache FormSchema => null!;
+            public FormLayoutCache FormLayout => null!;
+            public LanguageResourceCache LanguageResource => null!;
+            public SessionInfoCache SessionInfo => null!;
+            public CompanyInfoCache CompanyInfo => null!;
+        }
+
+        private sealed class TestDbException : DbException
+        {
+            public TestDbException(string message) : base(message) { }
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(null!, new StubContainer(), new StubRouter(), s_options, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子傳入 null container 應拋 ArgumentNullException")]
+        public void Constructor_NullContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(new StubDbFactory(), null!, new StubRouter(), s_options, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子傳入 null router 應拋 ArgumentNullException")]
+        public void Constructor_NullRouter_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), null!, s_options, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子傳入 null options 應拋 ArgumentNullException")]
+        public void Constructor_NullOptions_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), null!, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子傳入 null logger 應拋 ArgumentNullException")]
+        public void Constructor_NullLogger_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), s_options, null!));
+        }
+
+        private static Task RunExecuteAsync(CacheNotifyPoller poller, CancellationToken cancellationToken)
+        {
+            var method = typeof(CacheNotifyPoller).GetMethod(
+                "ExecuteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (Task)method!.Invoke(poller, new object[] { cancellationToken })!;
+        }
+
+        [Fact]
+        [DisplayName("SafePoll 遇到 DbException 應捕捉例外、不向外拋（輪詢不中斷）")]
+        public async Task ExecuteAsync_SafePollThrowsDbException_ExceptionSwallowed()
+        {
+            var factory = new ThrowingDbFactory(new TestDbException("db error"));
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("SafePoll 遇到 InvalidOperationException 應捕捉例外、不向外拋（輪詢不中斷）")]
+        public async Task ExecuteAsync_SafePollThrowsInvalidOperationException_ExceptionSwallowed()
+        {
+            var factory = new ThrowingDbFactory(new InvalidOperationException("invalid op"));
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -5,7 +5,6 @@ using Bee.Db;
 using Bee.Definition.Settings;
 using Bee.Hosting.CacheNotify;
 using Bee.ObjectCaching;
-using Bee.ObjectCaching.CacheNotify;
 using Bee.ObjectCaching.Database;
 using Bee.ObjectCaching.Define;
 using Microsoft.Extensions.Logging;
@@ -34,12 +33,6 @@ namespace Bee.Hosting.UnitTests
             public DbAccess Create(string databaseId) => throw _exception;
         }
 
-        private sealed class StubRouter : ICacheNotifyRouter
-        {
-            public void Register(string cacheGroup, Action<ICacheContainer, string> evict) { }
-            public bool TryInvoke(ICacheContainer container, string cacheKey) => false;
-        }
-
         private sealed class StubContainer : ICacheContainer
         {
             public SystemSettingsCache SystemSettings => null!;
@@ -52,6 +45,7 @@ namespace Bee.Hosting.UnitTests
             public LanguageResourceCache LanguageResource => null!;
             public SessionInfoCache SessionInfo => null!;
             public CompanyInfoCache CompanyInfo => null!;
+            public bool TryEvict(string cacheKey) => false;
         }
 
         private sealed class TestDbException : DbException
@@ -64,7 +58,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(null!, new StubContainer(), new StubRouter(), s_options, s_logger));
+                new CacheNotifyPoller(null!, new StubContainer(), s_options, s_logger));
         }
 
         [Fact]
@@ -72,15 +66,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullContainer_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), null!, new StubRouter(), s_options, s_logger));
-        }
-
-        [Fact]
-        [DisplayName("CacheNotifyPoller 建構子傳入 null router 應拋 ArgumentNullException")]
-        public void Constructor_NullRouter_ThrowsArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), null!, s_options, s_logger));
+                new CacheNotifyPoller(new StubDbFactory(), null!, s_options, s_logger));
         }
 
         [Fact]
@@ -88,7 +74,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullOptions_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), null!, s_logger));
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), null!, s_logger));
         }
 
         [Fact]
@@ -96,7 +82,7 @@ namespace Bee.Hosting.UnitTests
         public void Constructor_NullLogger_ThrowsArgumentNullException()
         {
             Assert.Throws<ArgumentNullException>(() =>
-                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), new StubRouter(), s_options, null!));
+                new CacheNotifyPoller(new StubDbFactory(), new StubContainer(), s_options, null!));
         }
 
         private static Task RunExecuteAsync(CacheNotifyPoller poller, CancellationToken cancellationToken)
@@ -111,7 +97,7 @@ namespace Bee.Hosting.UnitTests
         public async Task ExecuteAsync_SafePollThrowsDbException_ExceptionSwallowed()
         {
             var factory = new ThrowingDbFactory(new TestDbException("db error"));
-            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), s_options, s_logger);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));
@@ -123,7 +109,7 @@ namespace Bee.Hosting.UnitTests
         public async Task ExecuteAsync_SafePollThrowsInvalidOperationException_ExceptionSwallowed()
         {
             var factory = new ThrowingDbFactory(new InvalidOperationException("invalid op"));
-            var poller = new CacheNotifyPoller(factory, new StubContainer(), new StubRouter(), s_options, s_logger);
+            var poller = new CacheNotifyPoller(factory, new StubContainer(), s_options, s_logger);
             using var cts = new CancellationTokenSource();
             cts.Cancel();
             var exception = await Record.ExceptionAsync(() => RunExecuteAsync(poller, cts.Token));

--- a/tests/Bee.Hosting.UnitTests/CustomizationWiringTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CustomizationWiringTests.cs
@@ -4,7 +4,6 @@ using Bee.Definition;
 using Bee.Definition.Layouts;
 using Bee.Definition.Settings;
 using Bee.Definition.Storage;
-using Bee.Hosting;
 using Bee.ObjectCaching;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/tests/Bee.Hosting.UnitTests/CustomizationWiringTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CustomizationWiringTests.cs
@@ -4,6 +4,7 @@ using Bee.Definition;
 using Bee.Definition.Layouts;
 using Bee.Definition.Settings;
 using Bee.Definition.Storage;
+using Bee.Hosting;
 using Bee.ObjectCaching;
 using Microsoft.Extensions.DependencyInjection;
 


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Hosting/CacheNotify/CacheNotifyPoller.cs` | 0% | 7 |
| `src/Bee.Hosting/CacheNotify/CacheNotifyPollSession.cs` | 83.1% | 5 |

### 測試內容說明

**`CacheNotifyPollerUnitTests.cs`**（新增，對應 `CacheNotifyPoller.cs`）
- 建構子 5 個參數的 null guard 各 1 個測試
- `SafePoll` 遇到 `DbException` 例外吞噬行為
- `SafePoll` 遇到 `InvalidOperationException` 例外吞噬行為

**`CacheNotifyPollSessionUnitTests.cs`**（新增，對應 `CacheNotifyPollSession.cs`）
- `NaiveNowCommandText` SQLite case
- `NaiveNowCommandText` 不支援的資料庫類型拋 `NotSupportedException`
- `ThresholdBinding` SQLite case（格式字串與 cast 模板）
- `ThresholdBinding` 不支援的資料庫類型拋 `NotSupportedException`
- 建構子 `marginSeconds < 0` 時 margin clamp 為 `TimeSpan.Zero`

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | `.razor` 模板渲染行需要 bUnit，目前測試專案未引入 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |
| `src/Bee.UI.Core/ClientInfo.cs` | 剩餘 12 行為需執行中 API 服務才能覆蓋的路徑（`SaveEndpoint`、`return true` 等），無法在純單元測試環境下觸及 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjuLHcFPRGqzUpsa8peK12)_