### PR TITLE
[AutoFix] Coverage Fix (4 files) 2026-06-11 14:30

### DIFF
--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
@@ -103,15 +103,15 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
             {
                 GetListHandler = _ => throw new InvalidOperationException("list fetch failed"),
             };
-            var view = new TestFormView
-            {
-                Schema = schema,
-                FormConnector = connector,
-            };
+            // Schema 先設；FormConnector=null 時 OnInputsChanged 提早返回，不啟動初始化
+            var view = new TestFormView { Schema = schema };
 
             Exception? captured = null;
             view.ErrorOccurred += (_, ex) => captured = ex;
 
+            // 設定 FormConnector 觸發 OnInputsChanged → InitializeAsync 同步執行，
+            // 此時 ErrorOccurred 已訂閱，GetListAsync 拋出後 ReportError 能正確觸發事件
+            view.FormConnector = connector;
             await view.InitializeAsync();
 
             Assert.NotNull(captured);

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
@@ -1,0 +1,189 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Avalonia.Controls;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls
+{
+    /// <summary>
+    /// 補強 <see cref="FormView"/> 的測試覆蓋率：
+    /// <c>OnDeleteClickedAsync</c>、<c>ReloadListAsync</c> 的例外分支，
+    /// 以及 <c>ApplyAccessTokenFallback</c> 寫入 token 的路徑。
+    /// </summary>
+    public class FormViewCoverageTests
+    {
+        private const string TestProgId = "Employee";
+
+        private static FormSchema BuildEmployeeSchema()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            schema.ListFields = "emp_id,emp_name";
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("emp_id", "ID", FieldDbType.String);
+            master.Fields.Add("emp_name", "Name", FieldDbType.String);
+            return schema;
+        }
+
+        private static DataSet BuildServerDataSet(Guid rowId, string name)
+        {
+            var dataSet = new DataSet(TestProgId);
+            var master = new DataTable(TestProgId);
+            master.Columns.Add(SysFields.RowId, typeof(Guid));
+            master.Columns.Add("emp_name", typeof(string));
+            master.Rows.Add(rowId, name);
+            dataSet.Tables.Add(master);
+            dataSet.AcceptChanges();
+            return dataSet;
+        }
+
+        private static DataTable BuildListTable(Guid rowId)
+        {
+            var table = new DataTable(TestProgId);
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            table.Columns.Add("emp_id", typeof(string));
+            table.Columns.Add("emp_name", typeof(string));
+            table.Rows.Add(rowId, "E001", "Alice");
+            return table;
+        }
+
+        private static async Task InvokePrivateAsync(FormView view, string methodName, params object[] args)
+        {
+            var method = typeof(FormView).GetMethod(
+                methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            await (Task)method!.Invoke(view, args)!;
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteClickedAsync 成功時刪除 master row 並重設資料物件")]
+        public async Task OnDeleteClickedAsync_LoadedRow_ResetsDataObject()
+        {
+            var schema = BuildEmployeeSchema();
+            var rowId = Guid.NewGuid();
+            var loadedDataSet = BuildServerDataSet(rowId, "Alice");
+            Guid? deletedId = null;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildListTable(rowId) },
+                GetDataHandler = id => new GetDataResponse { DataSet = loadedDataSet },
+                DeleteHandler = id =>
+                {
+                    deletedId = id;
+                    return new DeleteResponse { RowsAffected = 1 };
+                },
+            };
+            var view = new TestFormView
+            {
+                Schema = schema,
+                FormConnector = connector,
+            };
+            await view.InitializeAsync();
+
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+            Assert.NotNull(view.DataObject!.MasterRow);
+
+            await InvokePrivateAsync(view, "OnDeleteClickedAsync");
+
+            Assert.Equal(rowId, deletedId);
+            Assert.Null(view.DataObject!.MasterRow);
+        }
+
+        [Fact]
+        [DisplayName("GetListAsync 拋出例外時 ErrorOccurred 帶出例外訊息且初始化仍完成")]
+        public async Task ReloadList_WhenGetListThrows_ErrorOccurredFires()
+        {
+            var schema = BuildEmployeeSchema();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => throw new InvalidOperationException("list fetch failed"),
+            };
+            var view = new TestFormView
+            {
+                Schema = schema,
+                FormConnector = connector,
+            };
+
+            Exception? captured = null;
+            view.ErrorOccurred += (_, ex) => captured = ex;
+
+            await view.InitializeAsync();
+
+            Assert.NotNull(captured);
+            Assert.Equal("list fetch failed", captured!.Message);
+            Assert.NotNull(view.DataObject);
+        }
+
+        [Fact]
+        [DisplayName("AccessToken 為 Guid.Empty 時會 fallback 到 ResolveAccessToken 回傳的 token")]
+        public async Task InitializeAsync_EmptyAccessToken_FallsBackToResolvedToken()
+        {
+            var expectedToken = Guid.NewGuid();
+            var schema = BuildEmployeeSchema();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse(),
+            };
+            var view = new TokenProvidingFormView(expectedToken)
+            {
+                Schema = schema,
+                FormConnector = connector,
+            };
+
+            await view.InitializeAsync();
+
+            Assert.Equal(expectedToken, view.AccessToken);
+        }
+
+        private sealed class TestFormView : FormView
+        {
+            protected override SystemApiConnector? ResolveSystemConnector() => null;
+
+            protected override FormApiConnector ResolveFormConnector(string progId)
+                => throw new InvalidOperationException("ClientInfo fallback must not be reached in unit tests.");
+
+            protected override Guid ResolveAccessToken() => Guid.Empty;
+        }
+
+        private sealed class TokenProvidingFormView : FormView
+        {
+            private readonly Guid _token;
+
+            public TokenProvidingFormView(Guid token) { _token = token; }
+
+            protected override SystemApiConnector? ResolveSystemConnector() => null;
+
+            protected override FormApiConnector ResolveFormConnector(string progId)
+                => throw new InvalidOperationException("ClientInfo fallback must not be reached in unit tests.");
+
+            protected override Guid ResolveAccessToken() => _token;
+        }
+
+        private sealed class FakeFormApiConnector : FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), TestProgId) { }
+
+            public Func<string, GetListResponse>? GetListHandler { get; set; }
+            public Func<Guid, GetDataResponse>? GetDataHandler { get; set; }
+            public Func<Guid, DeleteResponse>? DeleteHandler { get; set; }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                Bee.Definition.Filters.FilterNode? filter = null,
+                Bee.Definition.Sorting.SortFieldCollection? sortFields = null,
+                Bee.Definition.Paging.PagingOptions? paging = null)
+                => Task.FromResult((GetListHandler ?? (_ => new GetListResponse()))(selectFields));
+
+            public override Task<GetDataResponse> GetDataAsync(Guid rowId)
+                => Task.FromResult((GetDataHandler ?? (_ => new GetDataResponse()))(rowId));
+
+            public override Task<DeleteResponse> DeleteAsync(Guid rowId)
+                => Task.FromResult((DeleteHandler ?? (_ => new DeleteResponse()))(rowId));
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/DataObjects/FormDataObjectCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/DataObjects/FormDataObjectCoverageTests.cs
@@ -1,0 +1,118 @@
+using System.ComponentModel;
+using System.Data;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.DataObjects
+{
+    /// <summary>
+    /// 補強 <see cref="FormDataObject"/> 的測試覆蓋率：
+    /// 含時間的 DateTime 格式、Guid 欄位解析，以及 Binary 欄位的 base64 解析。
+    /// </summary>
+    public class FormDataObjectCoverageTests
+    {
+        private const string TestProgId = "Employee";
+
+        private static FormSchema BuildEmployeeSchema()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("emp_id", "Employee ID", FieldDbType.String);
+            master.Fields.Add("emp_name", "Name", FieldDbType.String);
+            master.Fields.Add("hire_date", "Hire Date", FieldDbType.Date);
+            return schema;
+        }
+
+        [Fact]
+        [DisplayName("含時間部分的 DateTime 欄位以 yyyy-MM-ddTHH:mm:ss 格式回傳")]
+        public void GetField_DateTimeWithTimePart_ReturnsIsoDateTime()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+
+            dataObject.SetField("hire_date", "2026-05-21T14:30:00");
+
+            Assert.Equal("2026-05-21T14:30:00", dataObject.GetField("hire_date"));
+            var stored = (DateTime)dataObject.MasterRow!["hire_date"];
+            Assert.Equal(new DateTime(2026, 5, 21, 14, 30, 0, DateTimeKind.Local), stored);
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 Guid 欄位字串後可讀回對應 Guid 值")]
+        public void SetField_GuidColumn_ParsesGuidString()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+
+            var newGuid = Guid.NewGuid();
+            dataObject.SetField(SysFields.RowId, newGuid.ToString());
+
+            Assert.Equal(newGuid, (Guid)dataObject.MasterRow![SysFields.RowId]);
+            Assert.True(dataObject.IsDirty);
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 base64 字串到 Binary 欄位後可讀回原始位元組")]
+        public void SetField_BinaryColumn_ParsesBase64()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("raw_data", "Raw Data", FieldDbType.Binary);
+
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+
+            var bytes = new byte[] { 1, 2, 3 };
+            dataObject.SetField("raw_data", Convert.ToBase64String(bytes));
+
+            Assert.Equal(bytes, (byte[])dataObject.MasterRow!["raw_data"]);
+            Assert.True(dataObject.IsDirty);
+        }
+
+        [Fact]
+        [DisplayName("SetField 空字串對非 nullable byte[] 欄位且無 DefaultValue 時回退到空陣列")]
+        public async Task SetField_EmptyOnRawNonNullByteArrayColumn_FallsBackToEmpty()
+        {
+            var schema = BuildEmployeeSchema();
+
+            // Server returns a DataSet with a raw byte[] column that has AllowDBNull=false
+            // and no explicit DefaultValue (simulates ADO.NET server response).
+            var serverDs = new DataSet(TestProgId);
+            var serverTable = new DataTable(TestProgId);
+            serverTable.Columns.Add(SysFields.RowId, typeof(Guid));
+            var binaryCol = serverTable.Columns.Add("raw_data", typeof(byte[]));
+            binaryCol.AllowDBNull = false;
+            // DefaultValue is DBNull.Value by default for raw ADO.NET DataColumn
+            serverTable.Rows.Add(Guid.NewGuid(), Array.Empty<byte>());
+            serverDs.Tables.Add(serverTable);
+            serverDs.AcceptChanges();
+
+            var connector = new FakeFormApiConnector
+            {
+                GetNewDataHandler = () => new GetNewDataResponse { DataSet = serverDs },
+            };
+            var dataObject = new FormDataObject(schema, connector);
+            await dataObject.NewAsync();
+
+            dataObject.SetField("raw_data", string.Empty);
+
+            Assert.Equal(Array.Empty<byte>(), (byte[])dataObject.MasterRow!["raw_data"]);
+        }
+
+        private sealed class FakeFormApiConnector : FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), TestProgId) { }
+
+            public Func<GetNewDataResponse>? GetNewDataHandler { get; set; }
+
+            public override Task<GetNewDataResponse> GetNewDataAsync()
+                => Task.FromResult((GetNewDataHandler ?? (() => new GetNewDataResponse()))());
+        }
+    }
+}

--- a/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
@@ -1,0 +1,175 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Maui.Controls;
+
+namespace Bee.UI.Maui.UnitTests.Controls
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> 的測試覆蓋率：
+    /// <c>ComputeSelectFields</c> foreach 路徑、<c>OnDeleteClickedAsync</c>，
+    /// 以及 <c>ReloadListAsync</c> 的例外分支。
+    /// </summary>
+    public class FormPageCoverageTests
+    {
+        private const string TestProgId = "Employee";
+
+        private static FormSchema BuildSchemaWithListFields()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            schema.ListFields = "emp_id,emp_name";
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("emp_id", "ID", FieldDbType.String);
+            master.Fields.Add("emp_name", "Name", FieldDbType.String);
+            return schema;
+        }
+
+        private static DataSet BuildServerDataSet(Guid rowId, string name)
+        {
+            var dataSet = new DataSet(TestProgId);
+            var master = new DataTable(TestProgId);
+            master.Columns.Add(SysFields.RowId, typeof(Guid));
+            master.Columns.Add("emp_name", typeof(string));
+            master.Rows.Add(rowId, name);
+            dataSet.Tables.Add(master);
+            dataSet.AcceptChanges();
+            return dataSet;
+        }
+
+        private static DataTable BuildListTable(Guid rowId)
+        {
+            var table = new DataTable(TestProgId);
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            table.Columns.Add("emp_id", typeof(string));
+            table.Columns.Add("emp_name", typeof(string));
+            table.Rows.Add(rowId, "E001", "Alice");
+            return table;
+        }
+
+        [Fact]
+        [DisplayName("schema.ListFields 非空時 GetListAsync 接收到包含 sys_rowid 前綴的 selectFields")]
+        public async Task InitializeAsync_WithListFields_PassesSelectFieldsWithSysRowId()
+        {
+            var schema = BuildSchemaWithListFields();
+            string? capturedSelectFields = null;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = sf =>
+                {
+                    capturedSelectFields = sf;
+                    return new GetListResponse();
+                },
+            };
+            var page = new TestFormPage
+            {
+                Schema = schema,
+                FormConnector = connector,
+            };
+
+            await page.InitializeAsync();
+
+            Assert.Equal("sys_rowid,emp_id,emp_name", capturedSelectFields);
+        }
+
+        [Fact]
+        [DisplayName("OnDeleteClickedAsync 成功時刪除 master row 並重設資料物件")]
+        public async Task OnDeleteClickedAsync_LoadedRow_ResetsDataObject()
+        {
+            var schema = BuildSchemaWithListFields();
+            var rowId = Guid.NewGuid();
+            var loadedDataSet = BuildServerDataSet(rowId, "Alice");
+            Guid? deletedId = null;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildListTable(rowId) },
+                GetDataHandler = id => new GetDataResponse { DataSet = loadedDataSet },
+                DeleteHandler = id =>
+                {
+                    deletedId = id;
+                    return new DeleteResponse { RowsAffected = 1 };
+                },
+            };
+            var page = new TestFormPage
+            {
+                Schema = schema,
+                FormConnector = connector,
+            };
+            await page.InitializeAsync();
+
+            var loadMethod = typeof(FormPage).GetMethod(
+                "OnRowSelectedAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            await (Task)loadMethod.Invoke(page, new object[] { rowId })!;
+            Assert.NotNull(page.DataObject!.MasterRow);
+
+            var deleteMethod = typeof(FormPage).GetMethod(
+                "OnDeleteClickedAsync", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            await (Task)deleteMethod.Invoke(page, Array.Empty<object>())!;
+
+            Assert.Equal(rowId, deletedId);
+            Assert.Null(page.DataObject!.MasterRow);
+        }
+
+        [Fact]
+        [DisplayName("GetListAsync 拋出例外時 ErrorOccurred 帶出例外訊息且初始化仍完成")]
+        public async Task ReloadList_WhenGetListThrows_ErrorOccurredFires()
+        {
+            var schema = BuildSchemaWithListFields();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => throw new InvalidOperationException("list fetch failed"),
+            };
+            var page = new TestFormPage
+            {
+                Schema = schema,
+                FormConnector = connector,
+            };
+
+            Exception? captured = null;
+            page.ErrorOccurred += (_, ex) => captured = ex;
+
+            await page.InitializeAsync();
+
+            Assert.NotNull(captured);
+            Assert.Equal("list fetch failed", captured!.Message);
+            Assert.NotNull(page.DataObject);
+        }
+
+        private sealed class TestFormPage : FormPage
+        {
+            protected override SystemApiConnector? ResolveSystemConnector() => null;
+
+            protected override FormApiConnector ResolveFormConnector(string progId)
+                => throw new InvalidOperationException("ClientInfo fallback must not be reached in unit tests.");
+
+            protected override Guid ResolveAccessToken() => Guid.Empty;
+        }
+
+        private sealed class FakeFormApiConnector : FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), TestProgId) { }
+
+            public Func<string, GetListResponse>? GetListHandler { get; set; }
+            public Func<Guid, GetDataResponse>? GetDataHandler { get; set; }
+            public Func<Guid, DeleteResponse>? DeleteHandler { get; set; }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                Bee.Definition.Filters.FilterNode? filter = null,
+                Bee.Definition.Sorting.SortFieldCollection? sortFields = null,
+                Bee.Definition.Paging.PagingOptions? paging = null)
+                => Task.FromResult((GetListHandler ?? (_ => new GetListResponse()))(selectFields));
+
+            public override Task<GetDataResponse> GetDataAsync(Guid rowId)
+                => Task.FromResult((GetDataHandler ?? (_ => new GetDataResponse()))(rowId));
+
+            public override Task<DeleteResponse> DeleteAsync(Guid rowId)
+                => Task.FromResult((DeleteHandler ?? (_ => new DeleteResponse()))(rowId));
+        }
+    }
+}

--- a/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
@@ -124,15 +124,15 @@ namespace Bee.UI.Maui.UnitTests.Controls
             {
                 GetListHandler = _ => throw new InvalidOperationException("list fetch failed"),
             };
-            var page = new TestFormPage
-            {
-                Schema = schema,
-                FormConnector = connector,
-            };
+            // Schema 先設；FormConnector=null 時 OnInputsChanged 提早返回，不啟動初始化
+            var page = new TestFormPage { Schema = schema };
 
             Exception? captured = null;
             page.ErrorOccurred += (_, ex) => captured = ex;
 
+            // 設定 FormConnector 觸發 OnInputsChanged → InitializeAsync 同步執行，
+            // 此時 ErrorOccurred 已訂閱，GetListAsync 拋出後 ReportError 能正確觸發事件
+            page.FormConnector = connector;
             await page.InitializeAsync();
 
             Assert.NotNull(captured);

--- a/tests/Bee.UI.Maui.UnitTests/DataObjects/FormDataObjectCoverageTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/DataObjects/FormDataObjectCoverageTests.cs
@@ -1,0 +1,133 @@
+using System.ComponentModel;
+using System.Data;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Maui.DataObjects;
+
+namespace Bee.UI.Maui.UnitTests.DataObjects
+{
+    /// <summary>
+    /// 補強 <see cref="FormDataObject"/> 的測試覆蓋率：
+    /// 相同值 short-circuit 防護、含時間的 DateTime 格式、Guid 欄位解析，
+    /// 以及 Binary 欄位的 base64 解析。
+    /// </summary>
+    public class FormDataObjectCoverageTests
+    {
+        private const string TestProgId = "Employee";
+
+        private static FormSchema BuildEmployeeSchema()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("emp_id", "Employee ID", FieldDbType.String);
+            master.Fields.Add("emp_name", "Name", FieldDbType.String);
+            master.Fields.Add("hire_date", "Hire Date", FieldDbType.Date);
+            return schema;
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入與現值相同的值時不標記 IsDirty（初始 render echo 防護）")]
+        public void SetField_SameValue_DoesNotMarkDirty()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+
+            // MAUI controls echo the initial value back through TextChanged once
+            // during construction; an identical write must not dirty the row.
+            dataObject.SetField("emp_name", dataObject.GetField("emp_name"));
+
+            Assert.False(dataObject.IsDirty);
+        }
+
+        [Fact]
+        [DisplayName("含時間部分的 DateTime 欄位以 yyyy-MM-ddTHH:mm:ss 格式回傳")]
+        public void GetField_DateTimeWithTimePart_ReturnsIsoDateTime()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+
+            dataObject.SetField("hire_date", "2026-05-21T14:30:00");
+
+            Assert.Equal("2026-05-21T14:30:00", dataObject.GetField("hire_date"));
+            var stored = (DateTime)dataObject.MasterRow!["hire_date"];
+            Assert.Equal(new DateTime(2026, 5, 21, 14, 30, 0, DateTimeKind.Local), stored);
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 Guid 欄位字串後可讀回對應 Guid 值")]
+        public void SetField_GuidColumn_ParsesGuidString()
+        {
+            var dataObject = new FormDataObject(BuildEmployeeSchema());
+            dataObject.InitializeNewMaster();
+
+            var newGuid = Guid.NewGuid();
+            dataObject.SetField(SysFields.RowId, newGuid.ToString());
+
+            Assert.Equal(newGuid, (Guid)dataObject.MasterRow![SysFields.RowId]);
+            Assert.True(dataObject.IsDirty);
+        }
+
+        [Fact]
+        [DisplayName("SetField 寫入 base64 字串到 Binary 欄位後可讀回原始位元組")]
+        public void SetField_BinaryColumn_ParsesBase64()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("raw_data", "Raw Data", FieldDbType.Binary);
+
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+
+            var bytes = new byte[] { 1, 2, 3 };
+            dataObject.SetField("raw_data", Convert.ToBase64String(bytes));
+
+            Assert.Equal(bytes, (byte[])dataObject.MasterRow!["raw_data"]);
+            Assert.True(dataObject.IsDirty);
+        }
+
+        [Fact]
+        [DisplayName("SetField 空字串對非 nullable byte[] 欄位且無 DefaultValue 時回退到空陣列")]
+        public async Task SetField_EmptyOnRawNonNullByteArrayColumn_FallsBackToEmpty()
+        {
+            var schema = BuildEmployeeSchema();
+
+            // Server returns a DataSet with a raw byte[] column that has AllowDBNull=false
+            // and no explicit DefaultValue (simulates ADO.NET server response).
+            var serverDs = new DataSet(TestProgId);
+            var serverTable = new DataTable(TestProgId);
+            serverTable.Columns.Add(SysFields.RowId, typeof(Guid));
+            var binaryCol = serverTable.Columns.Add("raw_data", typeof(byte[]));
+            binaryCol.AllowDBNull = false;
+            // DefaultValue is DBNull.Value by default for raw ADO.NET DataColumn
+            serverTable.Rows.Add(Guid.NewGuid(), Array.Empty<byte>());
+            serverDs.Tables.Add(serverTable);
+            serverDs.AcceptChanges();
+
+            var connector = new FakeFormApiConnector
+            {
+                GetNewDataHandler = () => new GetNewDataResponse { DataSet = serverDs },
+            };
+            var dataObject = new FormDataObject(schema, connector);
+            await dataObject.NewAsync();
+
+            dataObject.SetField("raw_data", string.Empty);
+
+            Assert.Equal(Array.Empty<byte>(), (byte[])dataObject.MasterRow!["raw_data"]);
+        }
+
+        private sealed class FakeFormApiConnector : FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), TestProgId) { }
+
+            public Func<GetNewDataResponse>? GetNewDataHandler { get; set; }
+
+            public override Task<GetNewDataResponse> GetNewDataAsync()
+                => Task.FromResult((GetNewDataHandler ?? (() => new GetNewDataResponse()))());
+        }
+    }
+}


### PR DESCRIPTION
## 覆蓋率補強摘要

本 PR 由自動化 coverage-fix agent 產生，針對 SonarCloud 回報覆蓋率低於 90% 的 4 個檔案補充單元測試。
`src/` 目錄下無任何修改，僅新增測試檔案。

## 目標檔案與補強路徑

| 檔案 | 補強前覆蓋率 | 補強路徑 |
|------|------------|---------|
| `src/Bee.UI.Maui/Controls/FormPage.cs` | 89.9% | `ComputeSelectFields` foreach、`OnDeleteClickedAsync`、`ReloadListAsync` catch |
| `src/Bee.UI.Maui/DataObjects/FormDataObject.cs` | 88.7% | SetField 同值 short-circuit、DateTime ISO 格式、Guid 解析、Binary base64、非 nullable byte[] 回退 |
| `src/Bee.UI.Avalonia/Controls/FormView.cs` | 80.0% | `OnDeleteClickedAsync`、`ReloadListAsync` catch、`ApplyAccessTokenFallback` |
| `src/Bee.UI.Avalonia/DataObjects/FormDataObject.cs` | 88.7% | DateTime ISO 格式、Guid 解析、Binary base64、非 nullable byte[] 回退 |

## 新增測試檔案（4 個）

- `tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs`（3 tests）
- `tests/Bee.UI.Maui.UnitTests/DataObjects/FormDataObjectCoverageTests.cs`（5 tests）
- `tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs`（3 tests）
- `tests/Bee.UI.Avalonia.UnitTests/DataObjects/FormDataObjectCoverageTests.cs`（4 tests）

## 無法補強項目

- `src/Bee.UI.Core/ClientInfo.cs`（85.5%）：未覆蓋路徑皆需真實 API server 或控制 `Environment.GetCommandLineArgs()`，CI 單元測試無法觸及，跳過。

## Analyzer 自檢

- IDE0005（未使用 using）：全部移除
- S2699（Assert 缺漏）：所有 `[Fact]` 均有 `Assert.*`
- CA1861（inline array）：無 inline `new[]` 常數陣列
- S6562（DateTime 缺 DateTimeKind）：`new DateTime(...)` 均指定 `DateTimeKind.Local`

https://claude.ai/code/session_01JmnFHtSN6XrhBj4VvDhbk4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmnFHtSN6XrhBj4VvDhbk4)_