### PR TITLE
[AutoFix] Coverage Fix (2 files) 2026-06-04 16:56

### DIFF
--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerExecuteTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerExecuteTests.cs
@@ -36,6 +36,7 @@ namespace Bee.Hosting.UnitTests
             public LanguageResourceCache LanguageResource => throw new NotImplementedException();
             public SessionInfoCache SessionInfo => throw new NotImplementedException();
             public CompanyInfoCache CompanyInfo => throw new NotImplementedException();
+            public CompanyRolePermissionsCache CompanyRolePermissions => throw new NotImplementedException();
             public bool TryEvict(string cacheKey) => false;
         }
 

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerExecuteTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerExecuteTests.cs
@@ -1,0 +1,87 @@
+using System.ComponentModel;
+using Bee.Db;
+using Bee.Definition.Settings;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheNotifyPoller.ExecuteAsync"/> 的單元測試：驗證 hosted service 啟動後
+    /// 取消時可乾淨退出，並覆蓋 <c>intervalSeconds</c> 預設值分支。
+    /// </summary>
+    public class CacheNotifyPollerExecuteTests
+    {
+        private sealed class ThrowingDbFactory : IDbAccessFactory
+        {
+            private readonly Exception _exception;
+            public ThrowingDbFactory(Exception exception) { _exception = exception; }
+            public DbAccess Create(string databaseId) => throw _exception;
+        }
+
+        private sealed class StubCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => throw new NotImplementedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotImplementedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotImplementedException();
+            public PermissionModelsCache PermissionModels => throw new NotImplementedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotImplementedException();
+            public TableSchemaCache TableSchema => throw new NotImplementedException();
+            public FormSchemaCache FormSchema => throw new NotImplementedException();
+            public FormLayoutCache FormLayout => throw new NotImplementedException();
+            public LanguageResourceCache LanguageResource => throw new NotImplementedException();
+            public SessionInfoCache SessionInfo => throw new NotImplementedException();
+            public CompanyInfoCache CompanyInfo => throw new NotImplementedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private sealed class StubLogger : ILogger<CacheNotifyPoller>
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter) { }
+        }
+
+        private static readonly ICacheContainer s_container = new StubCacheContainer();
+        private static readonly ILogger<CacheNotifyPoller> s_logger = new StubLogger();
+
+        [Fact]
+        [DisplayName("ExecuteAsync 啟動後取消應乾淨退出，不拋例外")]
+        public async Task ExecuteAsync_Cancelled_CompletesWithoutThrowing()
+        {
+            var options = new CacheNotifyOptions { IntervalSeconds = 60 };
+            var throwingFactory = new ThrowingDbFactory(new InvalidOperationException("DB 錯誤"));
+            var poller = new CacheNotifyPoller(throwingFactory, s_container, options, s_logger);
+
+            IHostedService hosted = poller;
+            var exception = await Record.ExceptionAsync(async () =>
+            {
+                await hosted.StartAsync(CancellationToken.None);
+                await hosted.StopAsync(CancellationToken.None);
+            });
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("ExecuteAsync IntervalSeconds 為 0 時應使用預設 5 秒間隔並在取消後乾淨退出")]
+        public async Task ExecuteAsync_ZeroIntervalSeconds_DefaultsToFiveSecondsAndCompletes()
+        {
+            var options = new CacheNotifyOptions { IntervalSeconds = 0 };
+            var throwingFactory = new ThrowingDbFactory(new InvalidOperationException("DB 錯誤"));
+            var poller = new CacheNotifyPoller(throwingFactory, s_container, options, s_logger);
+
+            IHostedService hosted = poller;
+            var exception = await Record.ExceptionAsync(async () =>
+            {
+                await hosted.StartAsync(CancellationToken.None);
+                await hosted.StopAsync(CancellationToken.None);
+            });
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessMissingCoverageTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessMissingCoverageTests.cs
@@ -1,0 +1,136 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Language;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+using Bee.ObjectCaching;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="LocalDefineAccess"/> 中 PermissionModels 與 Language 存取路徑的覆蓋測試，
+    /// 以及 GetDefine(ProgramSettings) 的 dispatch 路徑。
+    /// 各測試以本地 temp 目錄隔離 PathOptions 與 CacheContainerService，可與其他 test class 平行執行。
+    /// </summary>
+    public class LocalDefineAccessMissingCoverageTests
+    {
+        private static readonly string[] s_zhTwCommonKeys = { "zh-TW", "Common" };
+
+        private sealed class TempContext : IDisposable
+        {
+            public string Dir { get; }
+            public PathOptions Paths { get; }
+            public LocalDefineAccess Access { get; }
+
+            public TempContext()
+            {
+                Dir = Path.Combine(Path.GetTempPath(), $"bee-miss-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(Dir);
+                Paths = new PathOptions { DefinePath = Dir };
+                var storage = new FileDefineStorage(Paths);
+                var cache = new CacheContainerService(storage, Paths, Guid.NewGuid().ToString("N"));
+                Access = new LocalDefineAccess(storage, Paths, cache, Array.Empty<byte>());
+            }
+
+            public void Dispose()
+            {
+                try { Directory.Delete(Dir, recursive: true); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
+        [DisplayName("SavePermissionModels 應寫入 PermissionModels.xml")]
+        public void SavePermissionModels_WritesFile()
+        {
+            using var ctx = new TempContext();
+            ctx.Access.SavePermissionModels(new PermissionModels());
+            Assert.True(File.Exists(ctx.Paths.GetPermissionModelsFilePath()));
+        }
+
+        [Fact]
+        [DisplayName("GetPermissionModels 檔案存在時應回傳 PermissionModels 實例")]
+        public void GetPermissionModels_FileExists_ReturnsInstance()
+        {
+            using var ctx = new TempContext();
+            ctx.Access.SavePermissionModels(new PermissionModels());
+
+            var result = ctx.Access.GetPermissionModels();
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(PermissionModels) 應回傳 PermissionModels 實例")]
+        public void GetDefine_PermissionModels_ReturnsPermissionModels()
+        {
+            using var ctx = new TempContext();
+            ctx.Access.SavePermissionModels(new PermissionModels());
+
+            var result = ctx.Access.GetDefine(DefineType.PermissionModels);
+            Assert.IsType<PermissionModels>(result);
+        }
+
+        [Fact]
+        [DisplayName("SaveDefine(PermissionModels) 應委派至 SavePermissionModels 並寫入檔案")]
+        public void SaveDefine_PermissionModels_DelegatesToSavePermissionModels()
+        {
+            using var ctx = new TempContext();
+            ctx.Access.SaveDefine(DefineType.PermissionModels, new PermissionModels());
+            Assert.True(File.Exists(ctx.Paths.GetPermissionModelsFilePath()));
+        }
+
+        [Fact]
+        [DisplayName("SaveLanguage 應寫入對應的 Language XML 檔案")]
+        public void SaveLanguage_WritesFile()
+        {
+            using var ctx = new TempContext();
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+            ctx.Access.SaveLanguage(resource);
+            Assert.True(File.Exists(ctx.Paths.GetLanguageFilePath("zh-TW", "Common")));
+        }
+
+        [Fact]
+        [DisplayName("GetLanguage 儲存後讀取應回傳 LanguageResource 實例")]
+        public void GetLanguage_AfterSave_ReturnsInstance()
+        {
+            using var ctx = new TempContext();
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+            ctx.Access.SaveLanguage(resource);
+
+            var result = ctx.Access.GetLanguage("zh-TW", "Common");
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(Language) 帶兩個 keys 應回傳 LanguageResource 實例")]
+        public void GetDefine_Language_WithCorrectKeys_ReturnsLanguageResource()
+        {
+            using var ctx = new TempContext();
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+            ctx.Access.SaveLanguage(resource);
+
+            var result = ctx.Access.GetDefine(DefineType.Language, s_zhTwCommonKeys);
+            Assert.IsType<LanguageResource>(result);
+        }
+
+        [Fact]
+        [DisplayName("SaveDefine(Language) 應委派至 SaveLanguage 並寫入檔案")]
+        public void SaveDefine_Language_DelegatesToSaveLanguage()
+        {
+            using var ctx = new TempContext();
+            var resource = new LanguageResource { Lang = "en-US", Namespace = "Test" };
+            ctx.Access.SaveDefine(DefineType.Language, resource);
+            Assert.True(File.Exists(ctx.Paths.GetLanguageFilePath("en-US", "Test")));
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(ProgramSettings) 應回傳 ProgramSettings 實例")]
+        public void GetDefine_ProgramSettings_ReturnsProgramSettings()
+        {
+            using var ctx = new TempContext();
+            ctx.Access.SaveProgramSettings(new ProgramSettings());
+
+            var result = ctx.Access.GetDefine(DefineType.ProgramSettings);
+            Assert.IsType<ProgramSettings>(result);
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessMissingCoverageTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessMissingCoverageTests.cs
@@ -3,7 +3,6 @@ using Bee.Definition;
 using Bee.Definition.Language;
 using Bee.Definition.Settings;
 using Bee.Definition.Storage;
-using Bee.ObjectCaching;
 
 namespace Bee.ObjectCaching.UnitTests
 {


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.ObjectCaching/LocalDefineAccess.cs` | 85.6% | 9 |
| `src/Bee.Hosting/CacheNotify/CacheNotifyPoller.cs` | 60.0% | 2 |

### 新增測試說明

**`LocalDefineAccessMissingCoverageTests.cs`**（9 個測試）：
補強 `LocalDefineAccess` 中 `PermissionModels` 與 `Language` 的讀取/儲存路徑，以及 `GetDefine(ProgramSettings)` 的 dispatch 路徑。覆蓋原先未測試的 `SavePermissionModels`、`GetPermissionModels`、`SaveLanguage`、`GetLanguage`、`SaveDefine(PermissionModels/Language)`、`GetDefine(ProgramSettings/PermissionModels/Language)` 等分支。

**`CacheNotifyPollerExecuteTests.cs`**（2 個測試）：
補強 `CacheNotifyPoller.ExecuteAsync` 的覆蓋率，包含正常取消退出路徑與 `IntervalSeconds = 0` 預設值分支。

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | `.razor` 模板 C# 程式碼需 bUnit 渲染器方可覆蓋，現有單元測試框架不支援 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |
| `src/Bee.UI.Core/ClientInfo.cs` | 剩餘未覆蓋行（`EndpointStorage.SaveEndpoint`、`InitializeConnect` 的 `return true`、`EndpointStorage.SetEndpoint(endpointArg)`）需要運行中的 API 伺服器或命令列參數注入，單元測試無法涵蓋 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rb5CwguDdhKDkpHBxcNyZy)_