### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-06-05 00:58

### DIFF
--- a/tests/Bee.Definition.UnitTests/Organization/DepartmentNodeCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Organization/DepartmentNodeCollectionTests.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel;
+using Bee.Definition.Organization;
+
+namespace Bee.Definition.UnitTests.Organization
+{
+    /// <summary>
+    /// <see cref="DepartmentNodeCollection.AddRange"/> 行為的單元測試：
+    /// null 輸入不拋例外、有效節點全部加入、集合中的 null 項目自動略過。
+    /// </summary>
+    public class DepartmentNodeCollectionTests
+    {
+        private static DepartmentNode NewNode(string deptId) =>
+            new DepartmentNode(Guid.NewGuid(), deptId, deptId, Guid.Empty, Guid.Empty);
+
+        [Fact]
+        [DisplayName("AddRange null 輸入不應拋例外（直接回傳）")]
+        public void AddRange_NullInput_DoesNotThrow()
+        {
+            var collection = new DepartmentNodeCollection();
+            var exception = Record.Exception(() => collection.AddRange(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("AddRange 傳入有效節點後集合應包含所有節點")]
+        public void AddRange_ValidNodes_AddsAll()
+        {
+            var collection = new DepartmentNodeCollection();
+            var nodes = new[] { NewNode("D1"), NewNode("D2"), NewNode("D3") };
+
+            collection.AddRange(nodes);
+
+            Assert.Equal(3, collection.Count);
+        }
+
+        [Fact]
+        [DisplayName("AddRange 集合中含 null 項目時應略過 null，只加入非 null 節點")]
+        public void AddRange_CollectionWithNullItems_SkipsNulls()
+        {
+            var collection = new DepartmentNodeCollection();
+            var nodes = new List<DepartmentNode> { NewNode("D1"), NewNode("D2") };
+            nodes.Insert(1, null!);   // 刻意插入 null 以測試過濾邏輯
+
+            collection.AddRange(nodes);
+
+            Assert.Equal(2, collection.Count);
+        }
+
+        [Fact]
+        [DisplayName("AddRange 空集合不應拋例外且集合應保持空")]
+        public void AddRange_EmptyInput_CollectionRemainsEmpty()
+        {
+            var collection = new DepartmentNodeCollection();
+            var exception = Record.Exception(() => collection.AddRange([]));
+            Assert.Null(exception);
+            Assert.Empty(collection);
+        }
+    }
+}

--- a/tests/Bee.Hosting.UnitTests/CacheNotifyPollerExecuteTests.cs
+++ b/tests/Bee.Hosting.UnitTests/CacheNotifyPollerExecuteTests.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+using System.Data.Common;
+using System.Reflection;
+using Bee.Db;
+using Bee.Definition.Settings;
+using Bee.Hosting.CacheNotify;
+using Bee.ObjectCaching;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Microsoft.Extensions.Logging;
+
+namespace Bee.Hosting.UnitTests
+{
+    /// <summary>
+    /// <see cref="CacheNotifyPoller.ExecuteAsync"/> 的輕量單元測試。
+    /// 以已取消的 <see cref="CancellationToken"/> 確保 timer 不實際等待，
+    /// 驗證方法能正常完成（baseline SafePoll 執行後因 token 取消而結束）。
+    /// </summary>
+    public class CacheNotifyPollerExecuteTests
+    {
+        private sealed class ThrowingDbFactory : IDbAccessFactory
+        {
+            private readonly Exception _exception;
+            public ThrowingDbFactory(Exception exception) => _exception = exception;
+            public DbAccess Create(string databaseId) => throw _exception;
+        }
+
+        private sealed class FakeDbException : DbException
+        {
+            public FakeDbException(string message) : base(message) { }
+        }
+
+        private sealed class SilentLogger : ILogger<CacheNotifyPoller>
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter) { }
+        }
+
+        private sealed class StubCacheContainer : ICacheContainer
+        {
+            public SystemSettingsCache SystemSettings => throw new NotImplementedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotImplementedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotImplementedException();
+            public PermissionModelsCache PermissionModels => throw new NotImplementedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotImplementedException();
+            public TableSchemaCache TableSchema => throw new NotImplementedException();
+            public FormSchemaCache FormSchema => throw new NotImplementedException();
+            public FormLayoutCache FormLayout => throw new NotImplementedException();
+            public LanguageResourceCache LanguageResource => throw new NotImplementedException();
+            public SessionInfoCache SessionInfo => throw new NotImplementedException();
+            public CompanyInfoCache CompanyInfo => throw new NotImplementedException();
+            public CompanyRolePermissionsCache CompanyRolePermissions => throw new NotImplementedException();
+            public DepartmentTreeCache DepartmentTree => throw new NotImplementedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private static readonly ICacheContainer s_container = new StubCacheContainer();
+        private static readonly ILogger<CacheNotifyPoller> s_logger = new SilentLogger();
+
+        private static Task InvokeExecuteAsync(CacheNotifyPoller poller, CancellationToken token)
+        {
+            var method = typeof(CacheNotifyPoller).GetMethod(
+                "ExecuteAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (Task)method!.Invoke(poller, [token])!;
+        }
+
+        [Fact]
+        [DisplayName("ExecuteAsync 以已取消的 token 啟動時應在 baseline Poll 後立即結束，不拋例外")]
+        public async Task ExecuteAsync_PreCancelledToken_CompletesWithoutError()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var factory = new ThrowingDbFactory(new FakeDbException("baseline poll db error"));
+            var options = new CacheNotifyOptions { IntervalSeconds = 5 };
+            var poller = new CacheNotifyPoller(factory, s_container, options, s_logger);
+
+            var task = InvokeExecuteAsync(poller, cts.Token);
+            var exception = await Record.ExceptionAsync(() => task);
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("ExecuteAsync IntervalSeconds 為 0 時應以預設 5 秒執行（以已取消 token 驗證不拋例外）")]
+        public async Task ExecuteAsync_IntervalSecondsZero_DefaultsToFive_CompletesWithoutError()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var factory = new ThrowingDbFactory(new FakeDbException("db error"));
+            var options = new CacheNotifyOptions { IntervalSeconds = 0 };
+            var poller = new CacheNotifyPoller(factory, s_container, options, s_logger);
+
+            var task = InvokeExecuteAsync(poller, cts.Token);
+            var exception = await Record.ExceptionAsync(() => task);
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessMissingCoverageTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/LocalDefineAccessMissingCoverageTests.cs
@@ -1,0 +1,145 @@
+using System.ComponentModel;
+using Bee.Definition;
+using Bee.Definition.Language;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.ObjectCaching.UnitTests
+{
+    /// <summary>
+    /// <see cref="LocalDefineAccess"/> 尚未覆蓋路徑的補強測試：
+    /// <c>GetDefine(ProgramSettings)</c>、<c>GetDefine(PermissionModels)</c>、
+    /// <c>GetDefine(Language)</c>，以及 <c>SavePermissionModels</c> / <c>SaveLanguage</c>
+    /// 和對應的 <c>SaveDefine</c> 委派路徑。
+    /// 使用本地暫存目錄，與其他測試完全隔離。
+    /// </summary>
+    public class LocalDefineAccessMissingCoverageTests
+    {
+        private static readonly string[] s_languageKeys = { "zh-TW", "Common" };
+
+        private static LocalDefineAccess CreateAccess(PathOptions paths)
+            => new LocalDefineAccess(new FileDefineStorage(paths), paths);
+
+        private sealed class TempDir : IDisposable
+        {
+            public string Path { get; }
+            public PathOptions Options { get; }
+
+            private TempDir(string path)
+            {
+                Path = path;
+                Options = new PathOptions { DefinePath = path };
+            }
+
+            public static TempDir Create()
+            {
+                var dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"bee-miss-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(dir);
+                return new TempDir(dir);
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    if (Directory.Exists(Path))
+                        Directory.Delete(Path, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // best effort
+                }
+            }
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(ProgramSettings) 應回傳 ProgramSettings 實例")]
+        public void GetDefine_ProgramSettings_ReturnsProgramSettings()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            access.SaveProgramSettings(new ProgramSettings());
+
+            var result = access.GetDefine(DefineType.ProgramSettings);
+
+            Assert.IsType<ProgramSettings>(result);
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(PermissionModels) 應回傳 PermissionModels 實例")]
+        public void GetDefine_PermissionModels_ReturnsPermissionModels()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            access.SavePermissionModels(new PermissionModels());
+
+            var result = access.GetDefine(DefineType.PermissionModels);
+
+            Assert.IsType<PermissionModels>(result);
+        }
+
+        [Fact]
+        [DisplayName("GetDefine(Language) 帶有效兩個 keys 應回傳 LanguageResource 實例")]
+        public void GetDefine_Language_WithValidKeys_ReturnsLanguageResource()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+            access.SaveLanguage(resource);
+
+            var result = access.GetDefine(DefineType.Language, s_languageKeys);
+
+            Assert.IsType<LanguageResource>(result);
+        }
+
+        [Fact]
+        [DisplayName("SavePermissionModels 應寫入 PermissionModels.xml")]
+        public void SavePermissionModels_WritesFile()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+
+            access.SavePermissionModels(new PermissionModels());
+
+            Assert.True(File.Exists(temp.Options.GetPermissionModelsFilePath()));
+        }
+
+        [Fact]
+        [DisplayName("SaveLanguage 應寫入對應語言目錄下的 LanguageResource xml")]
+        public void SaveLanguage_WritesFile()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+
+            access.SaveLanguage(resource);
+
+            Assert.True(File.Exists(temp.Options.GetLanguageFilePath("zh-TW", "Common")));
+        }
+
+        [Fact]
+        [DisplayName("SaveDefine(PermissionModels) 應委派至 SavePermissionModels")]
+        public void SaveDefine_PermissionModels_DelegatesToSavePermissionModels()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+
+            access.SaveDefine(DefineType.PermissionModels, new PermissionModels());
+
+            Assert.True(File.Exists(temp.Options.GetPermissionModelsFilePath()));
+        }
+
+        [Fact]
+        [DisplayName("SaveDefine(Language) 應委派至 SaveLanguage")]
+        public void SaveDefine_Language_DelegatesToSaveLanguage()
+        {
+            using var temp = TempDir.Create();
+            var access = CreateAccess(temp.Options);
+            var resource = new LanguageResource { Lang = "zh-TW", Namespace = "Common" };
+
+            access.SaveDefine(DefineType.Language, resource);
+
+            Assert.True(File.Exists(temp.Options.GetLanguageFilePath("zh-TW", "Common")));
+        }
+    }
+}

--- a/tests/Bee.ObjectCaching.UnitTests/Services/DepartmentTreeServiceTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/Services/DepartmentTreeServiceTests.cs
@@ -1,0 +1,163 @@
+using System.ComponentModel;
+using Bee.Definition.Identity;
+using Bee.Definition.Organization;
+using Bee.ObjectCaching.Database;
+using Bee.ObjectCaching.Define;
+using Bee.ObjectCaching.Services;
+using Bee.Repository.Abstractions.System;
+
+namespace Bee.ObjectCaching.UnitTests.Services
+{
+    /// <summary>
+    /// <see cref="DepartmentTreeService"/> 建構子防衛與 Get / Remove 邏輯的單元測試。
+    /// 依賴注入以 stub 取代，快取以 per-test 唯一 prefix 隔離，不影響其他並行測試。
+    /// </summary>
+    public class DepartmentTreeServiceTests
+    {
+        private sealed class StubCompanyInfoService : ICompanyInfoService
+        {
+            private readonly CompanyInfo? _result;
+            public StubCompanyInfoService(CompanyInfo? result) => _result = result;
+            public CompanyInfo? Get(string companyId) => _result;
+            public void Set(CompanyInfo companyInfo) { }
+            public void Remove(string companyId) { }
+        }
+
+        private sealed class StubDepartmentRepository : IDepartmentRepository
+        {
+            private readonly IReadOnlyList<DepartmentNode> _nodes;
+            public StubDepartmentRepository(IReadOnlyList<DepartmentNode> nodes) => _nodes = nodes;
+            public IReadOnlyList<DepartmentNode> GetDepartments(string databaseId) => _nodes;
+        }
+
+        private sealed class MinimalCacheContainer : ICacheContainer
+        {
+            public DepartmentTreeCache DepartmentTree { get; }
+
+            public MinimalCacheContainer(string prefix) => DepartmentTree = new DepartmentTreeCache(prefix);
+
+            public SystemSettingsCache SystemSettings => throw new NotImplementedException();
+            public DatabaseSettingsCache DatabaseSettings => throw new NotImplementedException();
+            public ProgramSettingsCache ProgramSettings => throw new NotImplementedException();
+            public PermissionModelsCache PermissionModels => throw new NotImplementedException();
+            public DbCategorySettingsCache DbCategorySettings => throw new NotImplementedException();
+            public TableSchemaCache TableSchema => throw new NotImplementedException();
+            public FormSchemaCache FormSchema => throw new NotImplementedException();
+            public FormLayoutCache FormLayout => throw new NotImplementedException();
+            public LanguageResourceCache LanguageResource => throw new NotImplementedException();
+            public SessionInfoCache SessionInfo => throw new NotImplementedException();
+            public CompanyInfoCache CompanyInfo => throw new NotImplementedException();
+            public CompanyRolePermissionsCache CompanyRolePermissions => throw new NotImplementedException();
+            public bool TryEvict(string cacheKey) => false;
+        }
+
+        private static readonly IReadOnlyList<DepartmentNode> s_emptyNodes = [];
+
+        private static MinimalCacheContainer NewContainer() =>
+            new MinimalCacheContainer(Guid.NewGuid().ToString("N"));
+
+        [Fact]
+        [DisplayName("DepartmentTreeService 建構子 cache 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullCache_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DepartmentTreeService(
+                    null!,
+                    new StubCompanyInfoService(null),
+                    new StubDepartmentRepository(s_emptyNodes)));
+        }
+
+        [Fact]
+        [DisplayName("DepartmentTreeService 建構子 companyInfoService 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullCompanyInfoService_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DepartmentTreeService(
+                    NewContainer(),
+                    null!,
+                    new StubDepartmentRepository(s_emptyNodes)));
+        }
+
+        [Fact]
+        [DisplayName("DepartmentTreeService 建構子 repository 為 null 應拋 ArgumentNullException")]
+        public void Constructor_NullRepository_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new DepartmentTreeService(
+                    NewContainer(),
+                    new StubCompanyInfoService(null),
+                    null!));
+        }
+
+        [Fact]
+        [DisplayName("Get 快取命中時應直接回傳快取的樹狀結構，不呼叫 repository")]
+        public void Get_CacheHit_ReturnsCachedTree()
+        {
+            var container = NewContainer();
+            var tree = new DepartmentTree("C001", s_emptyNodes);
+            container.DepartmentTree.Set(tree);
+
+            var service = new DepartmentTreeService(
+                container,
+                new StubCompanyInfoService(null),
+                new StubDepartmentRepository(s_emptyNodes));
+
+            var result = service.Get("C001");
+
+            Assert.NotNull(result);
+            Assert.Equal("C001", result.CompanyId);
+        }
+
+        [Fact]
+        [DisplayName("Get 快取未命中且公司不存在時應回傳 null")]
+        public void Get_CompanyNotFound_ReturnsNull()
+        {
+            var service = new DepartmentTreeService(
+                NewContainer(),
+                new StubCompanyInfoService(null),
+                new StubDepartmentRepository(s_emptyNodes));
+
+            var result = service.Get("UNKNOWN");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("Get 快取未命中且公司存在時應從 repository 建立樹並寫入快取")]
+        public void Get_CacheMissAndCompanyFound_BuildsAndCachesTree()
+        {
+            var container = NewContainer();
+            var company = new CompanyInfo { CompanyId = "C002", CompanyDatabaseId = "company_db" };
+            var node = new DepartmentNode(Guid.NewGuid(), "DEPT1", "部門一", Guid.Empty, Guid.Empty);
+
+            var service = new DepartmentTreeService(
+                container,
+                new StubCompanyInfoService(company),
+                new StubDepartmentRepository([node]));
+
+            var result = service.Get("C002");
+
+            Assert.NotNull(result);
+            Assert.Equal("C002", result.CompanyId);
+            Assert.Single(result.Nodes!);
+            Assert.NotNull(container.DepartmentTree.Get("C002"));
+        }
+
+        [Fact]
+        [DisplayName("Remove 應將指定公司的樹狀結構從快取移除")]
+        public void Remove_DelegatesToCache_EvictsEntry()
+        {
+            var container = NewContainer();
+            var tree = new DepartmentTree("C003", s_emptyNodes);
+            container.DepartmentTree.Set(tree);
+
+            var service = new DepartmentTreeService(
+                container,
+                new StubCompanyInfoService(null),
+                new StubDepartmentRepository(s_emptyNodes));
+            service.Remove("C003");
+
+            Assert.Null(container.DepartmentTree.Get("C003"));
+        }
+    }
+}

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoInitializeEndpointTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoInitializeEndpointTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using Bee.Api.Client;
+
+namespace Bee.UI.Core.UnitTests
+{
+    /// <summary>
+    /// 補強 <see cref="ClientInfo.Initialize(string)"/> 覆蓋率：
+    /// 驗證以有效本機路徑呼叫時能通過驗證並設定 ConnectType。
+    /// 因修改靜態狀態，納入 <c>ClientInfoState</c> collection 確保串行執行。
+    /// </summary>
+    [Collection("ClientInfoState")]
+    public class ClientInfoInitializeEndpointTests
+    {
+        private static string CreateTempDefinePath()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), $"bee-init-ep-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(Path.Combine(tempDir, "SystemSettings.xml"), "<SystemSettings />");
+            return tempDir;
+        }
+
+        [Fact]
+        [DisplayName("Initialize(string) 有效本機路徑通過驗證後應將 ConnectType 設為 Local")]
+        public void Initialize_StringEndpoint_ValidLocalPath_SetsConnectTypeToLocal()
+        {
+            var tempDir = CreateTempDefinePath();
+            var originalConnectType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            try
+            {
+                ApiClientInfo.SupportedConnectTypes = SupportedConnectTypes.Both;
+                // Initialize(string) 呼叫 SetEndpoint；Validate 通過後設 ConnectType，
+                // 再呼叫 SyncExecutor.Run；無本機 API 服務時 Run 拋例外向上傳播。
+                Record.Exception(() => ClientInfo.Initialize(tempDir));
+                Assert.Equal(ConnectType.Local, ApiClientInfo.ConnectType);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalConnectType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+                ApiClientInfo.SupportedConnectTypes = originalSupportedTypes;
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.ObjectCaching/Services/DepartmentTreeService.cs` | 0.0% | 7 |
| `src/Bee.ObjectCaching/LocalDefineAccess.cs` | 85.6% | 7 |
| `src/Bee.Hosting/CacheNotify/CacheNotifyPoller.cs` | 60.0% | 2 |
| `src/Bee.UI.Core/ClientInfo.cs` | 85.5% | 1 |
| `src/Bee.Definition/Organization/DepartmentNodeCollection.cs` | 20.0% | 4 |

## 測試說明

### `DepartmentTreeService`（新增 `Services/DepartmentTreeServiceTests.cs`）
- 建構子 null 防衛（3 項）
- `Get` 快取命中、公司不存在（回傳 null）、快取未命中建樹並寫入快取
- `Remove` 委派快取移除

### `LocalDefineAccess`（新增 `LocalDefineAccessMissingCoverageTests.cs`）
- `GetDefine(ProgramSettings/PermissionModels/Language)` 路由路徑
- `SavePermissionModels`、`SaveLanguage` 寫檔
- `SaveDefine(PermissionModels/Language)` 委派路徑

### `CacheNotifyPoller`（新增 `CacheNotifyPollerExecuteTests.cs`）
- `ExecuteAsync` 以預先取消的 token 啟動，驗證 baseline SafePoll 執行後正常結束
- `IntervalSeconds = 0` 時預設 5 秒路徑

### `ClientInfo`（新增 `ClientInfoInitializeEndpointTests.cs`）
- `Initialize(string endpoint)` 有效本機路徑通過驗證，ConnectType 設為 Local

### `DepartmentNodeCollection`（新增 `Organization/DepartmentNodeCollectionTests.cs`）
- `AddRange` null 輸入不拋例外
- `AddRange` 有效節點全部加入
- `AddRange` 含 null 項目自動略過
- `AddRange` 空集合不拋例外

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | 剩餘未覆蓋路徑（LoginAsync 成功/空 token 路徑）需 mock `SystemApiConnector.LoginAsync`，但該方法為非虛擬實作，無 mocking framework 下無法補測 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上 |

https://claude.ai/code/session_014ghmLb1u54SzWg7oMuu7dn

---
_Generated by [Claude Code](https://claude.ai/code/session_014ghmLb1u54SzWg7oMuu7dn)_