### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-06-06 00:30

### DIFF
--- a/tests/Bee.Base.UnitTests/Exceptions/ForbiddenExceptionTests.cs
+++ b/tests/Bee.Base.UnitTests/Exceptions/ForbiddenExceptionTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Bee.Base.Exceptions;
 
 namespace Bee.Base.UnitTests.Exceptions

--- a/tests/Bee.Base.UnitTests/Exceptions/ForbiddenExceptionTests.cs
+++ b/tests/Bee.Base.UnitTests/Exceptions/ForbiddenExceptionTests.cs
@@ -1,0 +1,43 @@
+using Bee.Base.Exceptions;
+
+namespace Bee.Base.UnitTests.Exceptions
+{
+    public class ForbiddenExceptionTests
+    {
+        [Fact]
+        [DisplayName("單參數 ctor 應設定 Message，InnerException 為 null")]
+        public void Ctor_WithMessage_SetsMessage()
+        {
+            var ex = new ForbiddenException("permission denied");
+            Assert.Equal("permission denied", ex.Message);
+            Assert.Null(ex.InnerException);
+        }
+
+        [Fact]
+        [DisplayName("雙參數 ctor 應同時設定 Message 與 InnerException")]
+        public void Ctor_WithMessageAndInner_SetsBoth()
+        {
+            var inner = new InvalidOperationException("root cause");
+            var ex = new ForbiddenException("permission denied", inner);
+            Assert.Equal("permission denied", ex.Message);
+            Assert.Same(inner, ex.InnerException);
+        }
+
+        [Fact]
+        [DisplayName("ForbiddenException 應可由 catch (Exception) 接住")]
+        public void Throw_CanBeCaughtAsException()
+        {
+            Exception? caught = null;
+            try
+            {
+                throw new ForbiddenException("test");
+            }
+            catch (Exception ex)
+            {
+                caught = ex;
+            }
+            Assert.NotNull(caught);
+            Assert.IsType<ForbiddenException>(caught);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Organization/DepartmentNodeCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Organization/DepartmentNodeCollectionTests.cs
@@ -1,0 +1,49 @@
+using Bee.Definition.Organization;
+
+namespace Bee.Definition.UnitTests.Organization
+{
+    public class DepartmentNodeCollectionTests
+    {
+        private static DepartmentNode CreateNode(string id)
+            => new DepartmentNode(Guid.NewGuid(), id, id, Guid.Empty);
+
+        [Fact]
+        [DisplayName("AddRange 傳入 null 應直接返回，不拋例外")]
+        public void AddRange_NullInput_DoesNotThrow()
+        {
+            var collection = new DepartmentNodeCollection();
+            var exception = Record.Exception(() => collection.AddRange(null!));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("AddRange 傳入空集合應不新增任何節點")]
+        public void AddRange_EmptyCollection_DoesNotAddAny()
+        {
+            var collection = new DepartmentNodeCollection();
+            collection.AddRange(Array.Empty<DepartmentNode>());
+            Assert.Empty(collection);
+        }
+
+        [Fact]
+        [DisplayName("AddRange 集合含 null 元素應略過 null，只新增有效節點")]
+        public void AddRange_CollectionWithNullElements_SkipsNulls()
+        {
+            var collection = new DepartmentNodeCollection();
+            var node = CreateNode("DEPT01");
+            var nodes = new DepartmentNode[] { node, null! };
+            collection.AddRange(nodes);
+            Assert.Single(collection);
+        }
+
+        [Fact]
+        [DisplayName("AddRange 傳入有效節點集合應全部新增至 collection")]
+        public void AddRange_ValidNodes_AddsAll()
+        {
+            var collection = new DepartmentNodeCollection();
+            var nodes = new[] { CreateNode("A"), CreateNode("B"), CreateNode("C") };
+            collection.AddRange(nodes);
+            Assert.Equal(3, collection.Count);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Organization/DepartmentNodeCollectionTests.cs
+++ b/tests/Bee.Definition.UnitTests/Organization/DepartmentNodeCollectionTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Bee.Definition.Organization;
 
 namespace Bee.Definition.UnitTests.Organization

--- a/tests/Bee.Definition.UnitTests/Organization/EmployeeRowTests.cs
+++ b/tests/Bee.Definition.UnitTests/Organization/EmployeeRowTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Bee.Definition.Organization;
 
 namespace Bee.Definition.UnitTests.Organization

--- a/tests/Bee.Definition.UnitTests/Organization/EmployeeRowTests.cs
+++ b/tests/Bee.Definition.UnitTests/Organization/EmployeeRowTests.cs
@@ -1,0 +1,70 @@
+using Bee.Definition.Organization;
+
+namespace Bee.Definition.UnitTests.Organization
+{
+    public class EmployeeRowTests
+    {
+        [Fact]
+        [DisplayName("EmployeeRow ctor 應正確設定所有屬性")]
+        public void Ctor_SetsAllProperties()
+        {
+            var rowId = Guid.NewGuid();
+            var deptRowId = Guid.NewGuid();
+            var userRowId = Guid.NewGuid();
+
+            var row = new EmployeeRow(rowId, "EMP001", "張三", deptRowId, userRowId);
+
+            Assert.Equal(rowId, row.RowId);
+            Assert.Equal("EMP001", row.EmployeeId);
+            Assert.Equal("張三", row.EmployeeName);
+            Assert.Equal(deptRowId, row.DeptRowId);
+            Assert.Equal(userRowId, row.UserRowId);
+        }
+
+        [Fact]
+        [DisplayName("EmployeeRow 相同屬性值的兩個實例應相等")]
+        public void Equality_SameValues_AreEqual()
+        {
+            var rowId = Guid.NewGuid();
+            var deptRowId = Guid.NewGuid();
+            var userRowId = Guid.NewGuid();
+
+            var a = new EmployeeRow(rowId, "EMP001", "張三", deptRowId, userRowId);
+            var b = new EmployeeRow(rowId, "EMP001", "張三", deptRowId, userRowId);
+
+            Assert.Equal(a, b);
+            Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        }
+
+        [Fact]
+        [DisplayName("EmployeeRow ToString 應回傳含所有屬性資訊的字串")]
+        public void ToString_ContainsPropertyValues()
+        {
+            var rowId = Guid.NewGuid();
+            var row = new EmployeeRow(rowId, "EMP001", "張三", Guid.Empty, Guid.Empty);
+
+            var str = row.ToString();
+
+            Assert.Contains("EMP001", str);
+            Assert.Contains("張三", str);
+        }
+
+        [Fact]
+        [DisplayName("EmployeeRow Deconstruct 應正確拆解所有屬性")]
+        public void Deconstruct_ReturnsAllProperties()
+        {
+            var rowId = Guid.NewGuid();
+            var deptRowId = Guid.NewGuid();
+            var userRowId = Guid.NewGuid();
+            var row = new EmployeeRow(rowId, "EMP001", "張三", deptRowId, userRowId);
+
+            var (actualRowId, actualEmpId, actualEmpName, actualDeptRowId, actualUserRowId) = row;
+
+            Assert.Equal(rowId, actualRowId);
+            Assert.Equal("EMP001", actualEmpId);
+            Assert.Equal("張三", actualEmpName);
+            Assert.Equal(deptRowId, actualDeptRowId);
+            Assert.Equal(userRowId, actualUserRowId);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Settings/CacheNotifyOptionsTests.cs
+++ b/tests/Bee.Definition.UnitTests/Settings/CacheNotifyOptionsTests.cs
@@ -1,0 +1,26 @@
+using Bee.Definition.Settings;
+
+namespace Bee.Definition.UnitTests.Settings
+{
+    public class CacheNotifyOptionsTests
+    {
+        [Fact]
+        [DisplayName("CacheNotifyOptions 預設值應符合規格（Enabled=true、IntervalSeconds=5、MarginSeconds=5、DatabaseId=common）")]
+        public void DefaultValues_MatchExpectedDefaults()
+        {
+            var options = new CacheNotifyOptions();
+            Assert.True(options.Enabled);
+            Assert.Equal(5, options.IntervalSeconds);
+            Assert.Equal(5, options.MarginSeconds);
+            Assert.Equal("common", options.DatabaseId);
+        }
+
+        [Fact]
+        [DisplayName("ToString 應回傳型別名稱 CacheNotifyOptions")]
+        public void ToString_ReturnsTypeName()
+        {
+            var options = new CacheNotifyOptions();
+            Assert.Equal("CacheNotifyOptions", options.ToString());
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Settings/CacheNotifyOptionsTests.cs
+++ b/tests/Bee.Definition.UnitTests/Settings/CacheNotifyOptionsTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Bee.Definition.Settings;
 
 namespace Bee.Definition.UnitTests.Settings

--- a/tests/Bee.Definition.UnitTests/Storage/IDefineAccessDefaultMethodTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/IDefineAccessDefaultMethodTests.cs
@@ -1,0 +1,85 @@
+using Bee.Definition.Database;
+using Bee.Definition.Forms;
+using Bee.Definition.Language;
+using Bee.Definition.Layouts;
+using Bee.Definition.Settings;
+using Bee.Definition.Storage;
+
+namespace Bee.Definition.UnitTests.Storage
+{
+    /// <summary>
+    /// 驗證 <see cref="IDefineAccess"/> 三個預設介面實作（DIM）的委派行為：
+    /// <c>GetPermissionModels</c>、<c>SavePermissionModels</c>、
+    /// <c>GetFormLayout(customizeId, layoutId)</c>。
+    /// 透過 <see cref="MinimalDefineAccess"/> stub（不覆寫三個 DIM）呼叫，
+    /// 確認預設路徑確實執行。
+    /// </summary>
+    public class IDefineAccessDefaultMethodTests
+    {
+        private sealed class MinimalDefineAccess : IDefineAccess
+        {
+            public DefineType? LastSavedDefineType { get; private set; }
+            public string? LastGetFormLayoutId { get; private set; }
+
+            public object GetDefine(DefineType defineType, string[]? keys = null)
+                => defineType == DefineType.PermissionModels
+                    ? new PermissionModels()
+                    : throw new NotImplementedException();
+
+            public void SaveDefine(DefineType defineType, object defineObject, string[]? keys = null)
+                => LastSavedDefineType = defineType;
+
+            public SystemSettings GetSystemSettings() => throw new NotImplementedException();
+            public void SaveSystemSettings(SystemSettings settings) => throw new NotImplementedException();
+            public DatabaseSettings GetDatabaseSettings() => throw new NotImplementedException();
+            public void SaveDatabaseSettings(DatabaseSettings settings) => throw new NotImplementedException();
+            public ProgramSettings GetProgramSettings() => throw new NotImplementedException();
+            public void SaveProgramSettings(ProgramSettings settings) => throw new NotImplementedException();
+            public DbCategorySettings GetDbCategorySettings() => throw new NotImplementedException();
+            public void SaveDbCategorySettings(DbCategorySettings settings) => throw new NotImplementedException();
+            public TableSchema GetTableSchema(string categoryId, string tableName) => throw new NotImplementedException();
+            public void SaveTableSchema(string categoryId, TableSchema tableSchema) => throw new NotImplementedException();
+            public FormSchema GetFormSchema(string progId) => throw new NotImplementedException();
+            public void SaveFormSchema(FormSchema formSchema) => throw new NotImplementedException();
+            public FormLayout GetFormLayout(string layoutId)
+            {
+                LastGetFormLayoutId = layoutId;
+                return new FormLayout();
+            }
+            public void SaveFormLayout(FormLayout formLayout) => throw new NotImplementedException();
+            public LanguageResource GetLanguage(string lang, string ns) => throw new NotImplementedException();
+            public void SaveLanguage(LanguageResource resource) => throw new NotImplementedException();
+        }
+
+        [Fact]
+        [DisplayName("GetPermissionModels 預設實作應委派至 GetDefine(DefineType.PermissionModels) 並回傳 PermissionModels")]
+        public void GetPermissionModels_DefaultImpl_DelegatesToGetDefine()
+        {
+            IDefineAccess access = new MinimalDefineAccess();
+            var result = access.GetPermissionModels();
+            Assert.NotNull(result);
+            Assert.IsType<PermissionModels>(result);
+        }
+
+        [Fact]
+        [DisplayName("SavePermissionModels 預設實作應委派至 SaveDefine(DefineType.PermissionModels, ...)")]
+        public void SavePermissionModels_DefaultImpl_DelegatesToSaveDefine()
+        {
+            var stub = new MinimalDefineAccess();
+            IDefineAccess access = stub;
+            access.SavePermissionModels(new PermissionModels());
+            Assert.Equal(DefineType.PermissionModels, stub.LastSavedDefineType);
+        }
+
+        [Fact]
+        [DisplayName("GetFormLayout(customizeId, layoutId) 預設實作應忽略 customizeId 並委派至 GetFormLayout(layoutId)")]
+        public void GetFormLayout_WithCustomizeId_DefaultImpl_DelegatesToSingleParam()
+        {
+            var stub = new MinimalDefineAccess();
+            IDefineAccess access = stub;
+            var result = access.GetFormLayout("any_customize", "TestLayout");
+            Assert.NotNull(result);
+            Assert.Equal("TestLayout", stub.LastGetFormLayoutId);
+        }
+    }
+}

--- a/tests/Bee.Definition.UnitTests/Storage/IDefineAccessDefaultMethodTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/IDefineAccessDefaultMethodTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Bee.Definition.Database;
 using Bee.Definition.Forms;
 using Bee.Definition.Language;


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Definition/Organization/DepartmentNodeCollection.cs` | 20.0% | 4 |
| `src/Bee.Definition/Storage/IDefineAccess.cs` | 33.3% | 3 |
| `src/Bee.Definition/Settings/SystemSettings/CacheNotifyOptions.cs` | 80.0% | 2 |
| `src/Bee.Definition/Organization/EmployeeRow.cs` | 83.3% | 4 |
| `src/Bee.Base/Exceptions/ForbiddenException.cs` | 50.0% | 3 |

## 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | Blazor 模板渲染邏輯，需要 bUnit 才能覆蓋；無法在現有純 C# 測試中觸發 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 同上 |
| `src/Bee.UI.Core/ClientInfo.cs` | 已有 8 個測試檔，剩餘 12 個未覆蓋行需要真實 API 服務（`SyncExecutor.Run(() => SystemApiConnector.InitializeAsync())` 須連線成功）|
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor.cs` | `SystemApiConnector.LoginAsync` 非 virtual，無法在無服務的情況下 mock 成功登入路徑 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor.cs` | 同上 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面宣告，無可執行程式碼；SonarCloud 報告的 2 個覆蓋行為量測產物 |

https://claude.ai/code/session_0176Nxmivy1HcKVHEVeiMWxp

---
_Generated by [Claude Code](https://claude.ai/code/session_0176Nxmivy1HcKVHEVeiMWxp)_