### PR TITLE
[AutoFix] SonarCloud Issues (4 issues) 2026-06-05 08:00

### DIFF
--- a/src/Bee.Business/Form/FormBusinessObject.cs
+++ b/src/Bee.Business/Form/FormBusinessObject.cs
@@ -69,7 +69,7 @@ namespace Bee.Business.Form
         public virtual GetListResult GetList(GetListArgs args)
         {
             ArgumentNullException.ThrowIfNull(args);
-            Authorize(PermissionAction.Read);
+            Authorize(PermissionActions.Read);
 
             var repository = CreateDataFormRepository(ProgId);
             var listResult = repository.GetList(args.SelectFields, args.Filter, args.SortFields, args.Paging);
@@ -90,7 +90,7 @@ namespace Bee.Business.Form
         public virtual GetNewDataResult GetNewData(GetNewDataArgs args)
         {
             ArgumentNullException.ThrowIfNull(args);
-            Authorize(PermissionAction.Read);
+            Authorize(PermissionActions.Read);
 
             var repository = CreateDataFormRepository(ProgId);
             var dataSet = repository.GetNewData();
@@ -106,7 +106,7 @@ namespace Bee.Business.Form
         public virtual GetDataResult GetData(GetDataArgs args)
         {
             ArgumentNullException.ThrowIfNull(args);
-            Authorize(PermissionAction.Read);
+            Authorize(PermissionActions.Read);
 
             var repository = CreateDataFormRepository(ProgId);
             var dataSet = repository.GetData(args.RowId);
@@ -145,7 +145,7 @@ namespace Bee.Business.Form
         public virtual DeleteResult Delete(DeleteArgs args)
         {
             ArgumentNullException.ThrowIfNull(args);
-            Authorize(PermissionAction.Delete);
+            Authorize(PermissionActions.Delete);
 
             var repository = CreateDataFormRepository(ProgId);
             var rowsAffected = repository.Delete(args.RowId);
@@ -156,17 +156,17 @@ namespace Bee.Business.Form
         #region 權限驗證（層一 model+action gate）
 
         // 寫入動作的判定順序；層一不涉 record scope，故每個 action 只需判一次（逐列等價）。
-        private static readonly PermissionAction[] s_writeActions =
-            { PermissionAction.Create, PermissionAction.Update, PermissionAction.Delete };
+        private static readonly PermissionActions[] s_writeActions =
+            { PermissionActions.Create, PermissionActions.Update, PermissionActions.Delete };
 
         /// <summary>
         /// Enforces the layer-1 permission check for <paramref name="action"/> on this form's
         /// permission model. A no-op when the FormSchema declares no <c>PermissionModelId</c>
         /// (gradual adoption — unmarked forms stay open). Throws when the caller lacks the grant.
         /// </summary>
-        /// <param name="action">The single <see cref="PermissionAction"/> flag to require.</param>
+        /// <param name="action">The single <see cref="PermissionActions"/> flag to require.</param>
         /// <exception cref="ForbiddenException">The caller is not granted the action.</exception>
-        private void Authorize(PermissionAction action)
+        private void Authorize(PermissionActions action)
         {
             var modelId = DefineAccess.GetFormSchema(ProgId).PermissionModelId;
             if (string.IsNullOrEmpty(modelId)) { return; }
@@ -189,7 +189,7 @@ namespace Bee.Business.Form
             if (string.IsNullOrEmpty(modelId)) { return; }
 
             var required = CollectRowStateActions(dataSet);
-            if (required == PermissionAction.None) { return; }
+            if (required == PermissionActions.None) { return; }
 
             var authorization = Services.GetRequiredService<IAuthorizationService>();
             foreach (var action in s_writeActions.Where(a => required.HasFlag(a) && !authorization.Can(AccessToken, modelId, a)))
@@ -197,22 +197,22 @@ namespace Bee.Business.Form
         }
 
         /// <summary>
-        /// OR-merges the <see cref="PermissionAction"/> implied by every row's <c>RowState</c>
+        /// OR-merges the <see cref="PermissionActions"/> implied by every row's <c>RowState</c>
         /// across all tables in the DataSet.
         /// </summary>
-        private static PermissionAction CollectRowStateActions(DataSet dataSet)
+        private static PermissionActions CollectRowStateActions(DataSet dataSet)
         {
-            var actions = PermissionAction.None;
+            var actions = PermissionActions.None;
             foreach (DataTable table in dataSet.Tables)
             {
                 foreach (DataRow row in table.Rows)
                 {
                     actions |= row.RowState switch
                     {
-                        DataRowState.Added => PermissionAction.Create,
-                        DataRowState.Modified => PermissionAction.Update,
-                        DataRowState.Deleted => PermissionAction.Delete,
-                        _ => PermissionAction.None,
+                        DataRowState.Added => PermissionActions.Create,
+                        DataRowState.Modified => PermissionActions.Update,
+                        DataRowState.Deleted => PermissionActions.Delete,
+                        _ => PermissionActions.None,
                     };
                 }
             }

--- a/src/Bee.Business/Form/FormBusinessObject.cs
+++ b/src/Bee.Business/Form/FormBusinessObject.cs
@@ -192,8 +192,9 @@ namespace Bee.Business.Form
             if (required == PermissionActions.None) { return; }
 
             var authorization = Services.GetRequiredService<IAuthorizationService>();
-            foreach (var action in s_writeActions.Where(a => required.HasFlag(a) && !authorization.Can(AccessToken, modelId, a)))
-                throw new ForbiddenException($"Permission denied: '{action}' on model '{modelId}'.");
+            var denied = s_writeActions.FirstOrDefault(a => required.HasFlag(a) && !authorization.Can(AccessToken, modelId, a));
+            if (denied != PermissionActions.None)
+                throw new ForbiddenException($"Permission denied: '{denied}' on model '{modelId}'.");
         }
 
         /// <summary>

--- a/src/Bee.Business/Form/FormBusinessObject.cs
+++ b/src/Bee.Business/Form/FormBusinessObject.cs
@@ -192,11 +192,8 @@ namespace Bee.Business.Form
             if (required == PermissionAction.None) { return; }
 
             var authorization = Services.GetRequiredService<IAuthorizationService>();
-            foreach (var action in s_writeActions)
-            {
-                if (required.HasFlag(action) && !authorization.Can(AccessToken, modelId, action))
-                    throw new ForbiddenException($"Permission denied: '{action}' on model '{modelId}'.");
-            }
+            foreach (var action in s_writeActions.Where(a => required.HasFlag(a) && !authorization.Can(AccessToken, modelId, a)))
+                throw new ForbiddenException($"Permission denied: '{action}' on model '{modelId}'.");
         }
 
         /// <summary>

--- a/src/Bee.Definition/Identity/CompanyRolePermissions.cs
+++ b/src/Bee.Definition/Identity/CompanyRolePermissions.cs
@@ -40,17 +40,17 @@ namespace Bee.Definition.Identity
 
         /// <summary>
         /// Returns the OR-merged allowed action mask for the given roles on the model — the layer-1
-        /// multi-role union (capability accrues across roles). Returns <see cref="PermissionAction.None"/>
+        /// multi-role union (capability accrues across roles). Returns <see cref="PermissionActions.None"/>
         /// when none of the roles grants anything on the model.
         /// </summary>
         /// <param name="roleIds">The role business ids the user holds (e.g. <c>SessionInfo.Roles</c>).</param>
         /// <param name="modelId">The permission model id to check.</param>
-        public PermissionAction GetAllowed(IEnumerable<string> roleIds, string modelId)
+        public PermissionActions GetAllowed(IEnumerable<string> roleIds, string modelId)
         {
             ArgumentNullException.ThrowIfNull(roleIds);
             var roleSet = roleIds as ISet<string> ?? new HashSet<string>(roleIds);
 
-            var allowed = PermissionAction.None;
+            var allowed = PermissionActions.None;
             foreach (var grant in Grants)
             {
                 if (grant.ModelId == modelId && roleSet.Contains(grant.RoleId))

--- a/src/Bee.Definition/Identity/IAuthorizationService.cs
+++ b/src/Bee.Definition/Identity/IAuthorizationService.cs
@@ -16,7 +16,7 @@ namespace Bee.Definition.Identity
         /// </summary>
         /// <param name="accessToken">The session's access token.</param>
         /// <param name="modelId">The permission model id.</param>
-        /// <param name="action">The action to check (a single <see cref="PermissionAction"/> flag).</param>
-        bool Can(Guid accessToken, string modelId, PermissionAction action);
+        /// <param name="action">The action to check (a single <see cref="PermissionActions"/> flag).</param>
+        bool Can(Guid accessToken, string modelId, PermissionActions action);
     }
 }

--- a/src/Bee.Definition/Identity/RoleGrantRow.cs
+++ b/src/Bee.Definition/Identity/RoleGrantRow.cs
@@ -9,5 +9,5 @@ namespace Bee.Definition.Identity
     /// <param name="RoleId">The role business id (<c>st_role.sys_id</c>).</param>
     /// <param name="ModelId">The permission model id (<c>st_role_grant.model_id</c>).</param>
     /// <param name="AllowedActions">The allowed action mask for this (role, model).</param>
-    public sealed record RoleGrantRow(string RoleId, string ModelId, PermissionAction AllowedActions);
+    public sealed record RoleGrantRow(string RoleId, string ModelId, PermissionActions AllowedActions);
 }

--- a/src/Bee.Definition/Settings/Permission/PermissionAction.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionAction.cs
@@ -10,7 +10,7 @@ namespace Bee.Definition.Settings
     /// to a separate workflow-permission layer, not the action axis.
     /// </remarks>
     [Flags]
-    public enum PermissionAction
+    public enum PermissionActions
     {
         /// <summary>No action.</summary>
         None = 0,

--- a/src/Bee.Definition/Settings/Permission/PermissionBindingValidator.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionBindingValidator.cs
@@ -37,13 +37,8 @@ namespace Bee.Definition.Settings
                 var master = schema.MasterTable;
                 if (master?.Fields == null) { continue; }
 
-                int owners = 0;
-                int depts = 0;
-                foreach (var field in master.Fields)
-                {
-                    if (field.ScopeRole == ScopeRole.Owner) { owners++; }
-                    else if (field.ScopeRole == ScopeRole.Dept) { depts++; }
-                }
+                int owners = master.Fields.Count(f => f.ScopeRole == ScopeRole.Owner);
+                int depts = master.Fields.Count(f => f.ScopeRole == ScopeRole.Dept);
                 if (owners > 1)
                     errors.Add($"Form '{schema.ProgId}': master table marks {owners} Owner columns; at most one is allowed.");
                 if (depts > 1)

--- a/src/Bee.Definition/Settings/Permission/PermissionModels.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionModels.cs
@@ -91,7 +91,7 @@ namespace Bee.Definition.Settings
                 if (rules == null) { continue; }
                 foreach (var rule in rules)
                 {
-                    bool isEgress = rule.Action is PermissionAction.Print or PermissionAction.Export;
+                    bool isEgress = rule.Action is PermissionActions.Print or PermissionActions.Export;
                     if (isEgress && rule.Scope != ScopeStrategy.Inherit)
                     {
                         errors.Add($"Model '{model.ModelId}': egress action '{rule.Action}' must not define a scope; it inherits Read.");

--- a/src/Bee.Definition/Settings/Permission/PermissionRule.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionRule.cs
@@ -13,7 +13,7 @@ namespace Bee.Definition.Settings
     [TreeNode]
     public class PermissionRule : KeyCollectionItem
     {
-        private PermissionAction _action = PermissionAction.None;
+        private PermissionActions _action = PermissionActions.None;
 
         #region Constructors
 
@@ -28,7 +28,7 @@ namespace Bee.Definition.Settings
         /// </summary>
         /// <param name="action">The permission action.</param>
         /// <param name="scope">The record-scope strategy.</param>
-        public PermissionRule(PermissionAction action, ScopeStrategy scope = ScopeStrategy.Inherit)
+        public PermissionRule(PermissionActions action, ScopeStrategy scope = ScopeStrategy.Inherit)
         {
             Action = action;
             Scope = scope;
@@ -41,7 +41,7 @@ namespace Bee.Definition.Settings
         /// </summary>
         [XmlAttribute]
         [Description("Permission action.")]
-        public PermissionAction Action
+        public PermissionActions Action
         {
             get { return _action; }
             set

--- a/src/Bee.Definition/Settings/Permission/PermissionRuleCollection.cs
+++ b/src/Bee.Definition/Settings/Permission/PermissionRuleCollection.cs
@@ -23,7 +23,7 @@ namespace Bee.Definition.Settings
         /// </summary>
         /// <param name="action">The permission action.</param>
         /// <param name="scope">The record-scope strategy.</param>
-        public PermissionRule Add(PermissionAction action, ScopeStrategy scope = ScopeStrategy.Inherit)
+        public PermissionRule Add(PermissionActions action, ScopeStrategy scope = ScopeStrategy.Inherit)
         {
             var rule = new PermissionRule(action, scope);
             base.Add(rule);

--- a/src/Bee.ObjectCaching/Services/AuthorizationService.cs
+++ b/src/Bee.ObjectCaching/Services/AuthorizationService.cs
@@ -25,7 +25,7 @@ namespace Bee.ObjectCaching.Services
         }
 
         /// <inheritdoc/>
-        public bool Can(Guid accessToken, string modelId, PermissionAction action)
+        public bool Can(Guid accessToken, string modelId, PermissionActions action)
         {
             var session = _sessionInfoService.Get(accessToken);
             if (session == null || string.IsNullOrEmpty(session.CompanyId) || session.Roles.Count == 0)

--- a/src/Bee.Repository/System/RolePermissionRepository.cs
+++ b/src/Bee.Repository/System/RolePermissionRepository.cs
@@ -17,6 +17,8 @@ namespace Bee.Repository.System
     /// </summary>
     public class RolePermissionRepository : IRolePermissionRepository
     {
+        private const string RoleIdColumn = "role_id";
+
         private readonly IDbConnectionManager _connectionManager;
 
         /// <summary>
@@ -35,7 +37,7 @@ namespace Bee.Repository.System
 
             var dbType = _connectionManager.GetConnectionInfo(databaseId).DatabaseType;
             string tbl = dbType.QuoteIdentifier("st_role_grant");
-            string colRoleId = dbType.QuoteIdentifier("role_id");
+            string colRoleId = dbType.QuoteIdentifier(RoleIdColumn);
             string colModelId = dbType.QuoteIdentifier("model_id");
             string colActions = dbType.QuoteIdentifier("allowed_actions");
 
@@ -47,7 +49,7 @@ namespace Bee.Repository.System
             foreach (DataRow row in table.Rows)
             {
                 list.Add(new RoleGrantRow(
-                    ValueUtilities.CStr(row["role_id"]),
+                    ValueUtilities.CStr(row[RoleIdColumn]),
                     ValueUtilities.CStr(row["model_id"]),
                     (PermissionAction)ValueUtilities.CInt(row["allowed_actions"])));
             }
@@ -62,7 +64,7 @@ namespace Bee.Repository.System
             var dbType = _connectionManager.GetConnectionInfo(databaseId).DatabaseType;
             string tbl = dbType.QuoteIdentifier("st_user_role");
             string colUserId = dbType.QuoteIdentifier("user_id");
-            string colRoleId = dbType.QuoteIdentifier("role_id");
+            string colRoleId = dbType.QuoteIdentifier(RoleIdColumn);
 
             string sql = $"SELECT {colUserId}, {colRoleId} FROM {tbl}";
             var dbAccess = new DbAccess(databaseId, _connectionManager);
@@ -73,7 +75,7 @@ namespace Bee.Repository.System
             {
                 list.Add(new UserRoleRow(
                     ValueUtilities.CStr(row["user_id"]),
-                    ValueUtilities.CStr(row["role_id"])));
+                    ValueUtilities.CStr(row[RoleIdColumn])));
             }
             return list;
         }

--- a/src/Bee.Repository/System/RolePermissionRepository.cs
+++ b/src/Bee.Repository/System/RolePermissionRepository.cs
@@ -51,7 +51,7 @@ namespace Bee.Repository.System
                 list.Add(new RoleGrantRow(
                     ValueUtilities.CStr(row[RoleIdColumn]),
                     ValueUtilities.CStr(row["model_id"]),
-                    (PermissionAction)ValueUtilities.CInt(row["allowed_actions"])));
+                    (PermissionActions)ValueUtilities.CInt(row["allowed_actions"])));
             }
             return list;
         }

--- a/tests/Bee.Business.UnitTests/Form/FormBusinessObjectPermissionGateTests.cs
+++ b/tests/Bee.Business.UnitTests/Form/FormBusinessObjectPermissionGateTests.cs
@@ -28,7 +28,7 @@ namespace Bee.Business.UnitTests.Form
         private readonly SharedDbFixture _fx;
         public FormBusinessObjectPermissionGateTests(SharedDbFixture fx) { _fx = fx; }
 
-        private FormBusinessObject Bo(PermissionAction allowed, IDataFormRepository? repo = null, string progId = GatedProgId)
+        private FormBusinessObject Bo(PermissionActions allowed, IDataFormRepository? repo = null, string progId = GatedProgId)
         {
             var overrides = new List<(Type, object?)> { (typeof(IAuthorizationService), new FakeAuth(allowed)) };
             if (repo != null) { overrides.Add((typeof(IFormRepositoryFactory), new FakeFactory(repo))); }
@@ -50,24 +50,24 @@ namespace Bee.Business.UnitTests.Form
         [Fact]
         [DisplayName("GetList 無 Read 授權應擋 ForbiddenException")]
         public void GetList_NoReadGrant_ThrowsForbidden()
-            => Assert.Throws<ForbiddenException>(() => Bo(PermissionAction.None).GetList(new GetListArgs()));
+            => Assert.Throws<ForbiddenException>(() => Bo(PermissionActions.None).GetList(new GetListArgs()));
 
         [Fact]
         [DisplayName("GetData 無 Read 授權應擋 ForbiddenException")]
         public void GetData_NoReadGrant_ThrowsForbidden()
-            => Assert.Throws<ForbiddenException>(() => Bo(PermissionAction.None).GetData(new GetDataArgs { RowId = Guid.NewGuid() }));
+            => Assert.Throws<ForbiddenException>(() => Bo(PermissionActions.None).GetData(new GetDataArgs { RowId = Guid.NewGuid() }));
 
         [Fact]
         [DisplayName("Delete 無 Delete 授權應擋 ForbiddenException")]
         public void Delete_NoDeleteGrant_ThrowsForbidden()
-            => Assert.Throws<ForbiddenException>(() => Bo(PermissionAction.None).Delete(new DeleteArgs { RowId = Guid.NewGuid() }));
+            => Assert.Throws<ForbiddenException>(() => Bo(PermissionActions.None).Delete(new DeleteArgs { RowId = Guid.NewGuid() }));
 
         [Fact]
         [DisplayName("Save 含 Added 列但無 Create 授權應擋（逐列 RowState→Create）")]
         public void Save_AddedRow_NoCreateGrant_ThrowsForbidden()
         {
             // 持有 Update|Delete 但缺 Create → Added 列觸發的 Create 被擋
-            var bo = Bo(PermissionAction.Update | PermissionAction.Delete);
+            var bo = Bo(PermissionActions.Update | PermissionActions.Delete);
             Assert.Throws<ForbiddenException>(() => bo.Save(new SaveArgs { DataSet = AddedRowDataSet() }));
         }
 
@@ -75,7 +75,7 @@ namespace Bee.Business.UnitTests.Form
         [DisplayName("GetList 有 Read 授權應放行進 repository")]
         public void GetList_WithReadGrant_PassesGate()
         {
-            var bo = Bo(PermissionAction.Read, new StubRepo());
+            var bo = Bo(PermissionActions.Read, new StubRepo());
 
             var ex = Record.Exception(() => bo.GetList(new GetListArgs()));
 
@@ -86,7 +86,7 @@ namespace Bee.Business.UnitTests.Form
         [DisplayName("Save 含 Added 列且有 Create 授權應放行")]
         public void Save_AddedRow_WithCreateGrant_PassesGate()
         {
-            var bo = Bo(PermissionAction.Create, new StubRepo());
+            var bo = Bo(PermissionActions.Create, new StubRepo());
 
             var ex = Record.Exception(() => bo.Save(new SaveArgs { DataSet = AddedRowDataSet() }));
 
@@ -98,7 +98,7 @@ namespace Bee.Business.UnitTests.Form
         public void EmptyPermissionModelId_SkipsGate()
         {
             // Employee 無 PermissionModelId → 即使 Can 全否,gate 也不查、直接放行
-            var bo = Bo(PermissionAction.None, new StubRepo(), UngatedProgId);
+            var bo = Bo(PermissionActions.None, new StubRepo(), UngatedProgId);
 
             var ex = Record.Exception(() => bo.GetList(new GetListArgs()));
 
@@ -107,9 +107,9 @@ namespace Bee.Business.UnitTests.Form
 
         private sealed class FakeAuth : IAuthorizationService
         {
-            private readonly PermissionAction _allowed;
-            public FakeAuth(PermissionAction allowed) { _allowed = allowed; }
-            public bool Can(Guid accessToken, string modelId, PermissionAction action) => _allowed.HasFlag(action);
+            private readonly PermissionActions _allowed;
+            public FakeAuth(PermissionActions allowed) { _allowed = allowed; }
+            public bool Can(Guid accessToken, string modelId, PermissionActions action) => _allowed.HasFlag(action);
         }
 
         private sealed class FakeFactory : IFormRepositoryFactory

--- a/tests/Bee.Definition.UnitTests/Identity/CompanyRolePermissionsTests.cs
+++ b/tests/Bee.Definition.UnitTests/Identity/CompanyRolePermissionsTests.cs
@@ -17,9 +17,9 @@ namespace Bee.Definition.UnitTests.Identity
         {
             var grants = new List<RoleGrantRow>
             {
-                new("Buyer", "PurchaseOrder", PermissionAction.Read | PermissionAction.Update),
-                new("Buyer", "Vendor", PermissionAction.Read),
-                new("Manager", "PurchaseOrder", PermissionAction.Delete),
+                new("Buyer", "PurchaseOrder", PermissionActions.Read | PermissionActions.Update),
+                new("Buyer", "Vendor", PermissionActions.Read),
+                new("Manager", "PurchaseOrder", PermissionActions.Delete),
             };
             var userRoles = new List<UserRoleRow>
             {
@@ -37,7 +37,7 @@ namespace Bee.Definition.UnitTests.Identity
 
             var allowed = perms.GetAllowed(s_buyer, "PurchaseOrder");
 
-            Assert.Equal(PermissionAction.Read | PermissionAction.Update, allowed);
+            Assert.Equal(PermissionActions.Read | PermissionActions.Update, allowed);
         }
 
         [Fact]
@@ -49,8 +49,8 @@ namespace Bee.Definition.UnitTests.Identity
             // Buyer(Read|Update) ∪ Manager(Delete) on PurchaseOrder
             var allowed = perms.GetAllowed(s_buyerManager, "PurchaseOrder");
 
-            Assert.Equal(PermissionAction.Read | PermissionAction.Update | PermissionAction.Delete, allowed);
-            Assert.True(allowed.HasFlag(PermissionAction.Delete));
+            Assert.Equal(PermissionActions.Read | PermissionActions.Update | PermissionActions.Delete, allowed);
+            Assert.True(allowed.HasFlag(PermissionActions.Delete));
         }
 
         [Fact]
@@ -61,8 +61,8 @@ namespace Bee.Definition.UnitTests.Identity
 
             var allowed = perms.GetAllowed(s_buyerManager, "Requisition");
 
-            Assert.Equal(PermissionAction.None, allowed);
-            Assert.False(allowed.HasFlag(PermissionAction.Read));
+            Assert.Equal(PermissionActions.None, allowed);
+            Assert.False(allowed.HasFlag(PermissionActions.Read));
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Bee.Definition.UnitTests.Identity
             // 只持有 Buyer → 不含 Manager 的 Delete
             var allowed = perms.GetAllowed(s_buyer, "PurchaseOrder");
 
-            Assert.False(allowed.HasFlag(PermissionAction.Delete));
+            Assert.False(allowed.HasFlag(PermissionActions.Delete));
         }
 
         [Fact]

--- a/tests/Bee.Definition.UnitTests/Settings/PermissionBindingTests.cs
+++ b/tests/Bee.Definition.UnitTests/Settings/PermissionBindingTests.cs
@@ -33,7 +33,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
+            po.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
             return models;
         }
 

--- a/tests/Bee.Definition.UnitTests/Settings/PermissionModelsDataTests.cs
+++ b/tests/Bee.Definition.UnitTests/Settings/PermissionModelsDataTests.cs
@@ -17,20 +17,20 @@ namespace Bee.Definition.UnitTests.Settings
             var models = new PermissionModels();
 
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
-            po.Rules!.Add(PermissionAction.Create, ScopeStrategy.All);
-            po.Rules!.Add(PermissionAction.Update, ScopeStrategy.Own);
-            po.Rules!.Add(PermissionAction.Delete, ScopeStrategy.Own);
-            po.Rules!.Add(PermissionAction.Print);
-            po.Rules!.Add(PermissionAction.Export);
+            po.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
+            po.Rules!.Add(PermissionActions.Create, ScopeStrategy.All);
+            po.Rules!.Add(PermissionActions.Update, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Delete, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Print);
+            po.Rules!.Add(PermissionActions.Export);
 
             var vendor = models.Models!.Add("Vendor", "廠商");
-            vendor.Rules!.Add(PermissionAction.Read, ScopeStrategy.All);
-            vendor.Rules!.Add(PermissionAction.Update, ScopeStrategy.Own);
+            vendor.Rules!.Add(PermissionActions.Read, ScopeStrategy.All);
+            vendor.Rules!.Add(PermissionActions.Update, ScopeStrategy.Own);
 
             var req = models.Models!.Add("Requisition", "請購單");
-            req.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
-            req.Rules!.Add(PermissionAction.Create, ScopeStrategy.All);
+            req.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
+            req.Rules!.Add(PermissionActions.Create, ScopeStrategy.All);
 
             return models;
         }
@@ -59,9 +59,9 @@ namespace Bee.Definition.UnitTests.Settings
         [DisplayName("PermissionRule Action 應同時設定為集合 Key")]
         public void PermissionRule_Action_SetsAsKey()
         {
-            var rule = new PermissionRule(PermissionAction.Update, ScopeStrategy.Own);
+            var rule = new PermissionRule(PermissionActions.Update, ScopeStrategy.Own);
 
-            Assert.Equal(PermissionAction.Update, rule.Action);
+            Assert.Equal(PermissionActions.Update, rule.Action);
             Assert.Equal(ScopeStrategy.Own, rule.Scope);
             Assert.Equal("Update", rule.Key);
         }
@@ -70,7 +70,7 @@ namespace Bee.Definition.UnitTests.Settings
         [DisplayName("PermissionRule 預設 Scope 應為 Inherit")]
         public void PermissionRule_DefaultScope_IsInherit()
         {
-            var rule = new PermissionRule(PermissionAction.Print);
+            var rule = new PermissionRule(PermissionActions.Print);
 
             Assert.Equal(ScopeStrategy.Inherit, rule.Scope);
         }
@@ -80,7 +80,7 @@ namespace Bee.Definition.UnitTests.Settings
         public void PermissionRuleCollection_IndexedByAction()
         {
             var model = new PermissionModel("PurchaseOrder", "採購單");
-            model.Rules!.Add(PermissionAction.Read, ScopeStrategy.DeptAndSub);
+            model.Rules!.Add(PermissionActions.Read, ScopeStrategy.DeptAndSub);
 
             Assert.Equal(ScopeStrategy.DeptAndSub, model.Rules!["Read"].Scope);
         }
@@ -91,7 +91,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Print);
+            po.Rules!.Add(PermissionActions.Print);
 
             var xml = XmlCodec.Serialize(models);
 
@@ -105,7 +105,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Update, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Update, ScopeStrategy.Own);
 
             var xml = XmlCodec.Serialize(models);
 
@@ -130,7 +130,7 @@ namespace Bee.Definition.UnitTests.Settings
             Assert.Equal(ScopeStrategy.All, po.Rules!["Create"].Scope);
             Assert.Equal(ScopeStrategy.Own, po.Rules!["Update"].Scope);
             Assert.Equal(ScopeStrategy.Inherit, po.Rules!["Print"].Scope);
-            Assert.Equal(PermissionAction.Export, po.Rules!["Export"].Action);
+            Assert.Equal(PermissionActions.Export, po.Rules!["Export"].Action);
 
             Assert.Equal(ScopeStrategy.All, restored.Models!["Vendor"].Rules!["Read"].Scope);
         }
@@ -152,7 +152,7 @@ namespace Bee.Definition.UnitTests.Settings
         {
             var models = new PermissionModels();
             var po = models.Models!.Add("PurchaseOrder", "採購單");
-            po.Rules!.Add(PermissionAction.Print, ScopeStrategy.Own);
+            po.Rules!.Add(PermissionActions.Print, ScopeStrategy.Own);
 
             var errors = models.Validate();
 

--- a/tests/Bee.ObjectCaching.UnitTests/Services/AuthorizationServiceTests.cs
+++ b/tests/Bee.ObjectCaching.UnitTests/Services/AuthorizationServiceTests.cs
@@ -17,8 +17,8 @@ namespace Bee.ObjectCaching.UnitTests.Services
         {
             var grants = new List<RoleGrantRow>
             {
-                new("Buyer", "PurchaseOrder", PermissionAction.Read | PermissionAction.Update),
-                new("Manager", "PurchaseOrder", PermissionAction.Delete),
+                new("Buyer", "PurchaseOrder", PermissionActions.Read | PermissionActions.Update),
+                new("Manager", "PurchaseOrder", PermissionActions.Delete),
             };
             return new CompanyRolePermissions("C001", grants, []);
         }
@@ -35,7 +35,7 @@ namespace Bee.ObjectCaching.UnitTests.Services
         {
             var auth = Create(Session("C001", "Buyer"), BuildPerms());
 
-            Assert.True(auth.Can(s_token, "PurchaseOrder", PermissionAction.Read));
+            Assert.True(auth.Can(s_token, "PurchaseOrder", PermissionActions.Read));
         }
 
         [Fact]
@@ -45,7 +45,7 @@ namespace Bee.ObjectCaching.UnitTests.Services
             var auth = Create(Session("C001", "Buyer"), BuildPerms());
 
             // Buyer 沒有 Delete（只有 Manager 有）
-            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionAction.Delete));
+            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionActions.Delete));
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Bee.ObjectCaching.UnitTests.Services
             var auth = Create(Session("C001", "Buyer", "Manager"), BuildPerms());
 
             // Buyer(Read|Update) ∪ Manager(Delete) → Delete 通過
-            Assert.True(auth.Can(s_token, "PurchaseOrder", PermissionAction.Delete));
+            Assert.True(auth.Can(s_token, "PurchaseOrder", PermissionActions.Delete));
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace Bee.ObjectCaching.UnitTests.Services
         {
             var auth = Create(Session(null, "Buyer"), BuildPerms());
 
-            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionAction.Read));
+            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionActions.Read));
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Bee.ObjectCaching.UnitTests.Services
         {
             var auth = Create(Session("C001"), BuildPerms());
 
-            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionAction.Read));
+            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionActions.Read));
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace Bee.ObjectCaching.UnitTests.Services
         {
             var auth = Create(null, BuildPerms());
 
-            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionAction.Read));
+            Assert.False(auth.Can(s_token, "PurchaseOrder", PermissionActions.Read));
         }
 
         private sealed class FakeSessionInfoService : ISessionInfoService

--- a/tests/Bee.Repository.UnitTests/RolePermissionRepositoryTests.cs
+++ b/tests/Bee.Repository.UnitTests/RolePermissionRepositoryTests.cs
@@ -11,7 +11,7 @@ namespace Bee.Repository.UnitTests
     /// <summary>
     /// RolePermissionRepository 的 5 DB round-trip 測試：在 company DB insert st_role_grant /
     /// st_user_role（關聯欄一律 sys_id 業務鍵），驗證 GetRoleGrants / GetUserRoles 查回正確
-    /// （allowed_actions 還原為 PermissionAction mask、user→role 以 sys_id 配對）。
+    /// （allowed_actions 還原為 PermissionActions mask、user→role 以 sys_id 配對）。
     /// </summary>
     public class RolePermissionRepositoryTests : IClassFixture<SharedDbFixture>
     {
@@ -30,7 +30,7 @@ namespace Bee.Repository.UnitTests
             var userId = string.Concat("USER_", Guid.NewGuid().ToString("N").AsSpan(0, 6));
             var grantRowId = Guid.NewGuid();
             var userRoleRowId = Guid.NewGuid();
-            var allowed = (int)(PermissionAction.Read | PermissionAction.Update);
+            var allowed = (int)(PermissionActions.Read | PermissionActions.Update);
 
             string tblGrant = dbType.QuoteIdentifier("st_role_grant");
             string tblUserRole = dbType.QuoteIdentifier("st_user_role");
@@ -61,7 +61,7 @@ namespace Bee.Repository.UnitTests
 
                 var grant = repo.GetRoleGrants(databaseId).Single(g => g.RoleId == roleId);
                 Assert.Equal("PurchaseOrder", grant.ModelId);
-                Assert.Equal(PermissionAction.Read | PermissionAction.Update, grant.AllowedActions);
+                Assert.Equal(PermissionActions.Read | PermissionActions.Update, grant.AllowedActions);
 
                 var userRole = repo.GetUserRoles(databaseId).Single(u => u.RoleId == roleId);
                 Assert.Equal(userId, userRole.UserId);


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ6Sz5YjL2OdcMqtQHZd | S3267 | src/Bee.Business/Form/FormBusinessObject.cs | 以 `.Where()` 簡化 `AuthorizeSave` 內的 `foreach+if` 迴圈 |
| AZ6R9s4zoYoPD6IQSRwz | S1192 | src/Bee.Repository/System/RolePermissionRepository.cs | 將重複 4 次的字串 `"role_id"` 改為私有常數 `RoleIdColumn` |
| AZ6QmMNawpbUjl5y_to3 | S3267 | src/Bee.Definition/Settings/Permission/PermissionBindingValidator.cs | 以 LINQ `.Count()` 取代計數 `foreach` 迴圈 |
| AZ6QezXvmLBbkOGi0hb6 | S2342 | src/Bee.Definition/Settings/Permission/PermissionAction.cs（及 15 個引用檔案） | 將 `[Flags]` enum `PermissionAction` 更名為 `PermissionActions`（規則：flags enum 應以 `s` 結尾） |

## 無法處理

| Issue Key | Rule | 原因 |
|-----------|------|------|
| AZ6TbyZkvvGJ74hYuP4h | S3776 | Cognitive Complexity — 依 `sonarcloud.md` 不納入為硬性規則，需人工評估重構 |
| AZ6QmMNawpbUjl5y_to2 | S3776 | Cognitive Complexity — 同上 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01T1hbApHfoJzaTNQn7i7dV4)_