### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-06-02 00:30

### DIFF
--- a/tests/Bee.Hosting.UnitTests/Bee.Hosting.UnitTests.csproj
+++ b/tests/Bee.Hosting.UnitTests/Bee.Hosting.UnitTests.csproj
@@ -14,6 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionPrivateMethodTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionPrivateMethodTests.cs
@@ -1,0 +1,65 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Definition.Database;
+using Bee.Hosting.CacheNotify;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="CacheNotifyPollSession"/> 兩個 private static 方法的覆蓋率：
+    /// <c>NaiveNowCommandText</c> 與 <c>ThresholdBinding</c>。
+    /// 已有 DB 整合測試覆蓋 SQL Server / PostgreSQL / MySQL / Oracle 四個分支；
+    /// 本類別補 SQLite 分支與不支援型別的 NotSupportedException。
+    /// </summary>
+    public class CacheNotifyPollSessionPrivateMethodTests
+    {
+        private static readonly MethodInfo s_naiveNowMethod =
+            typeof(CacheNotifyPollSession).GetMethod(
+                "NaiveNowCommandText",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly MethodInfo s_thresholdBindingMethod =
+            typeof(CacheNotifyPollSession).GetMethod(
+                "ThresholdBinding",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        private static readonly object[] s_sqliteArg = { DatabaseType.SQLite };
+        private static readonly object[] s_unsupportedDbArg = { (DatabaseType)99 };
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText SQLite 應回傳 SELECT CURRENT_TIMESTAMP")]
+        public void NaiveNowCommandText_SQLite_ReturnsCurrentTimestampQuery()
+        {
+            var result = (string)s_naiveNowMethod.Invoke(null, s_sqliteArg)!;
+            Assert.Equal("SELECT CURRENT_TIMESTAMP", result);
+        }
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText 不支援的 DatabaseType 應拋 NotSupportedException")]
+        public void NaiveNowCommandText_UnsupportedDatabaseType_ThrowsNotSupportedException()
+        {
+            var ex = Assert.Throws<TargetInvocationException>(
+                () => s_naiveNowMethod.Invoke(null, s_unsupportedDbArg));
+            Assert.IsType<NotSupportedException>(ex.InnerException);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding SQLite 應回傳 yyyy-MM-dd HH:mm:ss 格式與 {0} 範本")]
+        public void ThresholdBinding_SQLite_ReturnsCorrectFormatAndCastTemplate()
+        {
+            var result = s_thresholdBindingMethod.Invoke(null, s_sqliteArg);
+            var (format, castTemplate) = ((string, string))result!;
+            Assert.Equal("yyyy-MM-dd HH:mm:ss", format);
+            Assert.Equal("{0}", castTemplate);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding 不支援的 DatabaseType 應拋 NotSupportedException")]
+        public void ThresholdBinding_UnsupportedDatabaseType_ThrowsNotSupportedException()
+        {
+            var ex = Assert.Throws<TargetInvocationException>(
+                () => s_thresholdBindingMethod.Invoke(null, s_unsupportedDbArg));
+            Assert.IsType<NotSupportedException>(ex.InnerException);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Definition.Settings;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Microsoft.Extensions.Logging;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheNotifyPoller"/> 建構子守衛與 ExecuteAsync 容錯行為的單元測試。
+    /// 不依賴真實資料庫——以 stub 讓 SafePoll 觸發並確認例外被吸收。
+    /// </summary>
+    public class CacheNotifyPollerUnitTests
+    {
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) =>
+                throw new InvalidOperationException("Stub：無真實資料庫連線。");
+        }
+
+        private sealed class StubCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => throw new NotImplementedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotImplementedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotImplementedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotImplementedException();
+            public TableSchemaCache TableSchema => throw new NotImplementedException();
+            public FormSchemaCache FormSchema => throw new NotImplementedException();
+            public FormLayoutCache FormLayout => throw new NotImplementedException();
+            public LanguageResourceCache LanguageResource => throw new NotImplementedException();
+            public SessionInfoCache SessionInfo => throw new NotImplementedException();
+            public CompanyInfoCache CompanyInfo => throw new NotImplementedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        [Fact]
+        [DisplayName("建構子 dbAccessFactory 為 null 應拋 ArgumentNullException")]
+        public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CacheNotifyPoller(
+                null!,
+                new StubCacheContainer(),
+                new CacheNotifyOptions(),
+                NullLogger<CacheNotifyPoller>.Instance));
+        }
+
+        [Fact]
+        [DisplayName("建構子 container 為 null 應拋 ArgumentNullException")]
+        public void Ctor_NullContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CacheNotifyPoller(
+                new StubDbAccessFactory(),
+                null!,
+                new CacheNotifyOptions(),
+                NullLogger<CacheNotifyPoller>.Instance));
+        }
+
+        [Fact]
+        [DisplayName("建構子 options 為 null 應拋 ArgumentNullException")]
+        public void Ctor_NullOptions_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CacheNotifyPoller(
+                new StubDbAccessFactory(),
+                new StubCacheContainer(),
+                null!,
+                NullLogger<CacheNotifyPoller>.Instance));
+        }
+
+        [Fact]
+        [DisplayName("建構子 logger 為 null 應拋 ArgumentNullException")]
+        public void Ctor_NullLogger_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new CacheNotifyPoller(
+                new StubDbAccessFactory(),
+                new StubCacheContainer(),
+                new CacheNotifyOptions(),
+                null!));
+        }
+
+        [Fact]
+        [DisplayName("ExecuteAsync SafePoll 中例外應被吸收，StopAsync 應正常完成")]
+        public async Task ExecuteAsync_InvalidOperationExceptionInPoll_StopAsyncCompletesWithoutException()
+        {
+            var poller = new CacheNotifyPoller(
+                new StubDbAccessFactory(),
+                new StubCacheContainer(),
+                new CacheNotifyOptions { DatabaseId = "test", IntervalSeconds = 60 },
+                NullLogger<CacheNotifyPoller>.Instance);
+
+            using var cts = new CancellationTokenSource();
+            await poller.StartAsync(cts.Token);
+
+            var exception = await Record.ExceptionAsync(() => poller.StopAsync(CancellationToken.None));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -36,6 +36,15 @@ namespace Bee.Hosting.UnitTests
             public bool TryEvict(string cacheKey) => false;
         }
 
+        private sealed class FakeLogger : ILogger<CacheNotifyPoller>
+        {
+            public static readonly FakeLogger Instance = new();
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter) { }
+        }
+
         [Fact]
         [DisplayName("建構子 dbAccessFactory 為 null 應拋 ArgumentNullException")]
         public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
@@ -44,7 +53,7 @@ namespace Bee.Hosting.UnitTests
                 null!,
                 new StubCacheContainer(),
                 new CacheNotifyOptions(),
-                NullLogger<CacheNotifyPoller>.Instance));
+                FakeLogger.Instance));
         }
 
         [Fact]
@@ -55,7 +64,7 @@ namespace Bee.Hosting.UnitTests
                 new StubDbAccessFactory(),
                 null!,
                 new CacheNotifyOptions(),
-                NullLogger<CacheNotifyPoller>.Instance));
+                FakeLogger.Instance));
         }
 
         [Fact]
@@ -66,7 +75,7 @@ namespace Bee.Hosting.UnitTests
                 new StubDbAccessFactory(),
                 new StubCacheContainer(),
                 null!,
-                NullLogger<CacheNotifyPoller>.Instance));
+                FakeLogger.Instance));
         }
 
         [Fact]
@@ -88,7 +97,7 @@ namespace Bee.Hosting.UnitTests
                 new StubDbAccessFactory(),
                 new StubCacheContainer(),
                 new CacheNotifyOptions { DatabaseId = "test", IntervalSeconds = 60 },
-                NullLogger<CacheNotifyPoller>.Instance);
+                FakeLogger.Instance);
 
             using var cts = new CancellationTokenSource();
             await poller.StartAsync(cts.Token);


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Hosting/CacheNotify/CacheNotifyPoller.cs` | 0.0% | 5 |
| `src/Bee.Hosting/CacheNotify/CacheNotifyPollSession.cs` | 82.4% | 4 |

### 無法處理（共 3 項）

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | Blazor UI 元件；需 bUnit 渲染測試，測試專案尚未引入 bUnit |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |
| `src/Bee.UI.Core/ClientInfo.cs` | 剩餘 12 行均需 API 伺服器正常運作（`InitializeConnect` 成功路徑、`SetEndpoint` 完成後的 `SaveEndpoint`）或 command-line 注入（`Endpoint=xxx`），無法在 CI 中覆蓋 |

### 新增測試說明

**CacheNotifyPollerUnitTests.cs**（5 個測試）
- 建構子四個參數的 null 守衛（`ArgumentNullException`）
- `ExecuteAsync`：`SafePoll` 拋出 `InvalidOperationException` 時被吸收，`StopAsync` 正常完成

**CacheNotifyPollSessionPrivateMethodTests.cs**（4 個測試）
- `NaiveNowCommandText(SQLite)` 回傳正確 SQL
- `NaiveNowCommandText(不支援類型)` 拋 `NotSupportedException`
- `ThresholdBinding(SQLite)` 回傳正確格式字串與 SQL 範本
- `ThresholdBinding(不支援類型)` 拋 `NotSupportedException`

---
_Generated by [Claude Code](https://claude.ai/code/session_0141mkRECkJErQjYJaVPfKeh)_