### PR TITLE
tests: fill coverage gaps in FormDataObject, FormView/FormPage, ClientInfo

### DIFF
--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewClientInfoTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewClientInfoTests.cs
@@ -1,0 +1,70 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Client;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Client.Providers;
+using Bee.Tests.Shared;
+using Bee.UI.Avalonia.Controls;
+using Bee.UI.Core;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls
+{
+    /// <summary>
+    /// 驗證 <see cref="FormView"/> 的預設 Resolve 路徑委派到 <see cref="ClientInfo"/>，
+    /// 涵蓋 Local 與 Remote 兩種連線模式。
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ClientInfo"/> / <see cref="ApiClientInfo"/> 持有 process-wide 靜態狀態；
+    /// 每個測試以 <see cref="ClientInfoTestScope"/> 保護，並透過 <c>[Collection("ClientInfo")]</c>
+    /// 與其他修改同一靜態狀態的 test class 串行執行。
+    /// </remarks>
+    [Collection("ClientInfo")]
+    public class FormViewClientInfoTests
+    {
+        private const string TestProgId = "Employee";
+        private static readonly object[] s_testProgIdArgs = [TestProgId];
+
+        [Theory]
+        [InlineData(ConnectType.Local)]
+        [InlineData(ConnectType.Remote)]
+        [DisplayName("預設 Resolve 路徑會委派到 ClientInfo，Local/Remote 兩種模式都可正確建立連線物件")]
+        public void Default_Resolve_DelegatesToClientInfo(ConnectType connectType)
+        {
+            using var scope = new ClientInfoTestScope();
+            ApiClientInfo.ConnectType = connectType;
+            ApiClientInfo.Endpoint = connectType == ConnectType.Remote
+                ? "http://localhost/jsonrpc/api"
+                : string.Empty;
+
+            // Clear cached connector so it is rebuilt with the current ConnectType.
+            var systemConnectorField = typeof(ClientInfo).GetField(
+                "_systemConnector", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(systemConnectorField);
+            systemConnectorField!.SetValue(null, null);
+
+            var view = new FormView();
+            var resolveSystem = typeof(FormView).GetMethod(
+                "ResolveSystemConnector", BindingFlags.NonPublic | BindingFlags.Instance);
+            var resolveForm = typeof(FormView).GetMethod(
+                "ResolveFormConnector", BindingFlags.NonPublic | BindingFlags.Instance);
+            var resolveToken = typeof(FormView).GetMethod(
+                "ResolveAccessToken", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(resolveSystem);
+            Assert.NotNull(resolveForm);
+            Assert.NotNull(resolveToken);
+
+            var system = (SystemApiConnector?)resolveSystem!.Invoke(view, Array.Empty<object>());
+            Assert.NotNull(system);
+            var form = (FormApiConnector)resolveForm!.Invoke(view, s_testProgIdArgs)!;
+            Assert.Equal(TestProgId, form.ProgId);
+            var token = (Guid)resolveToken!.Invoke(view, Array.Empty<object>())!;
+            Assert.Equal(ClientInfo.AccessToken, token);
+
+            var expectedProviderType = connectType == ConnectType.Local
+                ? typeof(LocalApiProvider)
+                : typeof(RemoteApiProvider);
+            Assert.IsType(expectedProviderType, system!.Provider);
+            Assert.IsType(expectedProviderType, form.Provider);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
@@ -194,6 +194,59 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
             Assert.Equal("backend rejected", captured!.Message);
         }
 
+        [Fact]
+        [DisplayName("InitializeAsync 已初始化後第二次呼叫為 no-op（不重建 DataObject 也不重新載入列表）")]
+        public async Task InitializeAsync_AlreadyInitialized_SecondCallIsNoOp()
+        {
+            var schema = BuildEmployeeSchema();
+            schema.ListFields = "sys_id,sys_name";
+            int getListCallCount = 0;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ =>
+                {
+                    getListCallCount++;
+                    return new GetListResponse { Table = BuildEmployeeListTable(Guid.NewGuid(), "Alice") };
+                },
+            };
+            var view = new TestFormView { Schema = schema, FormConnector = connector };
+            await view.InitializeAsync();
+            var firstDataObject = view.DataObject;
+
+            await view.InitializeAsync();
+
+            Assert.Same(firstDataObject, view.DataObject);
+            Assert.Equal(1, getListCallCount);
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteClickedAsync 成功刪除後 MasterRow 為 null")]
+        public async Task OnDeleteClickedAsync_WithLoadedRow_DeletesAndResetsDataObject()
+        {
+            var schema = BuildEmployeeSchema();
+            var rowId = Guid.NewGuid();
+            Guid? deletedRowId = null;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Eve") },
+                GetDataHandler = _ => new GetDataResponse { DataSet = BuildServerDataSet(rowId, "Eve") },
+                DeleteHandler = id =>
+                {
+                    deletedRowId = id;
+                    return new DeleteResponse();
+                },
+            };
+            var view = new TestFormView { Schema = schema, FormConnector = connector };
+            await view.InitializeAsync();
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+            Assert.NotNull(view.DataObject!.MasterRow);
+
+            await InvokePrivateAsync(view, "OnDeleteClickedAsync");
+
+            Assert.Equal(rowId, deletedRowId);
+            Assert.Null(view.DataObject.MasterRow);
+        }
+
         /// <summary>
         /// Overrides the <c>Resolve*</c> hooks so tests never read the process-wide
         /// <c>ClientInfo</c> statics; the unused <c>ResolveFormConnector</c> throws to

--- a/tests/Bee.UI.Avalonia.UnitTests/DataObjects/FormDataObjectTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/DataObjects/FormDataObjectTests.cs
@@ -453,6 +453,54 @@ namespace Bee.UI.Avalonia.UnitTests.DataObjects
             await Assert.ThrowsAsync<InvalidOperationException>(() => dataObject.DeleteAsync());
         }
 
+        [Fact]
+        [DisplayName("GetField 在 DateTime 欄位含時間分量時回傳 yyyy-MM-ddTHH:mm:ss 格式")]
+        public void GetField_DateTime_WithTimeComponent_ReturnsIsoDateTimeFormat()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+            var dt = new DateTime(2026, 5, 21, 14, 30, 0, DateTimeKind.Unspecified);
+            dataObject.MasterRow!["hire_date"] = dt;
+            var result = dataObject.GetField("hire_date");
+            Assert.Equal("2026-05-21T14:30:00", result);
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 Guid 欄位後 GetField 可讀回相同字串")]
+        public void SetField_Guid_RoundTripsThroughGetField()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+            var guid = Guid.NewGuid();
+            dataObject.SetField(SysFields.RowId, guid.ToString());
+            Assert.Equal(guid.ToString(), dataObject.GetField(SysFields.RowId));
+            Assert.Equal(guid, (Guid)dataObject.MasterRow![SysFields.RowId]);
+            Assert.True(dataObject.IsDirty);
+        }
+
+        private static FormSchema BuildSchemaWithBinary()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add("avatar", "Avatar", FieldDbType.Binary);
+            return schema;
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 Binary 欄位後儲存 byte[]，GetField 回傳 System.Byte[] 字串")]
+        public void SetField_Binary_StoresBytesFromBase64()
+        {
+            var schema = BuildSchemaWithBinary();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            var bytes = new byte[] { 0x01, 0x02, 0x03 };
+            var base64 = Convert.ToBase64String(bytes);
+            dataObject.SetField("avatar", base64);
+            Assert.Equal(bytes, (byte[])dataObject.MasterRow!["avatar"]);
+            Assert.True(dataObject.IsDirty);
+            Assert.Equal("System.Byte[]", dataObject.GetField("avatar"));
+        }
+
         /// <summary>
         /// Test double that bypasses the real JSON-RPC pipeline by overriding every
         /// virtual CRUD method on <see cref="FormApiConnector"/>. The base constructor

--- a/tests/Bee.UI.Core.UnitTests/ClientInfoLocalEndpointTests.cs
+++ b/tests/Bee.UI.Core.UnitTests/ClientInfoLocalEndpointTests.cs
@@ -71,6 +71,31 @@ namespace Bee.UI.Core.UnitTests
         }
 
         [Fact]
+        [DisplayName("Initialize(string) 有效本機路徑通過驗證後應將 ConnectType 設為 Local")]
+        public void Initialize_StringEndpoint_ValidLocalPath_SetsConnectTypeToLocal()
+        {
+            var tempDir = CreateTempDefinePath();
+            var originalConnectType = ApiClientInfo.ConnectType;
+            var originalEndpoint = ApiClientInfo.Endpoint;
+            var originalSupportedTypes = ApiClientInfo.SupportedConnectTypes;
+            try
+            {
+                ApiClientInfo.SupportedConnectTypes = SupportedConnectTypes.Both;
+                // Initialize(string) delegates to SetEndpoint which validates + calls
+                // SetConnectType; no local API service → SyncExecutor.Run throws.
+                Record.Exception(() => ClientInfo.Initialize(tempDir));
+                Assert.Equal(ConnectType.Local, ApiClientInfo.ConnectType);
+            }
+            finally
+            {
+                ApiClientInfo.ConnectType = originalConnectType;
+                ApiClientInfo.Endpoint = originalEndpoint;
+                ApiClientInfo.SupportedConnectTypes = originalSupportedTypes;
+                try { Directory.Delete(tempDir, recursive: true); } catch (IOException) { }
+            }
+        }
+
+        [Fact]
         [DisplayName("SetEndpoint 有效本機路徑通過驗證後應將 ConnectType 設為 Local")]
         public void SetEndpoint_ValidLocalPath_SetsConnectTypeToLocal()
         {

--- a/tests/Bee.UI.Maui.UnitTests/Controls/FormPageTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/FormPageTests.cs
@@ -195,6 +195,85 @@ namespace Bee.UI.Maui.UnitTests.Controls
             Assert.Equal("backend rejected", captured!.Message);
         }
 
+        [Fact]
+        [DisplayName("ComputeSelectFields 在 ListFields 非空時自動在頭部加上 sys_rowid")]
+        public async Task ComputeSelectFields_WithListFields_PrependsSysRowId()
+        {
+            var schema = BuildEmployeeSchema();
+            schema.ListFields = "sys_id,sys_name";
+            string? capturedSelectFields = null;
+            var connector = new SelectCapturingConnector(
+                sf => capturedSelectFields = sf,
+                BuildEmployeeListTable(Guid.NewGuid(), "Alice"));
+            var page = new FormPage { Schema = schema, FormConnector = connector };
+
+            await page.InitializeAsync();
+
+            Assert.Equal("sys_rowid,sys_id,sys_name", capturedSelectFields);
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteClickedAsync 成功刪除後 MasterRow 為 null")]
+        public async Task OnDeleteClickedAsync_WithLoadedRow_DeletesAndResetsDataObject()
+        {
+            var schema = BuildEmployeeSchema();
+            var rowId = Guid.NewGuid();
+            Guid? deletedRowId = null;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = () => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Eve") },
+                GetDataHandler = id => new GetDataResponse { DataSet = BuildServerDataSet(id, "Eve") },
+                DeleteHandler = id =>
+                {
+                    deletedRowId = id;
+                    return new DeleteResponse();
+                },
+            };
+            var page = new FormPage { Schema = schema, FormConnector = connector };
+            await page.InitializeAsync();
+
+            var rowSelectedMethod = typeof(FormPage).GetMethod(
+                "OnRowSelectedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            await (Task)rowSelectedMethod!.Invoke(page, new object[] { rowId })!;
+            Assert.NotNull(page.DataObject!.MasterRow);
+
+            var deleteMethod = typeof(FormPage).GetMethod(
+                "OnDeleteClickedAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            await (Task)deleteMethod!.Invoke(page, Array.Empty<object>())!;
+
+            Assert.Equal(rowId, deletedRowId);
+            Assert.Null(page.DataObject.MasterRow);
+        }
+
+        /// <summary>
+        /// Captures the <c>selectFields</c> argument passed to
+        /// <see cref="FormApiConnector.GetListAsync"/> so tests can assert on the value
+        /// that <c>ComputeSelectFields</c> computed. The existing
+        /// <see cref="FakeFormApiConnector"/> discards that argument.
+        /// </summary>
+        private sealed class SelectCapturingConnector : FormApiConnector
+        {
+            private readonly Action<string> _onGetList;
+            private readonly DataTable _listTable;
+
+            public SelectCapturingConnector(Action<string> onGetList, DataTable listTable)
+                : base(Guid.NewGuid(), TestProgId)
+            {
+                _onGetList = onGetList;
+                _listTable = listTable;
+            }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                Bee.Definition.Filters.FilterNode? filter = null,
+                Bee.Definition.Sorting.SortFieldCollection? sortFields = null,
+                Bee.Definition.Paging.PagingOptions? paging = null)
+            {
+                _onGetList(selectFields);
+                return Task.FromResult(new GetListResponse { Table = _listTable });
+            }
+        }
+
         /// <summary>
         /// Same test double the FormDataObject tests use; overrides every virtual
         /// CRUD method on <see cref="FormApiConnector"/> so the base

--- a/tests/Bee.UI.Maui.UnitTests/DataObjects/FormDataObjectTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/DataObjects/FormDataObjectTests.cs
@@ -438,6 +438,64 @@ namespace Bee.UI.Maui.UnitTests.DataObjects
             await Assert.ThrowsAsync<InvalidOperationException>(() => dataObject.DeleteAsync());
         }
 
+        [Fact]
+        [DisplayName("SetField 寫入與現值相同的值時不標記 IsDirty（初始 render echo 防護）")]
+        public void SetField_SameValue_DoesNotMarkDirty()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+            dataObject.SetField("emp_name", dataObject.GetField("emp_name"));
+            Assert.False(dataObject.IsDirty);
+        }
+
+        [Fact]
+        [DisplayName("GetField 在 DateTime 欄位含時間分量時回傳 yyyy-MM-ddTHH:mm:ss 格式")]
+        public void GetField_DateTime_WithTimeComponent_ReturnsIsoDateTimeFormat()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+            var dt = new DateTime(2026, 5, 21, 14, 30, 0, DateTimeKind.Unspecified);
+            dataObject.MasterRow!["hire_date"] = dt;
+            var result = dataObject.GetField("hire_date");
+            Assert.Equal("2026-05-21T14:30:00", result);
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 Guid 欄位後 GetField 可讀回相同字串")]
+        public void SetField_Guid_RoundTripsThroughGetField()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+            var guid = Guid.NewGuid();
+            dataObject.SetField(SysFields.RowId, guid.ToString());
+            Assert.Equal(guid.ToString(), dataObject.GetField(SysFields.RowId));
+            Assert.Equal(guid, (Guid)dataObject.MasterRow![SysFields.RowId]);
+            Assert.True(dataObject.IsDirty);
+        }
+
+        private static FormSchema BuildSchemaWithBinary()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add("avatar", "Avatar", FieldDbType.Binary);
+            return schema;
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 Binary 欄位後儲存 byte[]，GetField 回傳 System.Byte[] 字串")]
+        public void SetField_Binary_StoresBytesFromBase64()
+        {
+            var schema = BuildSchemaWithBinary();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            var bytes = new byte[] { 0x01, 0x02, 0x03 };
+            var base64 = Convert.ToBase64String(bytes);
+            dataObject.SetField("avatar", base64);
+            Assert.Equal(bytes, (byte[])dataObject.MasterRow!["avatar"]);
+            Assert.True(dataObject.IsDirty);
+            Assert.Equal("System.Byte[]", dataObject.GetField("avatar"));
+        }
+
         /// <summary>
         /// Test double that bypasses the real JSON-RPC pipeline by overriding every
         /// virtual CRUD method on <see cref="FormApiConnector"/>. The base constructor


### PR DESCRIPTION
## 摘要

針對 SonarCloud 回報覆蓋率不足的路徑新增 333 行測試，涵蓋 5 個測試檔案（含 1 個新建）：

- **`Bee.UI.Maui.UnitTests/DataObjects/FormDataObjectTests`**：新增 `SetField_SameValue_DoesNotMarkDirty`、`GetField_DateTime_WithTimeComponent`、`SetField_Guid_RoundTripsThroughGetField`、`SetField_Binary_StoresBytesFromBase64`
- **`Bee.UI.Avalonia.UnitTests/DataObjects/FormDataObjectTests`**：同步補齊 DateTime-with-time、Guid、Binary 三條路徑
- **`Bee.UI.Maui.UnitTests/Controls/FormPageTests`**：`ComputeSelectFields_WithListFields_PrependsSysRowId`（新增 `SelectCapturingConnector`）、`OnDeleteClickedAsync_WithLoadedRow_DeletesAndResetsDataObject`
- **`Bee.UI.Avalonia.UnitTests/Controls/FormViewTests`**：`InitializeAsync_AlreadyInitialized_SecondCallIsNoOp`、`OnDeleteClickedAsync_WithLoadedRow_DeletesAndResetsDataObject`
- **`Bee.UI.Avalonia.UnitTests/Controls/FormViewClientInfoTests`**（新建）：`Default_Resolve_DelegatesToClientInfo` Theory，驗證 Local / Remote 預設 Resolve 路徑
- **`Bee.UI.Core.UnitTests/ClientInfoLocalEndpointTests`**：`Initialize_StringEndpoint_ValidLocalPath_SetsConnectTypeToLocal`，覆蓋 `ClientInfo.Initialize(string)` overload

## 測試計畫

- [ ] CI 綠燈（所有現有測試繼續通過，新增測試通過）
- [ ] 無 IDE0005（未使用 using）
- [ ] 無 S2699（每個 Fact/Theory 含 Assert）
- [ ] 無 CA1861（無 inline 常數陣列）
- [ ] `FormViewClientInfoTests` 以 `[Collection("ClientInfo")]` 串行保護靜態狀態

https://claude.ai/code/session_013PA9nCVwz4PztL1skCLq7i

---
_Generated by [Claude Code](https://claude.ai/code/session_013PA9nCVwz4PztL1skCLq7i)_