### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-06-09 08:42

### DIFF
--- a/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormControlTypeRenderTests.cs
+++ b/tests/Bee.Web.Blazor.Server.UnitTests/Components/DynamicFormControlTypeRenderTests.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Server.Components;
+using Bee.Web.Blazor.Server.DataObjects;
+using Bunit;
+
+namespace Bee.Web.Blazor.Server.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 DynamicForm.razor switch 中 YearMonthEdit / MemoEdit / DropDownEdit 分支的渲染覆蓋率。
+    /// </summary>
+    public class DynamicFormControlTypeRenderTests : BunitContext
+    {
+        private static void SetFirstFieldControlType(FormLayout layout, ControlType controlType)
+        {
+            layout.Sections![0].Fields![0].ControlType = controlType;
+        }
+
+        [Fact]
+        [DisplayName("DynamicForm YearMonthEdit 欄位應渲染 input[type=month] 元素")]
+        public void DynamicForm_YearMonthEditField_RendersMonthInput()
+        {
+            var schema = new FormSchema("T", "T");
+            schema.Tables!.Add("T", "T").Fields!.Add("report_month", "Month", FieldDbType.String);
+            var layout = schema.GetFormLayout();
+            SetFirstFieldControlType(layout, ControlType.YearMonthEdit);
+            var dataObject = new FormDataObject(schema);
+
+            var cut = Render<DynamicForm>(p => p
+                .Add(c => c.Layout, layout)
+                .Add(c => c.DataObject, dataObject));
+
+            Assert.NotNull(cut.Find("input[type='month']"));
+        }
+
+        [Fact]
+        [DisplayName("DynamicForm MemoEdit 欄位應渲染 textarea 元素")]
+        public void DynamicForm_MemoEditField_RendersTextarea()
+        {
+            var schema = new FormSchema("T", "T");
+            schema.Tables!.Add("T", "T").Fields!.Add("remark", "Remark", FieldDbType.String);
+            var layout = schema.GetFormLayout();
+            SetFirstFieldControlType(layout, ControlType.MemoEdit);
+            var dataObject = new FormDataObject(schema);
+
+            var cut = Render<DynamicForm>(p => p
+                .Add(c => c.Layout, layout)
+                .Add(c => c.DataObject, dataObject));
+
+            Assert.NotNull(cut.Find("textarea.bee-dynamic-form__input--memo"));
+        }
+
+        [Fact]
+        [DisplayName("DynamicForm DropDownEdit 欄位應渲染 select 元素並包含選項")]
+        public void DynamicForm_DropDownEditField_RendersSelectWithOptions()
+        {
+            var schema = new FormSchema("T", "T");
+            var master = schema.Tables!.Add("T", "T");
+            var schemaField = master.Fields!.Add("status", "Status", FieldDbType.String);
+            schemaField.ListItems!.Add("A", "Active");
+            schemaField.ListItems.Add("I", "Inactive");
+            var layout = schema.GetFormLayout();
+            SetFirstFieldControlType(layout, ControlType.DropDownEdit);
+            var dataObject = new FormDataObject(schema);
+
+            var cut = Render<DynamicForm>(p => p
+                .Add(c => c.Layout, layout)
+                .Add(c => c.DataObject, dataObject));
+
+            Assert.NotNull(cut.Find("select.bee-dynamic-form__input--select"));
+            Assert.Equal(2, cut.FindAll("option").Count);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeAccessTokenProviderRenderTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/BeeAccessTokenProviderRenderTests.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel;
+using Bee.Web.Blazor.Wasm.Components;
+using Bunit;
+using Microsoft.AspNetCore.Components;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 BeeAccessTokenProvider.razor @ChildContent?.Invoke(this) 渲染行的覆蓋率。
+    /// </summary>
+    public class BeeAccessTokenProviderRenderTests : BunitContext
+    {
+        [Fact]
+        [DisplayName("BeeAccessTokenProvider 傳入 ChildContent 時應渲染子內容")]
+        public void BeeAccessTokenProvider_WithChildContent_RendersChildContent()
+        {
+            RenderFragment<BeeAccessTokenProvider> childContent =
+                _ => builder => builder.AddContent(0, "child-content-test");
+
+            var cut = Render<BeeAccessTokenProvider>(p => p
+                .Add(c => c.ChildContent, childContent));
+
+            Assert.Contains("child-content-test", cut.Markup);
+        }
+    }
+}

--- a/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormControlTypeRenderTests.cs
+++ b/tests/Bee.Web.Blazor.Wasm.UnitTests/Components/DynamicFormControlTypeRenderTests.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.Web.Blazor.Wasm.Components;
+using Bee.Web.Blazor.Wasm.DataObjects;
+using Bunit;
+
+namespace Bee.Web.Blazor.Wasm.UnitTests.Components
+{
+    /// <summary>
+    /// 補強 DynamicForm.razor switch 中 YearMonthEdit / MemoEdit / DropDownEdit 分支的渲染覆蓋率。
+    /// </summary>
+    public class DynamicFormControlTypeRenderTests : BunitContext
+    {
+        private static void SetFirstFieldControlType(FormLayout layout, ControlType controlType)
+        {
+            layout.Sections![0].Fields![0].ControlType = controlType;
+        }
+
+        [Fact]
+        [DisplayName("DynamicForm YearMonthEdit 欄位應渲染 input[type=month] 元素")]
+        public void DynamicForm_YearMonthEditField_RendersMonthInput()
+        {
+            var schema = new FormSchema("T", "T");
+            schema.Tables!.Add("T", "T").Fields!.Add("report_month", "Month", FieldDbType.String);
+            var layout = schema.GetFormLayout();
+            SetFirstFieldControlType(layout, ControlType.YearMonthEdit);
+            var dataObject = new FormDataObject(schema);
+
+            var cut = Render<DynamicForm>(p => p
+                .Add(c => c.Layout, layout)
+                .Add(c => c.DataObject, dataObject));
+
+            Assert.NotNull(cut.Find("input[type='month']"));
+        }
+
+        [Fact]
+        [DisplayName("DynamicForm MemoEdit 欄位應渲染 textarea 元素")]
+        public void DynamicForm_MemoEditField_RendersTextarea()
+        {
+            var schema = new FormSchema("T", "T");
+            schema.Tables!.Add("T", "T").Fields!.Add("remark", "Remark", FieldDbType.String);
+            var layout = schema.GetFormLayout();
+            SetFirstFieldControlType(layout, ControlType.MemoEdit);
+            var dataObject = new FormDataObject(schema);
+
+            var cut = Render<DynamicForm>(p => p
+                .Add(c => c.Layout, layout)
+                .Add(c => c.DataObject, dataObject));
+
+            Assert.NotNull(cut.Find("textarea.bee-dynamic-form__input--memo"));
+        }
+
+        [Fact]
+        [DisplayName("DynamicForm DropDownEdit 欄位應渲染 select 元素並包含選項")]
+        public void DynamicForm_DropDownEditField_RendersSelectWithOptions()
+        {
+            var schema = new FormSchema("T", "T");
+            var master = schema.Tables!.Add("T", "T");
+            var schemaField = master.Fields!.Add("status", "Status", FieldDbType.String);
+            schemaField.ListItems!.Add("A", "Active");
+            schemaField.ListItems.Add("I", "Inactive");
+            var layout = schema.GetFormLayout();
+            SetFirstFieldControlType(layout, ControlType.DropDownEdit);
+            var dataObject = new FormDataObject(schema);
+
+            var cut = Render<DynamicForm>(p => p
+                .Add(c => c.Layout, layout)
+                .Add(c => c.DataObject, dataObject));
+
+            Assert.NotNull(cut.Find("select.bee-dynamic-form__input--select"));
+            Assert.Equal(2, cut.FindAll("option").Count);
+        }
+    }
+}


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.Web.Blazor.Wasm/Components/DynamicForm.razor` | 64.7% | 3 |
| `src/Bee.Web.Blazor.Server/Components/DynamicForm.razor` | 64.7% | 3 |
| `src/Bee.Web.Blazor.Wasm/Components/BeeAccessTokenProvider.razor` | 0.0% | 1 |

### 補強說明

**DynamicForm.razor（Wasm / Server）**  
新增 `DynamicFormControlTypeRenderTests.cs`，以 bUnit 渲染具有以下 ControlType 的 DynamicForm，覆蓋 switch 三個未執行分支：
- `YearMonthEdit` → 渲染 `<input type="month">`
- `MemoEdit` → 渲染 `<textarea>`
- `DropDownEdit` → 渲染 `<select>` 含選項

**BeeAccessTokenProvider.razor（Wasm）**  
新增 `BeeAccessTokenProviderRenderTests.cs`，以 bUnit 傳入非 null 的 `ChildContent`，覆蓋 `@ChildContent?.Invoke(this)` 渲染行。

### 無法處理（共 2 筆）

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Core/ClientInfo.cs` | 殘餘 12 行（`InitializeConnect` return true、`SetEndpoint` 的 `SaveEndpoint`）需要運行中的 API 伺服器，或命令列注入 `Endpoint=` 參數，無法在 CI 環境補測 |
| `src/Bee.Base/Tracing/ITraceListener.cs` | 純介面宣告，SonarCloud 回報的 2 行為介面方法宣告行，無可執行邏輯 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01785FePpCVBFSMSt1Pc3tzS)_