### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-06-03 00:30

### DIFF
--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -1,0 +1,174 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Db;
+using Bee.Definition.Database;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 純單元測試：驗證 <see cref="CacheNotifyPollSession"/> 建構子防護及私有靜態方法的邏輯，
+    /// 不依賴資料庫，不依賴 DI 容器。
+    /// </summary>
+    public class CacheNotifyPollSessionUnitTests
+    {
+        private static readonly Type[] s_databaseTypeParam = [typeof(DatabaseType)];
+
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotSupportedException();
+        }
+
+        private sealed class StubCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => throw new NotSupportedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotSupportedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotSupportedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotSupportedException();
+            public TableSchemaCache TableSchema => throw new NotSupportedException();
+            public FormSchemaCache FormSchema => throw new NotSupportedException();
+            public FormLayoutCache FormLayout => throw new NotSupportedException();
+            public LanguageResourceCache LanguageResource => throw new NotSupportedException();
+            public SessionInfoCache SessionInfo => throw new NotSupportedException();
+            public CompanyInfoCache CompanyInfo => throw new NotSupportedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private static IDbAccessFactory NewFactory() => new StubDbAccessFactory();
+        private static ICacheContainer NewContainer() => new StubCacheContainer();
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 傳入 null databaseId 應拋 ArgumentException")]
+        public void Ctor_NullDatabaseId_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CacheNotifyPollSession(null!, NewFactory(), NewContainer(), 5));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 傳入空白 databaseId 應拋 ArgumentException")]
+        public void Ctor_WhiteSpaceDatabaseId_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CacheNotifyPollSession("  ", NewFactory(), NewContainer(), 5));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 傳入 null dbAccessFactory 應拋 ArgumentNullException")]
+        public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPollSession("db", null!, NewContainer(), 5));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 傳入 null container 應拋 ArgumentNullException")]
+        public void Ctor_NullContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPollSession("db", NewFactory(), null!, 5));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 全部有效參數應可正常建立實例")]
+        public void Ctor_AllValidArgs_CreatesInstance()
+        {
+            var exception = Record.Exception(() =>
+                new CacheNotifyPollSession("db", NewFactory(), NewContainer(), 5));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession marginSeconds 為負數應修正為 0")]
+        public void Ctor_NegativeMarginSeconds_NormalizesToZero()
+        {
+            var session = new CacheNotifyPollSession("db", NewFactory(), NewContainer(), -10);
+            var marginField = typeof(CacheNotifyPollSession).GetField(
+                "_margin", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(marginField);
+            var margin = (TimeSpan)marginField!.GetValue(session)!;
+            Assert.Equal(TimeSpan.Zero, margin);
+        }
+
+        [Theory]
+        [InlineData(DatabaseType.SQLServer, "SELECT getdate()")]
+        [InlineData(DatabaseType.PostgreSQL, "SELECT LOCALTIMESTAMP")]
+        [InlineData(DatabaseType.MySQL, "SELECT CURRENT_TIMESTAMP(6)")]
+        [InlineData(DatabaseType.Oracle, "SELECT LOCALTIMESTAMP FROM dual")]
+        [InlineData(DatabaseType.SQLite, "SELECT CURRENT_TIMESTAMP")]
+        [DisplayName("NaiveNowCommandText 各資料庫類型應回傳對應 SQL 字串")]
+        public void NaiveNowCommandText_KnownDatabaseType_ReturnsExpectedSql(DatabaseType dbType, string expected)
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "NaiveNowCommandText",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_databaseTypeParam,
+                null);
+            Assert.NotNull(method);
+            var result = method!.Invoke(null, new object[] { dbType }) as string;
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText 未知資料庫類型應拋 NotSupportedException")]
+        public void NaiveNowCommandText_UnknownDatabaseType_ThrowsNotSupportedException()
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "NaiveNowCommandText",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_databaseTypeParam,
+                null);
+            Assert.NotNull(method);
+            var ex = Record.Exception(() => method!.Invoke(null, new object[] { (DatabaseType)999 }));
+            Assert.NotNull(ex);
+            Assert.IsType<NotSupportedException>(ex.InnerException ?? ex);
+        }
+
+        [Theory]
+        [InlineData(DatabaseType.SQLServer, "yyyy-MM-ddTHH:mm:ss.fffffff", "CAST({0} AS datetime2)")]
+        [InlineData(DatabaseType.PostgreSQL, "yyyy-MM-ddTHH:mm:ss.ffffff", "CAST({0} AS timestamp)")]
+        [InlineData(DatabaseType.MySQL, "yyyy-MM-dd HH:mm:ss.ffffff", "CAST({0} AS DATETIME(6))")]
+        [InlineData(DatabaseType.Oracle, "yyyy-MM-ddTHH:mm:ss.ffffff", "TO_TIMESTAMP({0}, 'YYYY-MM-DD\"T\"HH24:MI:SS.FF6')")]
+        [InlineData(DatabaseType.SQLite, "yyyy-MM-dd HH:mm:ss", "{0}")]
+        [DisplayName("ThresholdBinding 各資料庫類型應回傳對應日期格式與 SQL 樣板")]
+        public void ThresholdBinding_KnownDatabaseType_ReturnsExpectedFormatAndTemplate(
+            DatabaseType dbType, string expectedFormat, string expectedCastTemplate)
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "ThresholdBinding",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_databaseTypeParam,
+                null);
+            Assert.NotNull(method);
+            var result = method!.Invoke(null, new object[] { dbType });
+            Assert.NotNull(result);
+            var resultType = result!.GetType();
+            var format = (string)resultType.GetField("Item1")!.GetValue(result)!;
+            var castTemplate = (string)resultType.GetField("Item2")!.GetValue(result)!;
+            Assert.Equal(expectedFormat, format);
+            Assert.Equal(expectedCastTemplate, castTemplate);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding 未知資料庫類型應拋 NotSupportedException")]
+        public void ThresholdBinding_UnknownDatabaseType_ThrowsNotSupportedException()
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "ThresholdBinding",
+                BindingFlags.NonPublic | BindingFlags.Static,
+                null,
+                s_databaseTypeParam,
+                null);
+            Assert.NotNull(method);
+            var ex = Record.Exception(() => method!.Invoke(null, new object[] { (DatabaseType)999 }));
+            Assert.NotNull(ex);
+            Assert.IsType<NotSupportedException>(ex.InnerException ?? ex);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -41,10 +41,10 @@ namespace Bee.Hosting.UnitTests
         private static ICacheContainer NewContainer() => new StubCacheContainer();
 
         [Fact]
-        [DisplayName("CacheNotifyPollSession 傳入 null databaseId 應拋 ArgumentException")]
-        public void Ctor_NullDatabaseId_ThrowsArgumentException()
+        [DisplayName("CacheNotifyPollSession 傳入 null databaseId 應拋 ArgumentNullException")]
+        public void Ctor_NullDatabaseId_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
                 new CacheNotifyPollSession(null!, NewFactory(), NewContainer(), 5));
         }
 

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerCtorTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerCtorTests.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Definition.Settings;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Microsoft.Extensions.Logging;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// 純單元測試：驗證 <see cref="CacheNotifyPoller"/> 建構子的 null 引數防護。
+    /// 不依賴資料庫，不依賴 DI 容器。
+    /// </summary>
+    public class CacheNotifyPollerCtorTests
+    {
+        private sealed class StubDbAccessFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotSupportedException();
+        }
+
+        private sealed class StubCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => throw new NotSupportedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotSupportedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotSupportedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotSupportedException();
+            public TableSchemaCache TableSchema => throw new NotSupportedException();
+            public FormSchemaCache FormSchema => throw new NotSupportedException();
+            public FormLayoutCache FormLayout => throw new NotSupportedException();
+            public LanguageResourceCache LanguageResource => throw new NotSupportedException();
+            public SessionInfoCache SessionInfo => throw new NotSupportedException();
+            public CompanyInfoCache CompanyInfo => throw new NotSupportedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private sealed class StubLogger : ILogger<CacheNotifyPoller>
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) { }
+        }
+
+        private static IDbAccessFactory NewFactory() => new StubDbAccessFactory();
+        private static ICacheContainer NewContainer() => new StubCacheContainer();
+        private static CacheNotifyOptions NewOptions() => new CacheNotifyOptions();
+        private static ILogger<CacheNotifyPoller> NewLogger() => new StubLogger();
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null IDbAccessFactory 應拋 ArgumentNullException")]
+        public void Ctor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(null!, NewContainer(), NewOptions(), NewLogger()));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null ICacheContainer 應拋 ArgumentNullException")]
+        public void Ctor_NullCacheContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(NewFactory(), null!, NewOptions(), NewLogger()));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null CacheNotifyOptions 應拋 ArgumentNullException")]
+        public void Ctor_NullOptions_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(NewFactory(), NewContainer(), null!, NewLogger()));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 傳入 null ILogger 應拋 ArgumentNullException")]
+        public void Ctor_NullLogger_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(NewFactory(), NewContainer(), NewOptions(), null!));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 全部有效參數應可正常建立實例，不拋例外")]
+        public void Ctor_AllValidArgs_CreatesInstance()
+        {
+            var exception = Record.Exception(() =>
+                new CacheNotifyPoller(NewFactory(), NewContainer(), NewOptions(), NewLogger()));
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Hosting/CacheNotify/CacheNotifyPoller.cs` | 0.0%（30 未覆蓋行） | 5 |
| `src/Bee.Hosting/CacheNotify/CacheNotifyPollSession.cs` | 82.4%（12 未覆蓋行） | 14 |

### 新增測試說明

**`CacheNotifyPollerCtorTests`**（新增至 `tests/Bee.Hosting.UnitTests/`）
- 建構子 4 個 null 引數各自的 `ArgumentNullException` 防護
- 全部有效引數正常建立實例

**`CacheNotifyPollSessionUnitTests`**（新增至 `tests/Bee.Hosting.UnitTests/`）
- 建構子：`null`/空白 `databaseId`（`ArgumentException`）、null `dbAccessFactory` / `container`（`ArgumentNullException`）
- `marginSeconds < 0` 修正為零的邏輯
- `NaiveNowCommandText`（私有靜態）：五種 `DatabaseType` 各自預期 SQL + 未知型別 `NotSupportedException`
- `ThresholdBinding`（私有靜態）：五種 `DatabaseType` 的日期格式與 SQL 樣板 + 未知型別 `NotSupportedException`

### 無法處理的檔案

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | Blazor 模板渲染行（`@if`、`@foreach`、`@switch`）需 bUnit 才能覆蓋，純單元測試無法驅動 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |
| `src/Bee.UI.Core/ClientInfo.cs` | 剩餘 12 行（`SaveEndpoint`、`return true` in `InitializeConnect`、`SetEndpoint(endpointArg)` 等）均需運行中的 API 服務才可到達，無法在 CI 中覆蓋 |

https://claude.ai/code/session_01KSnZcSXcRSjq9gh1JhWo3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSnZcSXcRSjq9gh1JhWo3D)_