### PR TITLE
[AutoFix] SonarCloud Issues (8 issues) 2026-06-12 16:00

### DIFF
--- a/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
+++ b/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
@@ -626,7 +626,7 @@ namespace Bee.UI.Avalonia.Controls.Editors
                 return checkBox;
             }
 
-            if (!canEdit || rowView is null)
+            if (!canEdit)
             {
                 return new TextBlock
                 {

--- a/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
+++ b/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
@@ -636,7 +636,7 @@ namespace Bee.UI.Avalonia.Controls.Editors
                 };
             }
 
-            return BuildSwapCell(rowView, column);
+            return BuildSwapCell(rowView!, column);
         }
 
         // Click-to-edit host: rests as the original text rendering, swaps to the

--- a/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
+++ b/src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs
@@ -642,7 +642,7 @@ namespace Bee.UI.Avalonia.Controls.Editors
         // Click-to-edit host: rests as the original text rendering, swaps to the
         // editor on pointer press and swaps back when the edit session ends, re-reading
         // the row so the committed value is what gets displayed.
-        private Control BuildSwapCell(DataRowView rowView, LayoutColumn column)
+        private ContentControl BuildSwapCell(DataRowView rowView, LayoutColumn column)
         {
             var host = new ContentControl
             {

--- a/src/Bee.UI.Avalonia/Controls/Editors/RowEditPanel.cs
+++ b/src/Bee.UI.Avalonia/Controls/Editors/RowEditPanel.cs
@@ -123,7 +123,7 @@ namespace Bee.UI.Avalonia.Controls.Editors
             Unbind();
         }
 
-        private Control BuildContent(FormDataObject dataObject, LayoutGrid layout, DataRow row)
+        private StackPanel BuildContent(FormDataObject dataObject, LayoutGrid layout, DataRow row)
         {
             var grid = new Grid
             {

--- a/src/Bee.UI.Avalonia/Controls/FormView.cs
+++ b/src/Bee.UI.Avalonia/Controls/FormView.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using Bee.Api.Client.Connectors;
 using Bee.Definition;
 using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
 using Bee.UI.Avalonia.Controls.Editors;
 using Bee.UI.Avalonia.DataObjects;
 using Bee.UI.Core;

--- a/src/Bee.UI.Avalonia/Controls/FormView.cs
+++ b/src/Bee.UI.Avalonia/Controls/FormView.cs
@@ -5,7 +5,6 @@ using Avalonia.Media;
 using Bee.Api.Client.Connectors;
 using Bee.Definition;
 using Bee.Definition.Forms;
-using Bee.Definition.Layouts;
 using Bee.UI.Avalonia.Controls.Editors;
 using Bee.UI.Avalonia.DataObjects;
 using Bee.UI.Core;
@@ -74,7 +73,6 @@ namespace Bee.UI.Avalonia.Controls
         private readonly GridControl _grid;
         private readonly DynamicForm _form;
         private FormDataObject? _dataObject;
-        private LayoutGrid? _listLayout;
         private bool _isBusy;
         private bool _initialized;
         private bool _isInitializing;
@@ -282,9 +280,9 @@ namespace Bee.UI.Avalonia.Controls
             _dataObject = new FormDataObject(Schema!, FormConnector!);
             _form.FormLayout = Schema!.GetFormLayout();
             _form.DataObject = _dataObject;
-            _listLayout = Schema.GetListLayout();
+            var listLayout = Schema.GetListLayout();
             // Columns render immediately; the rows arrive with the first ReloadListAsync.
-            _grid.Bind(_listLayout, rows: null);
+            _grid.Bind(listLayout, rows: null);
         }
 
         /// <summary>

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DropDownEditTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DropDownEditTests.cs
@@ -35,7 +35,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
 
             editor.Bind(dataObject, "dept_id");
 
-            var items = Assert.IsAssignableFrom<IEnumerable<ListItem>>(editor.ItemsSource).ToList();
+            var items = Assert.IsType<List<ListItem>>(editor.ItemsSource);
             Assert.Equal(2, items.Count);
             Assert.Equal("HR", items[0].Value);
         }

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorFactoryTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorFactoryTests.cs
@@ -27,7 +27,6 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
             var editor = FieldEditorFactory.Create(controlType);
 
             Assert.IsType(expectedType, editor);
-            Assert.IsAssignableFrom<IFieldEditor>(editor);
         }
 
         [Theory]

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
@@ -548,7 +548,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
 
             editor.IsChecked = true;
 
-            Assert.Equal(true, table.Rows[0]["ok"]);
+            Assert.True((bool)table.Rows[0]["ok"]);
         }
 
         [Fact]

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
@@ -73,7 +73,6 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
         {
             var grid = new GridControl();
 
-            Assert.IsAssignableFrom<ContentControl>(grid);
             var styleKey = typeof(global::Avalonia.StyledElement)
                 .GetProperty("StyleKeyOverride", BindingFlags.Instance | BindingFlags.NonPublic)!
                 .GetValue(grid);


### PR DESCRIPTION
## SonarCloud AutoFix

| Issue Key | Rule | 檔案 | 修復說明 |
|-----------|------|------|---------|
| AZ608MOWZBZf2NUkWiQl | csharpsquid:S2701 | tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs | 以 `Assert.True((bool)...)` 取代 `Assert.Equal(true, ...)` |
| AZ63aLafzxzPhDtxnCWD | external_roslyn:xUnit2032 | tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs | 移除 `Assert.IsAssignableFrom<ContentControl>` 繼承斷言（繼承由型別系統保證） |
| AZ60pHvmIG-iJUv57g1A | external_roslyn:xUnit2032 | tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorFactoryTests.cs | 移除 `Assert.IsAssignableFrom<IFieldEditor>`（同方法已有 `Assert.IsType` 斷言） |
| AZ60pHyOIG-iJUv57g1B | external_roslyn:xUnit2032 | tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DropDownEditTests.cs | 以 `Assert.IsType<List<ListItem>>` 取代 `Assert.IsAssignableFrom<IEnumerable<ListItem>>` |
| AZ61Qg_VUSgq0rpNurP_ | csharpsquid:S2589 | src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs | 移除恆為 false 的 `rowView is null` 子條件（`canEdit` 已包含此判斷） |
| AZ61Qg_VUSgq0rpNurQA | external_roslyn:CA1859 | src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs | `BuildSwapCell` 回傳型別由 `Control` 改為 `ContentControl` |
| AZ619aMZSIIH_2GS146P | external_roslyn:CA1859 | src/Bee.UI.Avalonia/Controls/Editors/RowEditPanel.cs | `BuildContent` 回傳型別由 `Control` 改為 `StackPanel` |
| AZ608L1MZBZf2NUkWiQk | csharpsquid:S1450 | src/Bee.UI.Avalonia/Controls/FormView.cs | 將 `_listLayout` 欄位轉為方法內區域變數，並移除對應的 unused `using Bee.Definition.Layouts` |

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsjYnrGaeirnYRbNoA8BWG)_