### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-06-03 08:30

### DIFF
--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -1,0 +1,159 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Db;
+using Bee.Definition.Database;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheNotifyPollSession"/> 建構子防衛式斷言，以及
+    /// <c>NaiveNowCommandText</c> / <c>ThresholdBinding</c> 兩個私有靜態方法
+    /// 各資料庫分支與 default 拋例外路徑的單元測試。
+    /// </summary>
+    public class CacheNotifyPollSessionUnitTests
+    {
+        private sealed class StubDbFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class StubCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => throw new NotImplementedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotImplementedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotImplementedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotImplementedException();
+            public TableSchemaCache TableSchema => throw new NotImplementedException();
+            public FormSchemaCache FormSchema => throw new NotImplementedException();
+            public FormLayoutCache FormLayout => throw new NotImplementedException();
+            public LanguageResourceCache LanguageResource => throw new NotImplementedException();
+            public SessionInfoCache SessionInfo => throw new NotImplementedException();
+            public CompanyInfoCache CompanyInfo => throw new NotImplementedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private static readonly IDbAccessFactory s_factory = new StubDbFactory();
+        private static readonly ICacheContainer s_container = new StubCacheContainer();
+        private static readonly object[] s_unknownDbTypeArg = [(DatabaseType)999];
+
+        // --- 建構子防衛式斷言 ---
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 建構子 databaseId 為 null 應拋 ArgumentException")]
+        public void Constructor_NullDatabaseId_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CacheNotifyPollSession(null!, s_factory, s_container, marginSeconds: 0));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 建構子 databaseId 為空白字串應拋 ArgumentException")]
+        public void Constructor_WhitespaceDatabaseId_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                new CacheNotifyPollSession("   ", s_factory, s_container, marginSeconds: 0));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 建構子 dbAccessFactory 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPollSession("test_db", null!, s_container, marginSeconds: 0));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 建構子 container 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPollSession("test_db", s_factory, null!, marginSeconds: 0));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPollSession 建構子 marginSeconds 為負值時應成功建立（正規化為 0）")]
+        public void Constructor_NegativeMarginSeconds_CreatesInstanceWithoutThrowing()
+        {
+            var exception = Record.Exception(() =>
+                new CacheNotifyPollSession("test_db", s_factory, s_container, marginSeconds: -1));
+            Assert.Null(exception);
+        }
+
+        // --- NaiveNowCommandText 各 DB 類型分支 ---
+
+        private static MethodInfo GetNaiveNowMethod()
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "NaiveNowCommandText", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Theory]
+        [InlineData(DatabaseType.SQLServer)]
+        [InlineData(DatabaseType.PostgreSQL)]
+        [InlineData(DatabaseType.MySQL)]
+        [InlineData(DatabaseType.Oracle)]
+        [InlineData(DatabaseType.SQLite)]
+        [DisplayName("NaiveNowCommandText 已知資料庫類型應回傳非空白 SQL 字串")]
+        public void NaiveNowCommandText_KnownDatabaseType_ReturnsNonEmptyString(DatabaseType databaseType)
+        {
+            var method = GetNaiveNowMethod();
+            var result = method.Invoke(null, new object[] { databaseType }) as string;
+            Assert.NotNull(result);
+            Assert.NotEmpty(result);
+        }
+
+        [Fact]
+        [DisplayName("NaiveNowCommandText 未知資料庫類型應拋 NotSupportedException")]
+        public void NaiveNowCommandText_UnknownDatabaseType_ThrowsNotSupportedException()
+        {
+            var method = GetNaiveNowMethod();
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                method.Invoke(null, s_unknownDbTypeArg));
+            Assert.IsType<NotSupportedException>(ex.InnerException);
+        }
+
+        // --- ThresholdBinding 各 DB 類型分支 ---
+
+        private static MethodInfo GetThresholdBindingMethod()
+        {
+            var method = typeof(CacheNotifyPollSession).GetMethod(
+                "ThresholdBinding", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return method!;
+        }
+
+        [Theory]
+        [InlineData(DatabaseType.SQLServer)]
+        [InlineData(DatabaseType.PostgreSQL)]
+        [InlineData(DatabaseType.MySQL)]
+        [InlineData(DatabaseType.Oracle)]
+        [InlineData(DatabaseType.SQLite)]
+        [DisplayName("ThresholdBinding 已知資料庫類型應回傳非空白 Format 與 CastTemplate")]
+        public void ThresholdBinding_KnownDatabaseType_ReturnsBothFieldsNonEmpty(DatabaseType databaseType)
+        {
+            var method = GetThresholdBindingMethod();
+            var result = method.Invoke(null, new object[] { databaseType });
+            Assert.NotNull(result);
+
+            var (format, castTemplate) = ((string, string))result!;
+            Assert.NotEmpty(format);
+            Assert.NotEmpty(castTemplate);
+        }
+
+        [Fact]
+        [DisplayName("ThresholdBinding 未知資料庫類型應拋 NotSupportedException")]
+        public void ThresholdBinding_UnknownDatabaseType_ThrowsNotSupportedException()
+        {
+            var method = GetThresholdBindingMethod();
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                method.Invoke(null, s_unknownDbTypeArg));
+            Assert.IsType<NotSupportedException>(ex.InnerException);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollSessionUnitTests.cs
@@ -43,10 +43,10 @@ namespace Bee.Hosting.UnitTests
         // --- 建構子防衛式斷言 ---
 
         [Fact]
-        [DisplayName("CacheNotifyPollSession 建構子 databaseId 為 null 應拋 ArgumentException")]
-        public void Constructor_NullDatabaseId_ThrowsArgumentException()
+        [DisplayName("CacheNotifyPollSession 建構子 databaseId 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullDatabaseId_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentException>(() =>
+            Assert.Throws<ArgumentNullException>(() =>
                 new CacheNotifyPollSession(null!, s_factory, s_container, marginSeconds: 0));
         }
 

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel;
+using System.Data.Common;
+using System.Reflection;
+using Bee.Db;
+using Bee.Definition.Settings;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Microsoft.Extensions.Logging;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheNotifyPoller"/> 建構子防衛式斷言與 <c>SafePoll</c> 例外吞除邏輯的單元測試。
+    /// </summary>
+    public class CacheNotifyPollerUnitTests
+    {
+        private sealed class StubDbFactory : IDbAccessFactory
+        {
+            public DbAccess Create(string databaseId) => throw new NotImplementedException();
+        }
+
+        private sealed class ThrowingDbFactory : IDbAccessFactory
+        {
+            private readonly Exception _exception;
+            public ThrowingDbFactory(Exception exception) { _exception = exception; }
+            public DbAccess Create(string databaseId) => throw _exception;
+        }
+
+        private sealed class FakeDbException : DbException
+        {
+            public FakeDbException(string message) : base(message) { }
+        }
+
+        private sealed class StubCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => throw new NotImplementedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotImplementedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotImplementedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotImplementedException();
+            public TableSchemaCache TableSchema => throw new NotImplementedException();
+            public FormSchemaCache FormSchema => throw new NotImplementedException();
+            public FormLayoutCache FormLayout => throw new NotImplementedException();
+            public LanguageResourceCache LanguageResource => throw new NotImplementedException();
+            public SessionInfoCache SessionInfo => throw new NotImplementedException();
+            public CompanyInfoCache CompanyInfo => throw new NotImplementedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private static readonly IDbAccessFactory s_factory = new StubDbFactory();
+        private static readonly ICacheContainer s_container = new StubCacheContainer();
+        private static readonly CacheNotifyOptions s_options = new();
+        private static readonly ILogger<CacheNotifyPoller> s_logger = NullLogger<CacheNotifyPoller>.Instance;
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子所有參數有效時應成功建立實例，不拋例外")]
+        public void Constructor_ValidArguments_CreatesInstance()
+        {
+            var exception = Record.Exception(() =>
+                new CacheNotifyPoller(s_factory, s_container, s_options, s_logger));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子 dbAccessFactory 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullDbAccessFactory_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(null!, s_container, s_options, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子 container 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullContainer_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(s_factory, null!, s_options, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子 options 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullOptions_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(s_factory, s_container, null!, s_logger));
+        }
+
+        [Fact]
+        [DisplayName("CacheNotifyPoller 建構子 logger 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullLogger_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new CacheNotifyPoller(s_factory, s_container, s_options, null!));
+        }
+
+        [Fact]
+        [DisplayName("SafePoll session.Poll() 拋 InvalidOperationException 時應被吞除，不向外傳播")]
+        public void SafePoll_SessionThrowsInvalidOperationException_DoesNotPropagate()
+        {
+            var throwingFactory = new ThrowingDbFactory(new InvalidOperationException("simulated db error"));
+            var session = new CacheNotifyPollSession("test_db", throwingFactory, s_container, marginSeconds: 0);
+            var poller = new CacheNotifyPoller(s_factory, s_container, s_options, s_logger);
+
+            var safePollMethod = typeof(CacheNotifyPoller).GetMethod(
+                "SafePoll", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(safePollMethod);
+
+            var exception = Record.Exception(() => safePollMethod!.Invoke(poller, new object[] { session }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("SafePoll session.Poll() 拋 DbException 時應被吞除，不向外傳播")]
+        public void SafePoll_SessionThrowsDbException_DoesNotPropagate()
+        {
+            var throwingFactory = new ThrowingDbFactory(new FakeDbException("simulated db provider exception"));
+            var session = new CacheNotifyPollSession("test_db", throwingFactory, s_container, marginSeconds: 0);
+            var poller = new CacheNotifyPoller(s_factory, s_container, s_options, s_logger);
+
+            var safePollMethod = typeof(CacheNotifyPoller).GetMethod(
+                "SafePoll", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(safePollMethod);
+
+            var exception = Record.Exception(() => safePollMethod!.Invoke(poller, new object[] { session }));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerUnitTests.cs
@@ -33,6 +33,14 @@ namespace Bee.Hosting.UnitTests
             public FakeDbException(string message) : base(message) { }
         }
 
+        private sealed class StubLogger : ILogger<CacheNotifyPoller>
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter) { }
+        }
+
         private sealed class StubCacheContainer : ICacheContainer
         {
             public SystemSettingsCache SystemSettings => throw new NotImplementedException();
@@ -51,7 +59,7 @@ namespace Bee.Hosting.UnitTests
         private static readonly IDbAccessFactory s_factory = new StubDbFactory();
         private static readonly ICacheContainer s_container = new StubCacheContainer();
         private static readonly CacheNotifyOptions s_options = new();
-        private static readonly ILogger<CacheNotifyPoller> s_logger = NullLogger<CacheNotifyPoller>.Instance;
+        private static readonly ILogger<CacheNotifyPoller> s_logger = new StubLogger();
 
         [Fact]
         [DisplayName("CacheNotifyPoller 建構子所有參數有效時應成功建立實例，不拋例外")]


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Hosting/CacheNotify/CacheNotifyPoller.cs` | 0.0% | 7 |
| `src/Bee.Hosting/CacheNotify/CacheNotifyPollSession.cs` | 82.4% | 14 |

### 測試說明

**CacheNotifyPoller（7 個測試）**
- 建構子四個 `ArgumentNullException` 防衛式斷言（dbAccessFactory / container / options / logger）
- 建構子 happy path（所有參數有效）
- `SafePoll` 吞除 `InvalidOperationException` 的 catch 分支
- `SafePoll` 吞除 `DbException` 的 catch 分支（以 `FakeDbException : DbException` stub 觸發）

**CacheNotifyPollSession（14 個測試）**
- 建構子 `databaseId` null / whitespace → `ArgumentException`
- 建構子 `dbAccessFactory` / `container` null → `ArgumentNullException`
- 建構子 `marginSeconds < 0` 正規化路徑（不拋例外）
- `NaiveNowCommandText`：SQL Server / PostgreSQL / MySQL / Oracle / SQLite 五個分支（返回非空白 SQL）+ unknown → `NotSupportedException`
- `ThresholdBinding`：同上五個分支（返回非空白 Format & CastTemplate）+ unknown → `NotSupportedException`

### 無法處理（3 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Core/ClientInfo.cs` | 剩餘未覆蓋行（`InitializeConnect return true`、`SetEndpoint.SaveEndpoint`、Endpoint CLI arg 分支）皆需要正常運行的 API 服務，無法在 CI 單元測試中覆蓋 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | `OnSubmitAsync` 的 `response.AccessToken == Guid.Empty` 與成功登入分支需要真實 login 回應；專案未引入 bUnit / Moq，無法注入假 `SystemApiConnector` |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上 |

https://claude.ai/code/session_01NYKUZZfv13awi7HyPif3gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYKUZZfv13awi7HyPif3gg)_