### PR TITLE
[AutoFix] SonarCloud Issues (3 issues) 2026-06-04 16:00

### DIFF
--- a/src/Bee.Definition/Identity/RoleGrantRow.cs
+++ b/src/Bee.Definition/Identity/RoleGrantRow.cs
@@ -9,5 +9,5 @@ namespace Bee.Definition.Identity
     /// <param name="RoleId">The role business id (<c>st_role.sys_id</c>).</param>
     /// <param name="ModelId">The permission model id (<c>st_role_grant.model_id</c>).</param>
     /// <param name="AllowedActions">The allowed action mask for this (role, model).</param>
-    public sealed record RoleGrantRow(string RoleId, string ModelId, PermissionAction AllowedActions);
+    public sealed record RoleGrantRow(string RoleId, string ModelId, PermissionActions AllowedActions);
 }

--- a/src/Bee.Definition/Settings/Permission/PermissionAction.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionAction.cs
@@ -10,7 +10,7 @@ namespace Bee.Definition.Settings
     /// to a separate workflow-permission layer, not the action axis.
     /// </remarks>
     [Flags]
-    public enum PermissionAction
+    public enum PermissionActions
     {
         /// <summary>No action.</summary>
         None = 0,

--- a/src/Bee.Definition/Settings/Permission/PermissionBindingValidator.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionBindingValidator.cs
@@ -37,13 +37,8 @@ namespace Bee.Definition.Settings
                 var master = schema.MasterTable;
                 if (master?.Fields == null) { continue; }
 
-                int owners = 0;
-                int depts = 0;
-                foreach (var field in master.Fields)
-                {
-                    if (field.ScopeRole == ScopeRole.Owner) { owners++; }
-                    else if (field.ScopeRole == ScopeRole.Dept) { depts++; }
-                }
+                int owners = master.Fields.Count(f => f.ScopeRole == ScopeRole.Owner);
+                int depts = master.Fields.Count(f => f.ScopeRole == ScopeRole.Dept);
                 if (owners > 1)
                     errors.Add($"Form '{schema.ProgId}': master table marks {owners} Owner columns; at most one is allowed.");
                 if (depts > 1)

--- a/src/Bee.Definition/Settings/Permission/PermissionModels.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionModels.cs
@@ -91,7 +91,7 @@ namespace Bee.Definition.Settings
                 if (rules == null) { continue; }
                 foreach (var rule in rules)
                 {
-                    bool isEgress = rule.Action is PermissionAction.Print or PermissionAction.Export;
+                    bool isEgress = rule.Action is PermissionActions.Print or PermissionActions.Export;
                     if (isEgress && rule.Scope != ScopeStrategy.Inherit)
                     {
                         errors.Add($"Model '{model.ModelId}': egress action '{rule.Action}' must not define a scope; it inherits Read.");

--- a/src/Bee.Definition/Settings/Permission/PermissionRule.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionRule.cs
@@ -13,7 +13,7 @@ namespace Bee.Definition.Settings
     [TreeNode]
     public class PermissionRule : KeyCollectionItem
     {
-        private PermissionAction _action = PermissionAction.None;
+        private PermissionActions _action = PermissionActions.None;
 
         #region Constructors
 
@@ -28,7 +28,7 @@ namespace Bee.Definition.Settings
         /// </summary>
         /// <param name="action">The permission action.</param>
         /// <param name="scope">The record-scope strategy.</param>
-        public PermissionRule(PermissionAction action, ScopeStrategy scope = ScopeStrategy.Inherit)
+        public PermissionRule(PermissionActions action, ScopeStrategy scope = ScopeStrategy.Inherit)
         {
             Action = action;
             Scope = scope;
@@ -41,7 +41,7 @@ namespace Bee.Definition.Settings
         /// </summary>
         [XmlAttribute]
         [Description("Permission action.")]
-        public PermissionAction Action
+        public PermissionActions Action
         {
             get { return _action; }
             set

--- a/src/Bee.Definition/Settings/Permission/PermissionRuleCollection.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionRuleCollection.cs
@@ -23,7 +23,7 @@ namespace Bee.Definition.Settings
         /// </summary>
         /// <param name="action">The permission action.</param>
         /// <param name="scope">The record-scope strategy.</param>
-        public PermissionRule Add(PermissionAction action, ScopeStrategy scope = ScopeStrategy.Inherit)
+        public PermissionRule Add(PermissionActions action, ScopeStrategy scope = ScopeStrategy.Inherit)
         {
             var rule = new PermissionRule(action, scope);
             base.Add(rule);

--- a/src/Bee.Repository/System/RolePermissionRepository.cs
+++ b/src/Bee.Repository/System/RolePermissionRepository.cs
@@ -16,6 +16,7 @@ namespace Bee.Repository.System
     /// </summary>
     public class RolePermissionRepository : IRolePermissionRepository
     {
+        private const string ColumnSysId = "sys_id";
         private readonly IDbConnectionManager _connectionManager;
 
         /// <summary>
@@ -36,7 +37,7 @@ namespace Bee.Repository.System
             string tblGrant = dbType.QuoteIdentifier("st_role_grant");
             string tblRole = dbType.QuoteIdentifier("st_role");
             string colRowId = dbType.QuoteIdentifier("sys_rowid");
-            string colSysId = dbType.QuoteIdentifier("sys_id");
+            string colSysId = dbType.QuoteIdentifier(ColumnSysId);
             string colRoleRowId = dbType.QuoteIdentifier("role_rowid");
             string colModelId = dbType.QuoteIdentifier("model_id");
             string colActions = dbType.QuoteIdentifier("allowed_actions");
@@ -52,7 +53,7 @@ namespace Bee.Repository.System
             foreach (DataRow row in table.Rows)
             {
                 list.Add(new RoleGrantRow(
-                    ValueUtilities.CStr(row["sys_id"]),
+                    ValueUtilities.CStr(row[ColumnSysId]),
                     ValueUtilities.CStr(row["model_id"]),
                     (PermissionAction)ValueUtilities.CInt(row["allowed_actions"])));
             }
@@ -68,7 +69,7 @@ namespace Bee.Repository.System
             string tblUserRole = dbType.QuoteIdentifier("st_user_role");
             string tblRole = dbType.QuoteIdentifier("st_role");
             string colRowId = dbType.QuoteIdentifier("sys_rowid");
-            string colSysId = dbType.QuoteIdentifier("sys_id");
+            string colSysId = dbType.QuoteIdentifier(ColumnSysId);
             string colUserRowId = dbType.QuoteIdentifier("user_rowid");
             string colRoleRowId = dbType.QuoteIdentifier("role_rowid");
 
@@ -84,7 +85,7 @@ namespace Bee.Repository.System
             {
                 list.Add(new UserRoleRow(
                     ToGuid(row["user_rowid"]).ToString(),
-                    ValueUtilities.CStr(row["sys_id"])));
+                    ValueUtilities.CStr(row[ColumnSysId])));
             }
             return list;
         }

--- a/src/Bee.Repository/System/RolePermissionRepository.cs
+++ b/src/Bee.Repository/System/RolePermissionRepository.cs
@@ -55,7 +55,7 @@ namespace Bee.Repository.System
                 list.Add(new RoleGrantRow(
                     ValueUtilities.CStr(row[ColumnSysId]),
                     ValueUtilities.CStr(row["model_id"]),
-                    (PermissionAction)ValueUtilities.CInt(row["allowed_actions"])));
+                    (PermissionActions)ValueUtilities.CInt(row["allowed_actions"])));
             }
             return list;
         }

--- a/tests/Bee.Definition.UnitTests/Settings/PermissionBindingTests.cs
+++ b/tests/Bee.Definition.UnitTests/Settings/PermissionBindingTests.cs
@@ -33,7 +33,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
+            po.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
             return models;
         }
 

--- a/tests/Bee.Definition.UnitTests/Settings/PermissionModelsDataTests.cs
+++ b/tests/Bee.Definition.UnitTests/Settings/PermissionModelsDataTests.cs
@@ -17,20 +17,20 @@ namespace Bee.Definition.UnitTests.Settings
             var models = new PermissionModels();
 
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
-            po.Rules!.Add(PermissionAction.Create, ScopeStrategy.All);
-            po.Rules!.Add(PermissionAction.Update, ScopeStrategy.Own);
-            po.Rules!.Add(PermissionAction.Delete, ScopeStrategy.Own);
-            po.Rules!.Add(PermissionAction.Print);
-            po.Rules!.Add(PermissionAction.Export);
+            po.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
+            po.Rules!.Add(PermissionActions.Create, ScopeStrategy.All);
+            po.Rules!.Add(PermissionActions.Update, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Delete, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Print);
+            po.Rules!.Add(PermissionActions.Export);
 
             var vendor = models.Models!.Add("Vendor", "廠商");
-            vendor.Rules!.Add(PermissionAction.Read, ScopeStrategy.All);
-            vendor.Rules!.Add(PermissionAction.Update, ScopeStrategy.Own);
+            vendor.Rules!.Add(PermissionActions.Read, ScopeStrategy.All);
+            vendor.Rules!.Add(PermissionActions.Update, ScopeStrategy.Own);
 
             var req = models.Models!.Add("Requisition", "請購單");
-            req.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
-            req.Rules!.Add(PermissionAction.Create, ScopeStrategy.All);
+            req.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
+            req.Rules!.Add(PermissionActions.Create, ScopeStrategy.All);
 
             return models;
         }
@@ -59,9 +59,9 @@ namespace Bee.Definition.UnitTests.Settings
         [DisplayName("PermissionRule Action 應同時設定為集合 Key")]
         public void PermissionRule_Action_SetsAsKey()
         {
-            var rule = new PermissionRule(PermissionAction.Update, ScopeStrategy.Own);
+            var rule = new PermissionRule(PermissionActions.Update, ScopeStrategy.Own);
 
-            Assert.Equal(PermissionAction.Update, rule.Action);
+            Assert.Equal(PermissionActions.Update, rule.Action);
             Assert.Equal(ScopeStrategy.Own, rule.Scope);
             Assert.Equal("Update", rule.Key);
         }
@@ -70,7 +70,7 @@ namespace Bee.Definition.UnitTests.Settings
         [DisplayName("PermissionRule 預設 Scope 應為 Inherit")]
         public void PermissionRule_DefaultScope_IsInherit()
         {
-            var rule = new PermissionRule(PermissionAction.Print);
+            var rule = new PermissionRule(PermissionActions.Print);
 
             Assert.Equal(ScopeStrategy.Inherit, rule.Scope);
         }
@@ -80,7 +80,7 @@ namespace Bee.Definition.UnitTests.Settings
         public void PermissionRuleCollection_IndexedByAction()
         {
             var model = new PermissionModel("PurchaseOrder", "採購單");
-            model.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
+            model.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
 
             Assert.Equal(ScopeStrategy.DeptAndSub, model.Rules!["Read"].Scope);
         }
@@ -91,7 +91,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Print);
+            po.Rules!.Add(PermissionActions.Print);
 
             var xml = XmlCodec.Serialize(models);
 
@@ -105,7 +105,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Update, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Update, ScopeStrategy.Own);
 
             var xml = XmlCodec.Serialize(models);
 
@@ -130,7 +130,7 @@ namespace Bee.Definition.UnitTests.Settings
             Assert.Equal(ScopeStrategy.All, po.Rules!["Create"].Scope);
             Assert.Equal(ScopeStrategy.Own, po.Rules!["Update"].Scope);
             Assert.Equal(ScopeStrategy.Inherit, po.Rules!["Print"].Scope);
-            Assert.Equal(PermissionAction.Export, po.Rules!["Export"].Action);
+            Assert.Equal(PermissionActions.Export, po.Rules!["Export"].Action);
 
             Assert.Equal(ScopeStrategy.All, restored.Models!["Vendor"].Rules!["Read"].Scope);
         }
@@ -152,7 +152,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Print, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Print, ScopeStrategy.Own);
 
             var errors = models.Validate();
 

--- a/tests/Bee.Repository.UnitTests/RolePermissionRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/RolePermissionRepositoryTests.cs
@@ -11,7 +11,7 @@ namespace Bee.Repository.UnitTests
     /// <summary>
     /// RolePermissionRepository 的 5 DB round-trip 測試：在 company DB insert
     /// st_role / st_role_grant / st_user_role，驗證 GetRoleGrants / GetUserRoles 查回正確
-    /// （role 以 sys_id 識別、grant 的 allowed_actions 還原為 PermissionAction mask）。
+    /// （role 以 sys_id 識別、grant 的 allowed_actions 還原為 PermissionActions mask）。
     /// </summary>
     public class RolePermissionRepositoryTests : IClassFixture<SharedDbFixture>
     {
@@ -31,7 +31,7 @@ namespace Bee.Repository.UnitTests
             var grantRowId = Guid.NewGuid();
             var userRoleRowId = Guid.NewGuid();
             var userRowId = Guid.NewGuid();
-            var allowed = (int)(PermissionAction.Read | PermissionAction.Update);
+            var allowed = (int)(PermissionActions.Read | PermissionActions.Update);
 
             string tblRole = dbType.QuoteIdentifier("st_role");
             string tblGrant = dbType.QuoteIdentifier("st_role_grant");
@@ -69,7 +69,7 @@ namespace Bee.Repository.UnitTests
 
                 var grant = repo.GetRoleGrants(databaseId).Single(g => g.RoleId == roleId);
                 Assert.Equal("PurchaseOrder", grant.ModelId);
-                Assert.Equal(PermissionAction.Read | PermissionAction.Update, grant.AllowedActions);
+                Assert.Equal(PermissionActions.Read | PermissionActions.Update, grant.AllowedActions);
 
                 var userRole = repo.GetUserRoles(databaseId).Single(u => u.RoleId == roleId);
                 Assert.Equal(userRowId.ToString(), userRole.UserRowId);


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ6RleMRizz9KrEZ9KQT | S1192 | `src/Bee.Repository/System/RolePermissionRepository.cs` | 新增常數 `ColumnSysId = "sys_id"` 取代 4 處重複字串字面量 |
| AZ6QmMNawpbUjl5y_to3 | S3267 | `src/Bee.Definition/Settings/Permission/PermissionBindingValidator.cs` | 以 LINQ `Count()` 取代 `foreach + if` 過濾迴圈 |
| AZ6QezXvmLBbkOGi0hb6 | S2342 | `src/Bee.Definition/Settings/Permission/PermissionAction.cs`（及所有引用檔案） | `[Flags]` 列舉 `PermissionAction` 重新命名為 `PermissionActions`（複數形式），更新 5 個 src 檔案與 3 個 tests 檔案 |

## 無法處理

| Issue Key | Rule | 原因 |
|-----------|------|------|
| AZ6QmMNawpbUjl5y_to2 | S3776 | Cognitive Complexity 屬重構判斷題，已在 `.claude/rules/sonarcloud.md` 明確排除為不納入之規則 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01EUUt6SXvcWKqGo33gf3Bwt)_