### PR TITLE
test(definition): 補 FileDefineStorage Language/ProgramSettings 覆蓋

### DIFF
--- a/tests/Bee.Definition.UnitTests/DefineTypeExtensionsTests.cs
+++ b/tests/Bee.Definition.UnitTests/DefineTypeExtensionsTests.cs
@@ -33,5 +33,12 @@ namespace Bee.Definition.UnitTests
 
             Assert.Throws<NotSupportedException>(() => invalid.ToClrType());
         }
+
+        [Fact]
+        [DisplayName("ToClrType Language 未在映射字典中應拋出 NotSupportedException")]
+        public void ToClrType_Language_ThrowsNotSupportedException()
+        {
+            Assert.Throws<NotSupportedException>(() => DefineType.Language.ToClrType());
+        }
     }
 }

--- a/tests/Bee.Definition.UnitTests/Storage/FileDefineStorageTests.cs
+++ b/tests/Bee.Definition.UnitTests/Storage/FileDefineStorageTests.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using Bee.Base.Data;
 using Bee.Definition.Database;
 using Bee.Definition.Forms;
+using Bee.Definition.Language;
 using Bee.Definition.Layouts;
 using Bee.Definition.Settings;
 using Bee.Definition.Storage;
@@ -152,6 +153,63 @@ namespace Bee.Definition.UnitTests.Storage
 
                 // Act & Assert
                 Assert.Throws<FileNotFoundException>(() => storage.GetDbCategorySettings());
+            });
+        }
+
+        [Fact]
+        [DisplayName("SaveProgramSettings / GetProgramSettings 應可寫入後讀回")]
+        public void SaveAndGetProgramSettings_RoundTrips()
+        {
+            WithTempDefinePath(paths =>
+            {
+                var storage = new FileDefineStorage(paths);
+                var settings = new ProgramSettings();
+
+                storage.SaveProgramSettings(settings);
+                var restored = storage.GetProgramSettings();
+
+                Assert.NotNull(restored);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetProgramSettings 檔案不存在應拋出 FileNotFoundException")]
+        public void GetProgramSettings_FileNotFound_Throws()
+        {
+            WithTempDefinePath(paths =>
+            {
+                var storage = new FileDefineStorage(paths);
+                Assert.Throws<FileNotFoundException>(() => storage.GetProgramSettings());
+            });
+        }
+
+        [Fact]
+        [DisplayName("SaveLanguage / GetLanguage 應可寫入後讀回相同語言資源")]
+        public void SaveAndGetLanguage_RoundTrips()
+        {
+            WithTempDefinePath(paths =>
+            {
+                var storage = new FileDefineStorage(paths);
+                var resource = new LanguageResource { Lang = "en", Namespace = "Core" };
+
+                storage.SaveLanguage(resource);
+                var restored = storage.GetLanguage("en", "Core");
+
+                Assert.NotNull(restored);
+                Assert.Equal("en", restored!.Lang);
+                Assert.Equal("Core", restored.Namespace);
+            });
+        }
+
+        [Fact]
+        [DisplayName("GetLanguage 檔案不存在應回傳 null（非拋例外）")]
+        public void GetLanguage_FileNotFound_ReturnsNull()
+        {
+            WithTempDefinePath(paths =>
+            {
+                var storage = new FileDefineStorage(paths);
+                var result = storage.GetLanguage("zh-TW", "Missing");
+                Assert.Null(result);
             });
         }
 


### PR DESCRIPTION
## Summary

- 新增 `using Bee.Definition.Language` 至 `FileDefineStorageTests.cs`
- 新增 5 個 `[Fact]` 測試覆蓋先前未走到的路徑：

| 新增測試 | 覆蓋路徑 |
|---------|---------|
| `SaveAndGetProgramSettings_RoundTrips` | `FileDefineStorage.SaveProgramSettings` + `GetProgramSettings` 正常路徑 |
| `GetProgramSettings_FileNotFound_Throws` | `FileDefineStorage.GetProgramSettings` → `ValidateFilePath` → `FileNotFoundException` |
| `SaveAndGetLanguage_RoundTrips` | `FileDefineStorage.SaveLanguage` + `GetLanguage` 正常路徑 |
| `GetLanguage_FileNotFound_ReturnsNull` | `FileDefineStorage.GetLanguage` 中 `!File.Exists → return null`（與其他 Get 方法不同，不拋例外） |
| `ToClrType_Language_ThrowsNotSupportedException` | `DefineTypeExtensions.ToClrType` 對 `DefineType.Language`（未在映射字典中）的 `NotSupportedException` 分支 |

## Test plan

- [ ] CI strict build 通過（analyzer gate）
- [ ] 所有新增 `[Fact]` 均 pass
- [ ] `GetLanguage_FileNotFound_ReturnsNull` 特別驗證 Language 的 null-return 行為（與其他 Get 方法拋出 `FileNotFoundException` 不同）

https://claude.ai/code/session_01BtL8vwPydKvAW41aDb86Vu

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtL8vwPydKvAW41aDb86Vu)_