### PR TITLE
[AutoFix] SonarCloud Issues (2 issues) 2026-06-02 00:00

### DIFF
--- a/tests/Bee.Db.UnitTests/DbDefineStorageTests.cs
+++ b/tests/Bee.Db.UnitTests/DbDefineStorageTests.cs
@@ -181,7 +181,7 @@ namespace Bee.Db.UnitTests
             Assert.NotNull(storage.GetCustomizeFormLayout(customizeId, layoutId));
 
             // Language override (composite "lang.ns" key).
-            string lang = "rt-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+            string lang = string.Concat("rt-", Guid.NewGuid().ToString("N").AsSpan(0, 8));
             const string ns = "common";
             SeedCustomizeRow(databaseType, "LanguageResource", customizeId, $"{lang}.{ns}",
                 XmlCodec.Serialize(new LanguageResource { Lang = lang, Namespace = ns }));

--- a/tests/Bee.Db.UnitTests/DbDefineStorageTests.cs
+++ b/tests/Bee.Db.UnitTests/DbDefineStorageTests.cs
@@ -84,7 +84,7 @@ namespace Bee.Db.UnitTests
             Assert.Equal(layoutId, storage.GetFormLayout(layoutId)!.LayoutId);
 
             // --- Language (optional: missing returns null; then round-trips) ---
-            string lang = "rt-" + Guid.NewGuid().ToString("N").Substring(0, 8);
+            string lang = string.Concat("rt-", Guid.NewGuid().ToString("N").AsSpan(0, 8));
             const string ns = "common";
             Assert.Null(storage.GetLanguage(lang, ns));
 


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ6DoHb_xhoxqMM9YpqB | external_roslyn:CA1845 | `tests/Bee.Db.UnitTests/DbDefineStorageTests.cs` L87 | `RunRoundTrip` 內以 `string.Concat("rt-", ...AsSpan(0, 8))` 取代 `"rt-" + ...Substring(0, 8)` |
| AZ6Dq_KJUpn8FbF7eAJ3 | external_roslyn:CA1845 | `tests/Bee.Db.UnitTests/DbDefineStorageTests.cs` L184 | `RunCustomizeOverlay` 內以 `string.Concat("rt-", ...AsSpan(0, 8))` 取代 `"rt-" + ...Substring(0, 8)` |

---

### 無法處理（需人工判斷）

| Issue Key | Rule | 檔案 | 原因 |
|-----------|------|------|------|
| AZ6B--9ZbWHmcSo44Qpm | csharpsquid:S125 | `src/Bee.Db/CacheNotify/CacheNotifyService.cs` L83 | 依 `sonarcloud.md` 規則，S125 一律列入人工審查。該處為 WHY 說明型英文註解（解釋 HOLDLOCK 的用途及 SQL Server MERGE 語法需求），高機率為誤判（false positive）；建議在 SonarCloud UI 標記為 *False Positive*。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuQPFASLobfjDd53UMjsL1)_