### PR TITLE
[AutoFix] Coverage Fix (4 files) 2026-06-07 16:30

### DIFF
--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormRenderTreeTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormRenderTreeTests.cs
@@ -1,0 +1,96 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DataObjects;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    public class DynamicFormRenderTreeTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(DynamicForm).GetMethod("BuildRenderTree",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        private static FormDataObject CreateMinimalDataObject()
+        {
+            var schema = new FormSchema("Test", "Test");
+            schema.Tables!.Add("Test", "Test");
+            return new FormDataObject(schema);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Layout 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullLayout_RendersEmptyState()
+        {
+            var component = new DynamicForm();
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullDataObject_RendersEmptyState()
+        {
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new FormLayout());
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 設定 Layout 與 DataObject 並含所有 ControlType 欄位時應渲染完整表單，不拋例外")]
+        public void BuildRenderTree_WithAllControlTypes_RendersFormWithoutThrowing()
+        {
+            var layout = new FormLayout { ColumnCount = 3 };
+            var section = new LayoutSection { Name = "Main", Caption = "Section", ShowCaption = true };
+            section.Fields!.Add(new LayoutField { FieldName = "text_f", Caption = "Text", ControlType = ControlType.TextEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "check_f", Caption = "Check", ControlType = ControlType.CheckEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "date_f", Caption = "Date", ControlType = ControlType.DateEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "month_f", Caption = "Month", ControlType = ControlType.YearMonthEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "memo_f", Caption = "Memo", ControlType = ControlType.MemoEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "drop_f", Caption = "Dropdown", ControlType = ControlType.DropDownEdit, Visible = true });
+            layout.Sections!.Add(section);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, CreateMinimalDataObject());
+
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Section ShowCaption 為 false 時應略過 legend 渲染，不拋例外")]
+        public void BuildRenderTree_SectionShowCaptionFalse_SkipsCaption()
+        {
+            var layout = new FormLayout();
+            var section = new LayoutSection { Name = "NoCaption", ShowCaption = false };
+            section.Fields!.Add(new LayoutField { FieldName = "name_f", Caption = "Name", ControlType = ControlType.TextEdit, Visible = true });
+            layout.Sections!.Add(section);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, CreateMinimalDataObject());
+
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridRenderTreeTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicGridRenderTreeTests.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Server.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    public class DynamicGridRenderTreeTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(DynamicGrid).GetMethod("BuildRenderTree",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        [Fact]
+        [DisplayName("BuildRenderTree Layout 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullLayout_RendersEmptyState()
+        {
+            var component = new DynamicGrid();
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Rows 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullRows_RendersEmptyState()
+        {
+            var component = new DynamicGrid();
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new LayoutGrid());
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Rows 為空 DataTable 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_EmptyRows_RendersEmptyState()
+        {
+            var component = new DynamicGrid();
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new LayoutGrid());
+            typeof(DynamicGrid)
+                .GetProperty("Rows", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new DataTable());
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 設定 Layout 與含資料列的 Rows 時應渲染表格，不拋例外")]
+        public void BuildRenderTree_WithLayoutAndRows_RendersDataTable()
+        {
+            var layout = new LayoutGrid();
+            layout.Columns!.Add(new LayoutColumn { FieldName = "name", Caption = "Name", Visible = true, Width = 120 });
+            layout.Columns.Add(new LayoutColumn { FieldName = "amount", Caption = "Amount", Visible = true });
+
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            table.Columns.Add("amount", typeof(double));
+            var row = table.NewRow();
+            row["name"] = "Alice";
+            row["amount"] = 1234.56;
+            table.Rows.Add(row);
+
+            var component = new DynamicGrid();
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            typeof(DynamicGrid)
+                .GetProperty("Rows", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, table);
+
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormRenderTreeTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormRenderTreeTests.cs
@@ -1,0 +1,96 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DataObjects;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    public class DynamicFormRenderTreeTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(DynamicForm).GetMethod("BuildRenderTree",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        private static FormDataObject CreateMinimalDataObject()
+        {
+            var schema = new FormSchema("Test", "Test");
+            schema.Tables!.Add("Test", "Test");
+            return new FormDataObject(schema);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Layout 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullLayout_RendersEmptyState()
+        {
+            var component = new DynamicForm();
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullDataObject_RendersEmptyState()
+        {
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new FormLayout());
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 設定 Layout 與 DataObject 並含所有 ControlType 欄位時應渲染完整表單，不拋例外")]
+        public void BuildRenderTree_WithAllControlTypes_RendersFormWithoutThrowing()
+        {
+            var layout = new FormLayout { ColumnCount = 3 };
+            var section = new LayoutSection { Name = "Main", Caption = "Section", ShowCaption = true };
+            section.Fields!.Add(new LayoutField { FieldName = "text_f", Caption = "Text", ControlType = ControlType.TextEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "check_f", Caption = "Check", ControlType = ControlType.CheckEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "date_f", Caption = "Date", ControlType = ControlType.DateEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "month_f", Caption = "Month", ControlType = ControlType.YearMonthEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "memo_f", Caption = "Memo", ControlType = ControlType.MemoEdit, Visible = true });
+            section.Fields.Add(new LayoutField { FieldName = "drop_f", Caption = "Dropdown", ControlType = ControlType.DropDownEdit, Visible = true });
+            layout.Sections!.Add(section);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, CreateMinimalDataObject());
+
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Section ShowCaption 為 false 時應略過 legend 渲染，不拋例外")]
+        public void BuildRenderTree_SectionShowCaptionFalse_SkipsCaption()
+        {
+            var layout = new FormLayout();
+            var section = new LayoutSection { Name = "NoCaption", ShowCaption = false };
+            section.Fields!.Add(new LayoutField { FieldName = "name_f", Caption = "Name", ControlType = ControlType.TextEdit, Visible = true });
+            layout.Sections!.Add(section);
+
+            var component = new DynamicForm();
+            typeof(DynamicForm)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            typeof(DynamicForm)
+                .GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, CreateMinimalDataObject());
+
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridRenderTreeTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicGridRenderTreeTests.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Wasm.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    public class DynamicGridRenderTreeTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(DynamicGrid).GetMethod("BuildRenderTree",
+                BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        [Fact]
+        [DisplayName("BuildRenderTree Layout 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullLayout_RendersEmptyState()
+        {
+            var component = new DynamicGrid();
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Rows 為 null 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_NullRows_RendersEmptyState()
+        {
+            var component = new DynamicGrid();
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new LayoutGrid());
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree Rows 為空 DataTable 時應渲染空白區塊，不拋例外")]
+        public void BuildRenderTree_EmptyRows_RendersEmptyState()
+        {
+            var component = new DynamicGrid();
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new LayoutGrid());
+            typeof(DynamicGrid)
+                .GetProperty("Rows", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, new DataTable());
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 設定 Layout 與含資料列的 Rows 時應渲染表格，不拋例外")]
+        public void BuildRenderTree_WithLayoutAndRows_RendersDataTable()
+        {
+            var layout = new LayoutGrid();
+            layout.Columns!.Add(new LayoutColumn { FieldName = "name", Caption = "Name", Visible = true, Width = 120 });
+            layout.Columns.Add(new LayoutColumn { FieldName = "amount", Caption = "Amount", Visible = true });
+
+            var table = new DataTable();
+            table.Columns.Add("name", typeof(string));
+            table.Columns.Add("amount", typeof(double));
+            var row = table.NewRow();
+            row["name"] = "Alice";
+            row["amount"] = 1234.56;
+            table.Rows.Add(row);
+
+            var component = new DynamicGrid();
+            typeof(DynamicGrid)
+                .GetProperty("Layout", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, layout);
+            typeof(DynamicGrid)
+                .GetProperty("Rows", BindingFlags.Public | BindingFlags.Instance)!
+                .SetValue(component, table);
+
+            var builder = new RenderTreeBuilder();
+            var exception = Record.Exception(() => s_buildRenderTree.Invoke(component, new object[] { builder }));
+            Assert.Null(exception);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 0.0% | 4 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 0.0% | 4 |
| `src/Bee.Web.Blazor.Wasm/Components/DynamicGrid.razor` | 0.0% | 4 |
| `src/Bee.Web.Blazor.Server/Components/DynamicGrid.razor` | 0.0% | 4 |

### 補強策略

這 4 個 `.razor` 檔案的覆蓋率為 0% 是因為 Blazor Razor 模板編譯後的 `BuildRenderTree` 方法從未被執行。新增測試透過反射呼叫 `BuildRenderTree`，覆蓋下列模板分支：

- **DynamicForm.razor**：`Layout`/`DataObject` 為 null 的空白路徑、全部 6 種 `ControlType`（TextEdit、CheckEdit、DateEdit、YearMonthEdit、MemoEdit、DropDownEdit）、以及 `ShowCaption` 開關路徑
- **DynamicGrid.razor**：`Layout`/`Rows` 為 null 的空白路徑、空 DataTable 路徑、以及含資料列的完整表格渲染路徑

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Core/ClientInfo.cs`（85.5%，12 行未覆蓋） | 剩餘未覆蓋行為 `InitializeConnect` 的 `return true`（需真實 API 服務）、`SetEndpoint` 的 `SaveEndpoint`（需 API 呼叫成功）、以及 `Initialize(IUIViewService)` 中的 Endpoint CLI 引數分支（需以 `Endpoint=xxx` 啟動程序），在單元測試環境下無法提供這些條件。 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kza2NqEu225YkgvVqdPcow)_