### PR TITLE
[AutoFix] Coverage Fix (3 files) 2026-06-13 08:30

### DIFF
--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditTests.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel;
+using System.Reflection;
+using Avalonia.Controls;
+using Bee.UI.Avalonia.Controls.Editors;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// Tests for <see cref="ButtonEdit"/> behavior independent of the lookup flow:
+    /// ButtonClick event for non-relation fields, IsReadOnly → button enabled sync.
+    /// </summary>
+    public class ButtonEditTests
+    {
+        [Fact]
+        [DisplayName("非 relation 欄位按下按鈕觸發 ButtonClick 事件")]
+        public async Task OnButtonClickAsync_NoLookup_RaisesButtonClickEvent()
+        {
+            var editor = new ButtonEdit();
+            var clicked = false;
+            editor.ButtonClick += (_, _) => clicked = true;
+
+            var method = typeof(ButtonEdit).GetMethod(
+                "OnButtonClickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            await (Task)method!.Invoke(editor, null)!;
+
+            Assert.True(clicked);
+        }
+
+        [Fact]
+        [DisplayName("非 lookup 欄位 IsReadOnly 變更時按鈕啟用狀態同步更新")]
+        public void IsReadOnly_NoLookup_SyncsButtonEnabledState()
+        {
+            var editor = new ButtonEdit();
+            var buttonField = typeof(ButtonEdit)
+                .GetField("_button", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(buttonField);
+            var button = (Button)buttonField!.GetValue(editor)!;
+
+            editor.IsReadOnly = true;
+            Assert.False(button.IsEnabled);
+
+            editor.IsReadOnly = false;
+            Assert.True(button.IsEnabled);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlTests.cs
@@ -779,6 +779,107 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
             Assert.Equal(string.Empty, nullRow);
         }
 
+        [Fact]
+        [DisplayName("Unbind 解除訂閱：後續 DataSet 置換不刷新明細表")]
+        public async Task Unbind_AfterDetailBind_StopsReceivingDataSetReplaced()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_name", "Name", FieldDbType.String);
+            var detail = schema.Tables.Add("EmployeePhone", "Phones");
+            detail.Fields!.Add("phone", "Phone", FieldDbType.String);
+
+            var refreshed = new DataSet("Employee");
+            refreshed.Tables.Add(new DataTable("Employee"));
+            var refreshedDetail = new DataTable("EmployeePhone");
+            refreshedDetail.Columns.Add("phone", typeof(string));
+            refreshed.Tables.Add(refreshedDetail);
+
+            var connector = new FakeFormApiConnector
+            {
+                GetNewDataHandler = () => new Bee.Api.Core.Messages.Form.GetNewDataResponse { DataSet = refreshed },
+            };
+            var dataObject = new FormDataObject(schema, connector);
+
+            var layout = new LayoutGrid("EmployeePhone", "Phones");
+            layout.Columns!.Add(new LayoutColumn { FieldName = "phone", Caption = "Phone", Visible = true });
+            var grid = new GridControl();
+            grid.Bind(dataObject, layout);
+            var tableBeforeUnbind = grid.DataTable;
+
+            grid.Unbind();
+            await dataObject.NewAsync();
+
+            // After Unbind the grid is unsubscribed from DataSetReplaced; DataTable must still
+            // point to the original stale instance, not the refreshed one.
+            Assert.Same(tableBeforeUnbind, grid.DataTable);
+            Assert.NotSame(refreshedDetail, grid.DataTable);
+        }
+
+        [Fact]
+        [DisplayName("RefreshRows 執行後 ItemsSource 不為 null（不拋例外）")]
+        public void RefreshRows_AfterBind_DoesNotThrowAndItemsSourceIsNonNull()
+        {
+            var grid = new GridControl();
+            grid.Bind(BuildEmployeeListLayout(), BuildEmployeeRows());
+
+            var exception = Record.Exception(grid.RefreshRows);
+
+            Assert.Null(exception);
+            Assert.NotNull(grid.InnerGrid.ItemsSource);
+        }
+
+        [Fact]
+        [DisplayName("DeleteSelectedRow 無選取列時為 no-op，不拋例外且列數不變")]
+        public void DeleteSelectedRow_NothingSelected_IsNoOp()
+        {
+            var rows = BuildEmployeeRows();
+            var grid = new GridControl();
+            grid.Bind(BuildEmployeeListLayout(), rows);
+            var countBefore = rows.Rows.Count;
+
+            var exception = Record.Exception(grid.DeleteSelectedRow);
+
+            Assert.Null(exception);
+            Assert.Equal(countBefore, rows.Rows.Count);
+        }
+
+        [Fact]
+        [DisplayName("BuildCellEditor rowView 為 null 時立即回傳空 TextBlock")]
+        public void BuildCellEditor_NullRowView_ReturnsTextBlock()
+        {
+            var grid = new GridControl();
+            grid.Bind(BuildEmployeeListLayout(), BuildEmployeeRows());
+
+            var method = typeof(GridControl).GetMethod(
+                "BuildCellEditor", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var result = method!.Invoke(grid, new object?[] { null, new LayoutColumn { FieldName = "sys_name" } });
+
+            Assert.IsType<TextBlock>(result);
+        }
+
+        [Fact]
+        [DisplayName("DropDownEdit 欄位無 ListItems 時 BuildCellEditor 回退為 TextBox（列表模式無資料物件）")]
+        public void BuildCellEditor_DropDownEdit_NoListItems_FallsBackToTextBox()
+        {
+            var table = new DataTable("Items");
+            table.Columns.Add("category", typeof(string));
+            table.Rows.Add("X");
+            var grid = new GridControl();
+            grid.Bind(new LayoutGrid("Items", "Items"), table);
+
+            var method = typeof(GridControl).GetMethod(
+                "BuildCellEditor", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var column = new LayoutColumn("category", "Category", ControlType.DropDownEdit);
+
+            var editor = method!.Invoke(grid, new object?[] { table.DefaultView[0], column });
+
+            Assert.IsType<TextBox>(editor);
+        }
+
         /// <summary>
         /// Test double that bypasses the real JSON-RPC pipeline by overriding the
         /// virtual CRUD methods used here. Mirrors the fake in

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
@@ -319,7 +319,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
         public void ComputeSelectFields_NullListFields_ReturnsOnlyRowId()
         {
             var schema = BuildEmployeeSchema();
-            schema.ListFields = null;
+            schema.ListFields = null!;
             var view = new TestFormView { Schema = schema };
             var method = typeof(FormView).GetMethod(
                 "ComputeSelectFields", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewTests.cs
@@ -274,6 +274,62 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
             Assert.Equal(SingleFormMode.View, view.FormMode);
         }
 
+        [Fact]
+        [DisplayName("OnDeleteClickedAsync 呼叫 DeleteAsync 並重載列表，最終回到 View 模式")]
+        public async Task OnDeleteClickedAsync_DelegatesToDeleteAsyncAndReturnsToView()
+        {
+            var rowId = Guid.NewGuid();
+            var deleteInvoked = false;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Alice") },
+                GetDataHandler = _ => new GetDataResponse { DataSet = BuildServerDataSet(rowId, "Alice") },
+                DeleteHandler = _ =>
+                {
+                    deleteInvoked = true;
+                    return new DeleteResponse();
+                },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+
+            await InvokePrivateAsync(view, "OnDeleteClickedAsync");
+
+            Assert.True(deleteInvoked);
+            Assert.Equal(SingleFormMode.View, view.FormMode);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields Schema 為 null 時回傳空字串")]
+        public void ComputeSelectFields_NullSchema_ReturnsEmpty()
+        {
+            var view = new TestFormView();
+            var method = typeof(FormView).GetMethod(
+                "ComputeSelectFields", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var result = (string)method!.Invoke(view, null)!;
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields ListFields 為 null 時只回傳 sys_rowid")]
+        public void ComputeSelectFields_NullListFields_ReturnsOnlyRowId()
+        {
+            var schema = BuildEmployeeSchema();
+            schema.ListFields = null;
+            var view = new TestFormView { Schema = schema };
+            var method = typeof(FormView).GetMethod(
+                "ComputeSelectFields", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var result = (string)method!.Invoke(view, null)!;
+
+            Assert.Equal(SysFields.RowId, result);
+        }
+
         /// <summary>
         /// Overrides the <c>Resolve*</c> hooks so tests never read the process-wide
         /// <c>ClientInfo</c> statics; the unused <c>ResolveFormConnector</c> throws to


### PR DESCRIPTION
## Coverage AutoFix

| 檔案 | 補強前覆蓋率 | 新增測試數 |
|------|------------|---------|
| `src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs` | 74.0% | 5 |
| `src/Bee.UI.Avalonia/Controls/FormView.cs` | 82.6% | 3 |
| `src/Bee.UI.Avalonia/Controls/Editors/ButtonEdit.cs` | 64.0% | 2 |

### 補強內容

**GridControl.cs**
- `Unbind_AfterDetailBind_StopsReceivingDataSetReplaced`：Unbind 後 DataSet 置換不刷新明細表
- `RefreshRows_AfterBind_DoesNotThrowAndItemsSourceIsNonNull`：RefreshRows 不拋例外且 ItemsSource 維持非 null
- `DeleteSelectedRow_NothingSelected_IsNoOp`：無選取列時為 no-op
- `BuildCellEditor_NullRowView_ReturnsTextBlock`：null rowView 早期回傳 TextBlock
- `BuildCellEditor_DropDownEdit_NoListItems_FallsBackToTextBox`：列表模式無 ListItems 時回退 TextBox

**FormView.cs**
- `OnDeleteClickedAsync_DelegatesToDeleteAsyncAndReturnsToView`：Delete 流程完整覆蓋
- `ComputeSelectFields_NullSchema_ReturnsEmpty`：Schema 為 null 時回傳空字串
- `ComputeSelectFields_NullListFields_ReturnsOnlyRowId`：ListFields 為 null 時只回傳 sys_rowid

**ButtonEdit.cs**
- `OnButtonClickAsync_NoLookup_RaisesButtonClickEvent`：非 lookup 欄位按鈕觸發 ButtonClick 事件
- `IsReadOnly_NoLookup_SyncsButtonEnabledState`：IsReadOnly 變更時按鈕啟用狀態同步

### 無法處理

| 檔案 | 原因 |
|------|------|
| `src/Bee.UI.Avalonia/Controls/Editors/FieldEditorBinder.cs` | ambient binding（`TryAmbientBind`）需要 `FormScope` 附著於 logical tree；無 Avalonia 平台無法觸發 |
| `src/Bee.UI.Avalonia/Controls/Editors/GridControlBinder.cs` | 同上；`OnBindingContextChanged`、`TryAmbientBind` 路徑需 visual tree |

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMyQDzmRHip7tesKCara6G)_