### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-06-12 08:30

### DIFF
--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DateEditTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DateEditTests.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using Bee.Base.Data;
 using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
 using Bee.UI.Avalonia.Controls.Editors;
 using Bee.UI.Avalonia.DataObjects;
 
@@ -76,6 +77,131 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
             editor.Bind(dataObject, "pay_month");
 
             Assert.Null(editor.SelectedDate);
+        }
+
+        [Fact]
+        [DisplayName("View 模式停用編輯器")]
+        public void SetControlState_ViewMode_DisablesEditor()
+        {
+            var editor = new DateEdit();
+
+            editor.SetControlState(SingleFormMode.View);
+
+            Assert.False(editor.IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("Edit 模式啟用編輯器")]
+        public void SetControlState_EditMode_EnablesEditor()
+        {
+            var editor = new DateEdit();
+            editor.SetControlState(SingleFormMode.View);
+
+            editor.SetControlState(SingleFormMode.Edit);
+
+            Assert.True(editor.IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("Bind(LayoutField) 載入欄位初值")]
+        public void Bind_WithLayoutField_LoadsValue()
+        {
+            var dataObject = BuildDataObject();
+            dataObject.SetField("hire_date", "2026-06-01");
+            var field = new LayoutField { FieldName = "hire_date", Caption = "Hire Date" };
+            var editor = new DateEdit();
+
+            editor.Bind(dataObject, field);
+
+            Assert.NotNull(editor.SelectedDate);
+            Assert.Equal(
+                new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Unspecified),
+                editor.SelectedDate!.Value.DateTime);
+        }
+
+        [Fact]
+        [DisplayName("ReadOnly layout field 下 Edit 模式仍停用編輯器")]
+        public void Bind_WithReadOnlyLayoutField_StaysDisabledInEditMode()
+        {
+            var dataObject = BuildDataObject();
+            var field = new LayoutField { FieldName = "hire_date", Caption = "Hire Date", ReadOnly = true };
+            var editor = new DateEdit();
+
+            editor.Bind(dataObject, field);
+            editor.SetControlState(SingleFormMode.Edit);
+
+            Assert.False(editor.IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("Unbind 後欄位變更不再刷新編輯器")]
+        public void Unbind_AfterBind_StopsTrackingFieldChanges()
+        {
+            var dataObject = BuildDataObject();
+            dataObject.SetField("hire_date", "2026-06-11");
+            var editor = new DateEdit();
+            editor.Bind(dataObject, "hire_date");
+
+            editor.Unbind();
+            dataObject.SetField("hire_date", "2020-01-01");
+
+            Assert.Equal(
+                new DateTime(2026, 6, 11, 0, 0, 0, DateTimeKind.Unspecified),
+                editor.SelectedDate!.Value.DateTime);
+        }
+
+        [Fact]
+        [DisplayName("FieldValue 設 null 清除 SelectedDate")]
+        public void FieldValue_NullSetter_ClearsSelectedDate()
+        {
+            var editor = new DateEdit();
+            editor.SelectedDate = new DateTimeOffset(
+                new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), TimeSpan.Zero);
+
+            editor.FieldValue = null;
+
+            Assert.Null(editor.SelectedDate);
+        }
+
+        [Fact]
+        [DisplayName("FieldValue 設 DateTime 更新 SelectedDate")]
+        public void FieldValue_DateTimeSetter_SetsSelectedDate()
+        {
+            var editor = new DateEdit();
+
+            editor.FieldValue = new DateTime(2026, 5, 15, 0, 0, 0, DateTimeKind.Unspecified);
+
+            Assert.NotNull(editor.SelectedDate);
+            Assert.Equal(new DateTime(2026, 5, 15), editor.SelectedDate!.Value.DateTime);
+        }
+
+        [Fact]
+        [DisplayName("Bind(row) 從指定明細列載入日期值並寫回該列")]
+        public void Bind_WithDetailRow_LoadsAndWritesBackToTargetRow()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_name", "Name", FieldDbType.String);
+            var detail = schema.Tables.Add("EmployeePhone", "Phones");
+            detail.Fields!.Add("start_date", "Start Date", FieldDbType.Date);
+
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            var phoneTable = dataObject.DataSet.Tables["EmployeePhone"]!;
+            phoneTable.Rows.Add(new DateTime(2026, 3, 15, 0, 0, 0, DateTimeKind.Unspecified));
+            var targetRow = phoneTable.Rows[0];
+
+            var field = new LayoutColumn("start_date", "Start Date", ControlType.DateEdit);
+            var editor = new DateEdit();
+            editor.Bind(dataObject, field, targetRow);
+
+            Assert.NotNull(editor.SelectedDate);
+            Assert.Equal(new DateTime(2026, 3, 15), editor.SelectedDate!.Value.DateTime);
+
+            editor.SelectedDate = new DateTimeOffset(
+                new DateTime(2026, 7, 20, 0, 0, 0, DateTimeKind.Unspecified), TimeSpan.Zero);
+
+            Assert.Equal("2026-07-20", dataObject.GetField(targetRow, "start_date"));
         }
     }
 }

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
@@ -671,6 +671,66 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
         }
 
         [Fact]
+        [DisplayName("Unbind 解除 DataObject 訂閱")]
+        public void Unbind_ClearsBoundDataObject()
+        {
+            var dataObject = BuildDataObjectWithDetail();
+            var layout = new LayoutGrid("EmployeePhone", "Phones");
+            layout.Columns!.Add(new LayoutColumn { FieldName = "phone", Caption = "Phone", Visible = true });
+            var grid = new GridControl();
+            grid.Bind(dataObject, layout);
+
+            var binderField = typeof(GridControl).GetField("_binder", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var binder = binderField.GetValue(grid)!;
+            var dataObjectProp = binder.GetType().GetProperty("DataObject", BindingFlags.Public | BindingFlags.Instance)!;
+            Assert.Same(dataObject, dataObjectProp.GetValue(binder));
+
+            grid.Unbind();
+
+            Assert.Null(dataObjectProp.GetValue(binder));
+        }
+
+        [Fact]
+        [DisplayName("RefreshRows 重置並重建 ItemsSource")]
+        public void RefreshRows_ResetsAndRebuildsItemsSource()
+        {
+            var grid = new GridControl();
+            grid.Bind(BuildEmployeeListLayout(), BuildEmployeeRows());
+            Assert.NotNull(grid.InnerGrid.ItemsSource);
+
+            var exception = Record.Exception(grid.RefreshRows);
+
+            Assert.Null(exception);
+            Assert.NotNull(grid.InnerGrid.ItemsSource);
+        }
+
+        [Fact]
+        [DisplayName("RefreshFromDataObject 無 layout 時依 DataTable 欄位建立後備欄位")]
+        public void RefreshFromDataObject_WithNoLayout_BuildsFallbackColumns()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("sys_id", "ID", FieldDbType.String);
+            master.Fields.Add("sys_name", "Name", FieldDbType.String);
+
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+
+            var grid = new GridControl();
+            grid.TableName = "Employee";
+
+            var binderField = typeof(GridControl).GetField("_binder", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            var binder = binderField.GetValue(grid)!;
+            var bindMethod = binder.GetType().GetMethod("BindExplicit", BindingFlags.Public | BindingFlags.Instance)!;
+            bindMethod.Invoke(binder, new object[] { dataObject });
+
+            var refreshMethod = typeof(GridControl).GetMethod("RefreshFromDataObject", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            refreshMethod.Invoke(grid, null);
+
+            Assert.True(grid.InnerGrid.Columns.Count > 0);
+        }
+
+        [Fact]
         [DisplayName("TryGetRowId 接受 Guid 欄位、字串可解析的 Guid、DBNull 時回傳 false")]
         public void TryGetRowId_VariantInputs_Behaviour()
         {

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
@@ -194,6 +194,57 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
             Assert.Equal("backend rejected", captured!.Message);
         }
 
+        [Fact]
+        [DisplayName("Delete 失敗時 ErrorOccurred 會帶出例外訊息")]
+        public async Task ErrorOccurred_FiresWhenDeleteThrows()
+        {
+            var schema = BuildEmployeeSchema();
+            var rowId = Guid.NewGuid();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Alice") },
+                GetDataHandler = id => new GetDataResponse { DataSet = BuildServerDataSet(id, "Alice") },
+                DeleteHandler = _ => throw new InvalidOperationException("delete rejected"),
+            };
+            var view = new TestFormView { Schema = schema, FormConnector = connector };
+            await view.InitializeAsync();
+
+            Exception? captured = null;
+            view.ErrorOccurred += (_, ex) => captured = ex;
+
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+            Assert.NotNull(view.DataObject!.MasterRow);
+
+            await InvokePrivateAsync(view, "OnDeleteClickedAsync");
+
+            Assert.NotNull(captured);
+            Assert.Equal("delete rejected", captured!.Message);
+        }
+
+        [Fact]
+        [DisplayName("Delete 成功後 DataObject.MasterRow 清除")]
+        public async Task OnDeleteClicked_DelegatesToDeleteAsync()
+        {
+            var schema = BuildEmployeeSchema();
+            var rowId = Guid.NewGuid();
+            Guid? deletedRowId = null;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Alice") },
+                GetDataHandler = id => new GetDataResponse { DataSet = BuildServerDataSet(id, "Alice") },
+                DeleteHandler = id => { deletedRowId = id; return new DeleteResponse(); },
+            };
+            var view = new TestFormView { Schema = schema, FormConnector = connector };
+            await view.InitializeAsync();
+
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+            Assert.NotNull(view.DataObject!.MasterRow);
+
+            await InvokePrivateAsync(view, "OnDeleteClickedAsync");
+
+            Assert.Equal(rowId, deletedRowId);
+        }
+
         /// <summary>
         /// Overrides the <c>Resolve*</c> hooks so tests never read the process-wide
         /// <c>ClientInfo</c> statics; the unused <c>ResolveFormConnector</c> throws to


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs` | 73.2% | 3 |
| `src/Bee.UI.Avalonia/Controls/FormView.cs` | 80.6% | 2 |
| `src/Bee.UI.Avalonia/Controls/Editors/FieldEditorBinder.cs` | 78.3% | （經由 DateEdit BindRow 間接覆蓋）|
| `src/Bee.UI.Avalonia/Controls/Editors/GridControlBinder.cs` | 54.3% | （經由 GridControl.Unbind/RefreshFromDataObject 間接覆蓋）|
| `src/Bee.UI.Avalonia/Controls/Editors/DateEdit.cs` | 63.6% | 8 |

### 新增測試說明

**DateEdit（8 個測試）**
- `SetControlState_ViewMode_DisablesEditor` — View 模式停用編輯器
- `SetControlState_EditMode_EnablesEditor` — Edit 模式啟用編輯器
- `Bind_WithLayoutField_LoadsValue` — `Bind(LayoutField)` 多載載入初值
- `Bind_WithReadOnlyLayoutField_StaysDisabledInEditMode` — ReadOnly layout field 在 Edit 模式仍停用
- `Unbind_AfterBind_StopsTrackingFieldChanges` — Unbind 後不再回應欄位變更
- `FieldValue_NullSetter_ClearsSelectedDate` — `FieldValue = null` 清除日期
- `FieldValue_DateTimeSetter_SetsSelectedDate` — `FieldValue = DateTime` 設定日期
- `Bind_WithDetailRow_LoadsAndWritesBackToTargetRow` — BindRow 路徑（FieldEditorBinder.BindRow / GetValue(TargetRow) / WriteBack(TargetRow)）

**FormView（2 個測試）**
- `ErrorOccurred_FiresWhenDeleteThrows` — Delete 失敗觸發 ErrorOccurred
- `OnDeleteClicked_DelegatesToDeleteAsync` — Delete 成功呼叫 connector.DeleteAsync

**GridControl（3 個測試）**
- `Unbind_ClearsBoundDataObject` — Unbind 解除 DataObject 訂閱
- `RefreshRows_ResetsAndRebuildsItemsSource` — RefreshRows 重置並重建 ItemsSource
- `RefreshFromDataObject_WithNoLayout_BuildsFallbackColumns` — 無 layout 時依 DataTable 欄位建立後備欄位（GridControlBinder.BindExplicit + RebuildFallbackColumns）

---
_Generated by [Claude Code](https://claude.ai/code/session_01W1nopZXQydZH7RpgZNTmvW)_