### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-06-02 08:30

### DIFF
--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -44,7 +44,7 @@ namespace Bee.Hosting.UnitTests
         [DisplayName("CacheNotifyPollSession 傳入 null 或空白 databaseId 應拋 ArgumentException")]
         public void Constructor_NullOrWhitespaceDatabaseId_ThrowsArgumentException(string? databaseId)
         {
-            Assert.Throws<ArgumentException>(() =>
+            Assert.ThrowsAny<ArgumentException>(() =>
                 new CacheNotifyPollSession(databaseId!, ValidFactory, ValidContainer, 5));
         }
 

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -1,0 +1,135 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Db;
+using Bee.Definition.Database;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheNotifyPollSession"/> 純邏輯路徑的單元測試（不依賴資料庫）：
+    /// 建構式引數驗證、負數 margin 的截斷行為，以及 SQLite 與不支援 DatabaseType 的 switch 分支。
+    /// </summary>
+    public class CacheNotifyPollSessionUnitTests
+    {
+        private static FakeDbAccessFactory ValidFactory => new();
+        private static FakeCacheContainer ValidContainer => new();
+
+        // 以反射呼叫私有靜態方法 NaiveNowCommandText
+        private static string InvokeNaiveNowCommandText(DatabaseType databaseType)
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "NaiveNowCommandText",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null, new object[] { databaseType })!;
+        }
+
+        // 以反射呼叫私有靜態方法 ThresholdBinding
+        private static object InvokeThresholdBinding(DatabaseType databaseType)
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "ThresholdBinding",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return method!.Invoke(null, new object[] { databaseType })!;
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("   ")]
+        [DisplayName("CacheNotifyPollSession 傳入 null 或空白 databaseId 應拋 ArgumentException")]
+        public void Constructor_NullOrWhitespaceDatabaseId_ThrowsArgumentException(string? databaseId)
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CacheNotifyPollSession(databaseId!, ValidFactory, ValidContainer, 5));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPollSession("common", null!, ValidContainer, 5));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 傳入 null container 應拋 ArgumentNullException")]
+        public void Constructor_NullContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPollSession("common", ValidFactory, null!, 5));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession marginSeconds 為負數時應以 TimeSpan.Zero 作為 margin")]
+        public void Constructor_NegativeMarginSeconds_UsesZeroMargin()
+        {
+            var session = new CacheNotifyPollSession("common", ValidFactory, ValidContainer, -1);
+            var marginField = typeof(CacheNotifyPollSession).GetField(
+                "_margin", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(marginField);
+            var margin = (TimeSpan)marginField!.GetValue(session)!;
+            Assert.Equal(TimeSpan.Zero, margin);
+        }
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText SQLite 應回傳 SELECT CURRENT_TIMESTAMP")]
+        public void NaiveNowCommandText_SQLite_ReturnsCurrentTimestampQuery()
+        {
+            var result = InvokeNaiveNowCommandText(DatabaseType.SQLite);
+            Assert.Equal("SELECT CURRENT_TIMESTAMP", result);
+        }
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText 不支援的 DatabaseType 應拋 NotSupportedException")]
+        public void NaiveNowCommandText_UnsupportedDatabaseType_ThrowsNotSupportedException()
+        {
+            var ex = Record.Exception(() => InvokeNaiveNowCommandText((DatabaseType)99));
+            Assert.NotNull(ex);
+            Assert.IsType<NotSupportedException>(ex.InnerException ?? ex);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding SQLite 應回傳 yyyy-MM-dd HH:mm:ss 格式與直通 castTemplate")]
+        public void ThresholdBinding_SQLite_ReturnsExpectedFormatAndTemplate()
+        {
+            var result = InvokeThresholdBinding(DatabaseType.SQLite);
+            Assert.NotNull(result);
+            var resultStr = result.ToString()!;
+            Assert.Contains("yyyy-MM-dd HH:mm:ss", resultStr);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding 不支援的 DatabaseType 應拋 NotSupportedException")]
+        public void ThresholdBinding_UnsupportedDatabaseType_ThrowsNotSupportedException()
+        {
+            var ex = Record.Exception(() => InvokeThresholdBinding((DatabaseType)99));
+            Assert.NotNull(ex);
+            Assert.IsType<NotSupportedException>(ex.InnerException ?? ex);
+        }
+
+        private sealed class FakeDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class FakeCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => null!;
+            public DatabaseSettingsCache DatabaseSettings => null!;
+            public ProgramSettingsCache ProgramSettings => null!;
+            public DbCategorySettingsCache DbCategorySettings => null!;
+            public TableSchemaCache TableSchema => null!;
+            public FormSchemaCache FormSchema => null!;
+            public FormLayoutCache FormLayout => null!;
+            public LanguageResourceCache LanguageResource => null!;
+            public SessionInfoCache SessionInfo => null!;
+            public CompanyInfoCache CompanyInfo => null!;
+            public bool TryEvict(string cacheKey) => false;
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerConstructorTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerConstructorTests.cs
@@ -1,0 +1,92 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Definition.Settings;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Microsoft.Extensions.Logging;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheNotifyPoller"/> 建構式的 null 引數驗證測試。
+    /// 不依賴資料庫，覆蓋 0% 覆蓋率的建構式程式碼。
+    /// </summary>
+    public class CacheNotifyPollerConstructorTests
+    {
+        private static FakeDbAccessFactory ValidFactory => new();
+        private static FakeCacheContainer ValidContainer => new();
+        private static CacheNotifyOptions ValidOptions => new();
+        private static ILogger<CacheNotifyPoller> ValidLogger => new FakeLogger<CacheNotifyPoller>();
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(null!, ValidContainer, ValidOptions, ValidLogger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null container 應拋 ArgumentNullException")]
+        public void Constructor_NullContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(ValidFactory, null!, ValidOptions, ValidLogger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null options 應拋 ArgumentNullException")]
+        public void Constructor_NullOptions_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(ValidFactory, ValidContainer, null!, ValidLogger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null logger 應拋 ArgumentNullException")]
+        public void Constructor_NullLogger_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(ValidFactory, ValidContainer, ValidOptions, null!));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入所有有效引數應成功建構，不拋例外")]
+        public void Constructor_AllValidArguments_DoesNotThrow()
+        {
+            var exception = Record.Exception(() =>
+                new CacheNotifyPoller(ValidFactory, ValidContainer, ValidOptions, ValidLogger));
+            Assert.Null(exception);
+        }
+
+        private sealed class FakeDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class FakeCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => null!;
+            public DatabaseSettingsCache DatabaseSettings => null!;
+            public ProgramSettingsCache ProgramSettings => null!;
+            public DbCategorySettingsCache DbCategorySettings => null!;
+            public TableSchemaCache TableSchema => null!;
+            public FormSchemaCache FormSchema => null!;
+            public FormLayoutCache FormLayout => null!;
+            public LanguageResourceCache LanguageResource => null!;
+            public SessionInfoCache SessionInfo => null!;
+            public CompanyInfoCache CompanyInfo => null!;
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private sealed class FakeLogger<T> : ILogger<T>
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter) { }
+        }
+    }
+}

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoInitializeStringTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoInitializeStringTests.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel;
+using Bee.Api.Client;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.Initialize(string)"/> 單行 wrapper 的覆蓋率。
+    /// 此方法內部呼叫 <see cref="ClientInfo.SetEndpoint"/>，SetEndpoint 在無本機 API 服務時
+    /// 拋例外，但 <c>SetConnectType</c> 已於拋例外前完成，因此可驗證 ConnectType 副作用。
+    /// 因修改靜態狀態，納入 <c>ClientInfoState</c> collection 確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoInitializeStringTests
+    {
+        private static string CreateTempDefinePath()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"bee-init-str-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(Path.Combine(tempDir, "SystemSettings.xml"), "<SystemSettings />");
+            return tempDir;
+        }
+
+        [Fact]
+        [DisplayName("Initialize(string endpoint) 有效本機路徑通過驗證後應將 ConnectType 設為 Local")]
+        public void Initialize_StringEndpoint_ValidLocalPath_SetsConnectTypeToLocal()
+        {
+            var tempDir = CreateTempDefinePath();
+            var originalConnectType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            try
+            {
+                ApiClientInfo.SupportedConnectTypes = SupportedConnectTypes.Both;
+                Record.Exception(() => ClientInfo.Initialize(tempDir));
+                Assert.Equal(ConnectType.Local, ApiClientInfo.ConnectType);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalConnectType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+                ApiClientInfo.SupportedConnectTypes = originalSupportedTypes;
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Hosting/CacheNotify/CacheNotifyPoller.cs` | 0.0% | 5 |
| `src/Bee.Hosting/CacheNotify/CacheNotifyPollSession.cs` | 82.4% | 7 |
| `src/Bee.UI.Core/ClientInfo.cs` | 85.5% | 1 |

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | `OnSubmitAsync` 深層路徑（`LoginAsync` 回應、`AccessToken == Guid.Empty` 分支、`OnLoggedIn.InvokeAsync`）需要真實 API 回應；`LoginAsync` 非 virtual，無 mocking 框架無法偽造，改由人工規劃 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上，Server-side 版本結構完全相同 |

### 新增測試說明

**`CacheNotifyPollerConstructorTests.cs`**（5 個測試）
- 4 個 null 引數驗證（`dbAccessFactory`、`container`、`options`、`logger`）
- 1 個全部有效引數建構不拋例外

**`CacheNotifyPollSessionUnitTests.cs`**（7 個測試）
- 建構式：`null`/空白 `databaseId`、`null dbAccessFactory`、`null container`
- `marginSeconds < 0` 截斷為 `TimeSpan.Zero`
- `NaiveNowCommandText`：SQLite 分支、不支援 `DatabaseType` 拋 `NotSupportedException`
- `ThresholdBinding`：SQLite 分支、不支援 `DatabaseType` 拋 `NotSupportedException`

**`ClientInfoInitializeStringTests.cs`**（1 個測試）
- `Initialize(string endpoint)` 單行 wrapper 有效本機路徑通過驗證後 `ConnectType` 設為 `Local`

https://claude.ai/code/session_01WnAij4oXcGCVg5PToGyDRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnAij4oXcGCVg5PToGyDRs)_