### PR TITLE
[AutoFix] SonarCloud Issues (8 issues) 2026-06-12 00:00

### DIFF
--- a/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
+++ b/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
@@ -623,7 +623,7 @@ namespace Bee.UI.Avalonia.Controls.Editors
                 return checkBox;
             }
 
-            if (!canEdit || rowView is null)
+            if (!canEdit)
             {
                 return new TextBlock
                 {
@@ -633,13 +633,13 @@ namespace Bee.UI.Avalonia.Controls.Editors
                 };
             }
 
-            return BuildSwapCell(rowView, column);
+            return BuildSwapCell(rowView!, column);
         }
 
         // Click-to-edit host: rests as the original text rendering, swaps to the
         // editor on pointer press and swaps back when the edit session ends, re-reading
         // the row so the committed value is what gets displayed.
-        private Control BuildSwapCell(DataRowView rowView, LayoutColumn column)
+        private ContentControl BuildSwapCell(DataRowView rowView, LayoutColumn column)
         {
             var host = new ContentControl
             {

--- a/src/Bee.UI.Avalonia/Controls/Editors/RowEditPanel.cs
+++ b/src/Bee.UI.Avalonia/Controls/Editors/RowEditPanel.cs
@@ -123,7 +123,7 @@ namespace Bee.UI.Avalonia.Controls.Editors
             Unbind();
         }
 
-        private Control BuildContent(FormDataObject dataObject, LayoutGrid layout, DataRow row)
+        private StackPanel BuildContent(FormDataObject dataObject, LayoutGrid layout, DataRow row)
         {
             var grid = new Grid
             {

--- a/src/Bee.UI.Avalonia/Controls/FormView.cs
+++ b/src/Bee.UI.Avalonia/Controls/FormView.cs
@@ -69,7 +69,6 @@ namespace Bee.UI.Avalonia.Controls
         private readonly GridControl _grid;
         private readonly DynamicForm _form;
         private FormDataObject? _dataObject;
-        private LayoutGrid? _listLayout;
         private bool _isBusy;
         private bool _initialized;
         private bool _isInitializing;
@@ -273,9 +272,9 @@ namespace Bee.UI.Avalonia.Controls
             _dataObject = new FormDataObject(Schema!, FormConnector!);
             _form.FormLayout = Schema!.GetFormLayout();
             _form.DataObject = _dataObject;
-            _listLayout = Schema.GetListLayout();
+            var listLayout = Schema.GetListLayout();
             // Columns render immediately; the rows arrive with the first ReloadListAsync.
-            _grid.Bind(_listLayout, rows: null);
+            _grid.Bind(listLayout, rows: null);
         }
 
         /// <summary>

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DropDownEditTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DropDownEditTests.cs
@@ -34,7 +34,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
 
             editor.Bind(dataObject, "dept_id");
 
-            var items = Assert.IsAssignableFrom<IEnumerable<ListItem>>(editor.ItemsSource).ToList();
+            var items = Assert.IsType<IEnumerable<ListItem>>(editor.ItemsSource, exactMatch: false).ToList();
             Assert.Equal(2, items.Count);
             Assert.Equal("HR", items[0].Value);
         }

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorFactoryTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorFactoryTests.cs
@@ -27,7 +27,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
             var editor = FieldEditorFactory.Create(controlType);
 
             Assert.IsType(expectedType, editor);
-            Assert.IsAssignableFrom<IFieldEditor>(editor);
+            Assert.IsType<IFieldEditor>(editor, exactMatch: false);
         }
 
         [Theory]

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
@@ -73,7 +73,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
         {
             var grid = new GridControl();
 
-            Assert.IsAssignableFrom<ContentControl>(grid);
+            Assert.IsType<ContentControl>(grid, exactMatch: false);
             var styleKey = typeof(global::Avalonia.StyledElement)
                 .GetProperty("StyleKeyOverride", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .GetValue(grid);
@@ -509,7 +509,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
 
             editor.IsChecked = true;
 
-            Assert.Equal(true, table.Rows[0]["ok"]);
+            Assert.True((bool)table.Rows[0]["ok"]);
         }
 
         [Fact]


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ63aLafzxzPhDtxnCWD | xUnit2032 | `tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs` | 將 `Assert.IsAssignableFrom<ContentControl>(grid)` 替換為 `Assert.IsType<ContentControl>(grid, exactMatch: false)` |
| AZ608MOWZBZf2NUkWiQl | S2701 | `tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs` | 將 `Assert.Equal(true, ...)` 替換為 `Assert.True((bool)...)` |
| AZ619aMZSIIH_2GS146P | CA1859 | `src/Bee.UI.Avalonia/Controls/Editors/RowEditPanel.cs` | 將 `BuildContent` 回傳型別從 `Control` 改為 `StackPanel` |
| AZ61Qg_VUSgq0rpNurP_ | S2589 | `src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs` | 移除 `rowView is null` 永遠為 false 的冗餘條件，並加 null-forgiving operator `rowView!` |
| AZ61Qg_VUSgq0rpNurQA | CA1859 | `src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs` | 將 `BuildSwapCell` 回傳型別從 `Control` 改為 `ContentControl` |
| AZ608L1MZBZf2NUkWiQk | S1450 | `src/Bee.UI.Avalonia/Controls/FormView.cs` | 移除 `_listLayout` 欄位，在 `AttachDataObject` 內改為區域變數 |
| AZ60pHyOIG-iJUv57g1B | xUnit2032 | `tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DropDownEditTests.cs` | 將 `Assert.IsAssignableFrom<IEnumerable<ListItem>>(...)` 替換為 `Assert.IsType<IEnumerable<ListItem>>(..., exactMatch: false)` |
| AZ60pHvmIG-iJUv57g1A | xUnit2032 | `tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorFactoryTests.cs` | 將 `Assert.IsAssignableFrom<IFieldEditor>(...)` 替換為 `Assert.IsType<IFieldEditor>(..., exactMatch: false)` |


---
_Generated by [Claude Code](https://claude.ai/code/session_01HV6R7WabvMwak7P9JjsGwJ)_