### PR TITLE
[AutoFix] Coverage Fix (4 files) 2026-06-08 00:45

### DIFF
--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeLoginPanelRenderTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/BeeLoginPanelRenderTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Server.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="BeeLoginPanel"/> Razor 模板 <c>BuildRenderTree</c> 的覆蓋率。
+    /// 測試在無 DI 環境下直接呼叫 <c>BuildRenderTree</c>，
+    /// 涵蓋有無錯誤訊息的兩條條件分支。
+    /// </summary>
+    public class BeeLoginPanelRenderTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(BeeLoginPanel)
+                .GetMethod("BuildRenderTree", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_errorField =
+            typeof(BeeLoginPanel).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static void Render(BeeLoginPanel component)
+        {
+            var builder = new RenderTreeBuilder();
+            s_buildRenderTree.Invoke(component, new object[] { builder });
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 無錯誤訊息時不應拋出例外")]
+        public void BuildRenderTree_NoError_DoesNotThrow()
+        {
+            var component = new BeeLoginPanel();
+            var ex = Record.Exception(() => Render(component));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 有錯誤訊息時應渲染錯誤提示區塊且不拋出例外")]
+        public void BuildRenderTree_WithError_DoesNotThrow()
+        {
+            var component = new BeeLoginPanel();
+            s_errorField.SetValue(component, "登入失敗：憑證無效");
+            var ex = Record.Exception(() => Render(component));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageRenderTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/FormPageRenderTests.cs
@@ -1,0 +1,107 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DataObjects;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> Razor 模板 <c>BuildRenderTree</c> 的覆蓋率。
+    /// 測試在無 DI 環境下以反射設定私有欄位並呼叫 <c>BuildRenderTree</c>，
+    /// 涵蓋錯誤、Loading、完整工具列（IsDirty false / true）四條模板分支。
+    /// </summary>
+    public class FormPageRenderTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(FormPage)
+                .GetMethod("BuildRenderTree", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_errorField =
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_isInitializingField =
+            typeof(FormPage).GetField("_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_dataObjectField =
+            typeof(FormPage).GetField("_dataObject", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static void Render(FormPage page)
+        {
+            var builder = new RenderTreeBuilder();
+            s_buildRenderTree.Invoke(page, new object[] { builder });
+        }
+
+        private static FormDataObject CreateFreshDataObject()
+        {
+            var schema = new FormSchema("Test", "Test");
+            schema.Tables!.Add("Test", "Test");
+            return new FormDataObject(schema);
+        }
+
+        private static FormDataObject CreateDirtyDataObject()
+        {
+            var schema = new FormSchema("Test", "Test");
+            var masterTable = schema.Tables!.Add("Test", "Test");
+            masterTable.Fields!.Add("name", "名稱", FieldDbType.String);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            dataObject.SetField("name", "dirty-value");
+            return dataObject;
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 有錯誤訊息時應渲染錯誤區塊且不拋出例外")]
+        public void BuildRenderTree_WithError_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_errorField.SetValue(page, "初始化失敗");
+            s_isInitializingField.SetValue(page, false);
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 初始化進行中時應渲染 Loading 區塊且不拋出例外")]
+        public void BuildRenderTree_Initializing_DoesNotThrow()
+        {
+            var page = new FormPage();
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject 為 null 且已完成初始化時應渲染 Loading 區塊且不拋出例外")]
+        public void BuildRenderTree_DataObjectNull_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_isInitializingField.SetValue(page, false);
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject 已設定且 IsDirty 為 false 時應渲染完整工具列且不拋出例外")]
+        public void BuildRenderTree_DataObjectSet_NotDirty_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_isInitializingField.SetValue(page, false);
+            s_dataObjectField.SetValue(page, CreateFreshDataObject());
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject IsDirty 為 true 時應渲染 unsaved 提示且不拋出例外")]
+        public void BuildRenderTree_DataObjectDirty_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_isInitializingField.SetValue(page, false);
+            s_dataObjectField.SetValue(page, CreateDirtyDataObject());
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeLoginPanelRenderTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeLoginPanelRenderTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Web.Blazor.Wasm.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="BeeLoginPanel"/> Razor 模板 <c>BuildRenderTree</c> 的覆蓋率。
+    /// 測試在無 DI 環境下直接呼叫 <c>BuildRenderTree</c>，
+    /// 涵蓋有無錯誤訊息的兩條條件分支。
+    /// </summary>
+    public class BeeLoginPanelRenderTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(BeeLoginPanel)
+                .GetMethod("BuildRenderTree", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_errorField =
+            typeof(BeeLoginPanel).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static void Render(BeeLoginPanel component)
+        {
+            var builder = new RenderTreeBuilder();
+            s_buildRenderTree.Invoke(component, new object[] { builder });
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 無錯誤訊息時不應拋出例外")]
+        public void BuildRenderTree_NoError_DoesNotThrow()
+        {
+            var component = new BeeLoginPanel();
+            var ex = Record.Exception(() => Render(component));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 有錯誤訊息時應渲染錯誤提示區塊且不拋出例外")]
+        public void BuildRenderTree_WithError_DoesNotThrow()
+        {
+            var component = new BeeLoginPanel();
+            s_errorField.SetValue(component, "登入失敗：憑證無效");
+            var ex = Record.Exception(() => Render(component));
+            Assert.Null(ex);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageRenderTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/FormPageRenderTests.cs
@@ -1,0 +1,107 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DataObjects;
+using Microsoft.AspNetCore.Components.Rendering;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> Razor 模板 <c>BuildRenderTree</c> 的覆蓋率。
+    /// 測試在無 DI 環境下以反射設定私有欄位並呼叫 <c>BuildRenderTree</c>，
+    /// 涵蓋錯誤、Loading、完整工具列（IsDirty false / true）四條模板分支。
+    /// </summary>
+    public class FormPageRenderTests
+    {
+        private static readonly MethodInfo s_buildRenderTree =
+            typeof(FormPage)
+                .GetMethod("BuildRenderTree", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_errorField =
+            typeof(FormPage).GetField("_error", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_isInitializingField =
+            typeof(FormPage).GetField("_isInitializing", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static readonly FieldInfo s_dataObjectField =
+            typeof(FormPage).GetField("_dataObject", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        private static void Render(FormPage page)
+        {
+            var builder = new RenderTreeBuilder();
+            s_buildRenderTree.Invoke(page, new object[] { builder });
+        }
+
+        private static FormDataObject CreateFreshDataObject()
+        {
+            var schema = new FormSchema("Test", "Test");
+            schema.Tables!.Add("Test", "Test");
+            return new FormDataObject(schema);
+        }
+
+        private static FormDataObject CreateDirtyDataObject()
+        {
+            var schema = new FormSchema("Test", "Test");
+            var masterTable = schema.Tables!.Add("Test", "Test");
+            masterTable.Fields!.Add("name", "名稱", FieldDbType.String);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            dataObject.SetField("name", "dirty-value");
+            return dataObject;
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 有錯誤訊息時應渲染錯誤區塊且不拋出例外")]
+        public void BuildRenderTree_WithError_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_errorField.SetValue(page, "初始化失敗");
+            s_isInitializingField.SetValue(page, false);
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree 初始化進行中時應渲染 Loading 區塊且不拋出例外")]
+        public void BuildRenderTree_Initializing_DoesNotThrow()
+        {
+            var page = new FormPage();
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject 為 null 且已完成初始化時應渲染 Loading 區塊且不拋出例外")]
+        public void BuildRenderTree_DataObjectNull_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_isInitializingField.SetValue(page, false);
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject 已設定且 IsDirty 為 false 時應渲染完整工具列且不拋出例外")]
+        public void BuildRenderTree_DataObjectSet_NotDirty_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_isInitializingField.SetValue(page, false);
+            s_dataObjectField.SetValue(page, CreateFreshDataObject());
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        [DisplayName("BuildRenderTree DataObject IsDirty 為 true 時應渲染 unsaved 提示且不拋出例外")]
+        public void BuildRenderTree_DataObjectDirty_DoesNotThrow()
+        {
+            var page = new FormPage();
+            s_isInitializingField.SetValue(page, false);
+            s_dataObjectField.SetValue(page, CreateDirtyDataObject());
+            var ex = Record.Exception(() => Render(page));
+            Assert.Null(ex);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Wasm/Components/BeeLoginPanel.razor` | 0.0% | 2 |
| `src/Bee.Web.Blazor.Server/Components/BeeLoginPanel.razor` | 0.0% | 2 |
| `src/Bee.Web.Blazor.Wasm/Components/FormPage.razor` | 0.0% | 5 |
| `src/Bee.Web.Blazor.Server/Components/FormPage.razor` | 0.0% | 5 |

### 補強策略

所有 `.razor` 檔案的覆蓋率為 0% 是因為 Blazor Razor 模板編譯後的 `BuildRenderTree` 方法從未被執行。新增測試透過反射呼叫 `BuildRenderTree`，覆蓋各模板分支：

- **BeeLoginPanel.razor**（Wasm / Server）：無錯誤訊息路徑（`@if (!string.IsNullOrEmpty(_error))` false 分支）、有錯誤訊息路徑（true 分支）
- **FormPage.razor**（Wasm / Server）：`_error not null` 錯誤路徑、`_isInitializing` 初始化路徑、`_dataObject is null` 空物件路徑、`IsDirty = false` 完整工具列路徑、`IsDirty = true` unsaved 提示路徑

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.Base/Tracing/ITraceListener.cs`（2 行未覆蓋，0%） | 純介面，無可執行程式碼。`TraceListener` 實作已由 `TraceListenerTests.cs` 與 `TracerTests.cs` 完整覆蓋，含 null writer 建構子與 `TraceEnd(null)` 保護分支。SonarCloud 回報的 2 個未覆蓋行為介面宣告的分析工件，無法透過新增測試改善。 |


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xr8Wz86YTXC7kjmbjtHtHZ)_