### PR TITLE
[AutoFix] Coverage Fix (1 file) 2026-06-03 16:49

### DIFF
--- a/tests/Bee.Db.UnitTests/CacheNotifyServiceArgumentTests.cs
+++ b/tests/Bee.Db.UnitTests/CacheNotifyServiceArgumentTests.cs
@@ -17,25 +17,28 @@ namespace Bee.Db.UnitTests
 
         [Fact]
         [DisplayName("TouchAsync: null cacheKey 應丟 ArgumentNullException")]
-        public void TouchAsync_NullCacheKey_ThrowsArgumentNullException()
+        public async Task TouchAsync_NullCacheKey_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => s_service.TouchAsync(null!, null!, DatabaseType.SQLServer));
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => s_service.TouchAsync(null!, null!, DatabaseType.SQLServer));
         }
 
         [Theory]
         [InlineData("")]
         [InlineData("   ")]
         [DisplayName("TouchAsync: 空白 cacheKey 應丟 ArgumentException")]
-        public void TouchAsync_WhitespaceCacheKey_ThrowsArgumentException(string cacheKey)
+        public async Task TouchAsync_WhitespaceCacheKey_ThrowsArgumentException(string cacheKey)
         {
-            Assert.Throws<ArgumentException>(() => s_service.TouchAsync(cacheKey, null!, DatabaseType.SQLServer));
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => s_service.TouchAsync(cacheKey, null!, DatabaseType.SQLServer));
         }
 
         [Fact]
         [DisplayName("TouchAsync: null transaction 應丟 ArgumentNullException")]
-        public void TouchAsync_NullTransaction_ThrowsArgumentNullException()
+        public async Task TouchAsync_NullTransaction_ThrowsArgumentNullException()
         {
-            Assert.Throws<ArgumentNullException>(() => s_service.TouchAsync("key", null!, DatabaseType.SQLServer));
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => s_service.TouchAsync("key", null!, DatabaseType.SQLServer));
         }
 
         #endregion

--- a/tests/Bee.Db.UnitTests/CacheNotifyServiceArgumentTests.cs
+++ b/tests/Bee.Db.UnitTests/CacheNotifyServiceArgumentTests.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using Bee.Db.CacheNotify;
+using Bee.Definition.Database;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="CacheNotifyService"/> 的引數驗證純單元測試（不需資料庫連線）。
+    /// 補強 <c>TouchAsync</c> 的引數守衛覆蓋率：既有 DB 整合測試只呼叫
+    /// <c>Touch</c>，<c>TouchAsync</c> 的守衛行從未被執行。
+    /// </summary>
+    public class CacheNotifyServiceArgumentTests
+    {
+        private static readonly CacheNotifyService s_service = new();
+
+        #region TouchAsync 引數守衛
+
+        [Fact]
+        [DisplayName("TouchAsync: null cacheKey 應丟 ArgumentNullException")]
+        public void TouchAsync_NullCacheKey_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => s_service.TouchAsync(null!, null!, DatabaseType.SQLServer));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("TouchAsync: 空白 cacheKey 應丟 ArgumentException")]
+        public void TouchAsync_WhitespaceCacheKey_ThrowsArgumentException(string cacheKey)
+        {
+            Assert.Throws<ArgumentException>(() => s_service.TouchAsync(cacheKey, null!, DatabaseType.SQLServer));
+        }
+
+        [Fact]
+        [DisplayName("TouchAsync: null transaction 應丟 ArgumentNullException")]
+        public void TouchAsync_NullTransaction_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => s_service.TouchAsync("key", null!, DatabaseType.SQLServer));
+        }
+
+        #endregion
+
+        #region Touch 引數守衛
+
+        [Fact]
+        [DisplayName("Touch: null cacheKey 應丟 ArgumentNullException")]
+        public void Touch_NullCacheKey_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => s_service.Touch(null!, null!, DatabaseType.SQLServer));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        [DisplayName("Touch: 空白 cacheKey 應丟 ArgumentException")]
+        public void Touch_WhitespaceCacheKey_ThrowsArgumentException(string cacheKey)
+        {
+            Assert.Throws<ArgumentException>(() => s_service.Touch(cacheKey, null!, DatabaseType.SQLServer));
+        }
+
+        [Fact]
+        [DisplayName("Touch: null transaction 應丟 ArgumentNullException")]
+        public void Touch_NullTransaction_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => s_service.Touch("key", null!, DatabaseType.SQLServer));
+        }
+
+        #endregion
+    }
+}

--- a/tests/Bee.Db.UnitTests/CacheNotifyServiceAsyncDbTests.cs
+++ b/tests/Bee.Db.UnitTests/CacheNotifyServiceAsyncDbTests.cs
@@ -1,0 +1,97 @@
+using System.ComponentModel;
+using System.Globalization;
+using Bee.Db.CacheNotify;
+using Bee.Db.Manager;
+using Bee.Definition.Database;
+using Bee.Tests.Shared;
+
+namespace Bee.Db.UnitTests
+{
+    /// <summary>
+    /// 針對 <see cref="CacheNotifyService.TouchAsync"/> 的 DB 整合測試。
+    /// 既有 <c>CacheNotifyServiceTests</c> 只測試同步版本 <c>Touch</c>；
+    /// 本類別補強非同步執行路徑，確保 UPSERT 在各方言下均能正常非同步執行。
+    /// </summary>
+    public class CacheNotifyServiceAsyncDbTests : IClassFixture<SharedDbFixture>
+    {
+        private readonly SharedDbFixture _fx;
+
+        public CacheNotifyServiceAsyncDbTests(SharedDbFixture fx) { _fx = fx; }
+
+        private static string NewKey() => $"CacheNotifyAsyncTest:{Guid.NewGuid():N}";
+
+        private async Task ExecuteTouchAsync(DatabaseType databaseType, string cacheKey)
+        {
+            var databaseId = TestDbConventions.GetDatabaseId(databaseType);
+            var connectionManager = _fx.GetRequiredService<IDbConnectionManager>();
+            var service = _fx.GetRequiredService<ICacheNotifyService>();
+
+            using var connection = connectionManager.CreateConnection(databaseId);
+            connection.Open();
+            using var transaction = connection.BeginTransaction();
+            await service.TouchAsync(cacheKey, transaction, databaseType).ConfigureAwait(false);
+            transaction.Commit();
+        }
+
+        private long ReadVersion(DatabaseType databaseType, string cacheKey)
+        {
+            var databaseId = TestDbConventions.GetDatabaseId(databaseType);
+            var dbAccess = _fx.NewDbAccess(databaseId);
+
+            string tbl = databaseType.QuoteIdentifier("st_cache_notify");
+            string key = databaseType.QuoteIdentifier("cache_key");
+            string ver = databaseType.QuoteIdentifier("cache_version");
+
+            var table = dbAccess.ExecuteDataTable(
+                $"SELECT {ver} FROM {tbl} WHERE {key} = {{0}}", cacheKey)
+                ?? throw new InvalidOperationException("Query returned no table.");
+
+            Assert.Single(table.Rows);
+            return Convert.ToInt64(table.Rows[0][0], CultureInfo.InvariantCulture);
+        }
+
+        [DbFact(DatabaseType.SQLServer)]
+        [DisplayName("SQL Server：TouchAsync 版本號自增且第二次 Touch 累加至 2")]
+        public async Task TouchAsync_SqlServer_VersionIncrements()
+        {
+            var key = NewKey();
+            await ExecuteTouchAsync(DatabaseType.SQLServer, key).ConfigureAwait(false);
+            Assert.Equal(1L, ReadVersion(DatabaseType.SQLServer, key));
+            await ExecuteTouchAsync(DatabaseType.SQLServer, key).ConfigureAwait(false);
+            Assert.Equal(2L, ReadVersion(DatabaseType.SQLServer, key));
+        }
+
+        [DbFact(DatabaseType.PostgreSQL)]
+        [DisplayName("PostgreSQL：TouchAsync 版本號自增且第二次 Touch 累加至 2")]
+        public async Task TouchAsync_PostgreSQL_VersionIncrements()
+        {
+            var key = NewKey();
+            await ExecuteTouchAsync(DatabaseType.PostgreSQL, key).ConfigureAwait(false);
+            Assert.Equal(1L, ReadVersion(DatabaseType.PostgreSQL, key));
+            await ExecuteTouchAsync(DatabaseType.PostgreSQL, key).ConfigureAwait(false);
+            Assert.Equal(2L, ReadVersion(DatabaseType.PostgreSQL, key));
+        }
+
+        [DbFact(DatabaseType.MySQL)]
+        [DisplayName("MySQL：TouchAsync 版本號自增且第二次 Touch 累加至 2")]
+        public async Task TouchAsync_MySQL_VersionIncrements()
+        {
+            var key = NewKey();
+            await ExecuteTouchAsync(DatabaseType.MySQL, key).ConfigureAwait(false);
+            Assert.Equal(1L, ReadVersion(DatabaseType.MySQL, key));
+            await ExecuteTouchAsync(DatabaseType.MySQL, key).ConfigureAwait(false);
+            Assert.Equal(2L, ReadVersion(DatabaseType.MySQL, key));
+        }
+
+        [DbFact(DatabaseType.Oracle)]
+        [DisplayName("Oracle：TouchAsync 版本號自增且第二次 Touch 累加至 2")]
+        public async Task TouchAsync_Oracle_VersionIncrements()
+        {
+            var key = NewKey();
+            await ExecuteTouchAsync(DatabaseType.Oracle, key).ConfigureAwait(false);
+            Assert.Equal(1L, ReadVersion(DatabaseType.Oracle, key));
+            await ExecuteTouchAsync(DatabaseType.Oracle, key).ConfigureAwait(false);
+            Assert.Equal(2L, ReadVersion(DatabaseType.Oracle, key));
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Db/CacheNotify/CacheNotifyService.cs` | 88.6%（5 未覆蓋行） | 10 |

### 新增測試說明

**`CacheNotifyServiceArgumentTests`**（新增至 `tests/Bee.Db.UnitTests/`）
- `TouchAsync` null cacheKey → `ArgumentNullException`
- `TouchAsync` 空白 cacheKey（`""`、`"   "`）→ `ArgumentException`
- `TouchAsync` null transaction → `ArgumentNullException`
- `Touch` 同三條引數守衛（確保對稱性）

**`CacheNotifyServiceAsyncDbTests`**（新增至 `tests/Bee.Db.UnitTests/`）
- SQL Server / PostgreSQL / MySQL / Oracle 各一條 `[DbFact]`：呼叫 `TouchAsync` 執行完整 UPSERT 路徑，驗證版本號自增語意（1→2），補強非同步執行路徑（lines 44–45）

### 無法處理的檔案

| 檔案 | 未覆蓋行 | 原因 |
|------|---------|------|
| `src/Bee.UI.Core/ClientInfo.cs` | 12 | 剩餘路徑（`SetEndpoint`、`InitializeConnect` 的 `return true`）均需執行中 API 服務才可到達，CI 無法覆蓋 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 8 | `OnSubmitAsync` 為 `private` 方法，需 bUnit 驅動才能觸發 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 8 | 同上 |
| `src/Bee.UI.Maui/Storage/MauiPreferenceEndpointStorage.cs` | 3 | 依賴 `Microsoft.Maui.Storage.Preferences.Default`，純 .NET 單元測試環境無法取得 MAUI 執行期 |

https://claude.ai/code/session_01Fi2bKq2jFsc976PCWiRQFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fi2bKq2jFsc976PCWiRQFA)_