### PR TITLE
[AutoFix] Coverage Fix (4 files) 2026-06-13 16:55

### DIFF
--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditAdditionalTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditAdditionalTests.cs
@@ -1,0 +1,161 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Avalonia.Input;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="ButtonEdit"/> 覆蓋率：ButtonClick 事件（非 lookup 欄）、
+    /// Delete/Back 清除 lookup 選取、版面層級 DisplayFields 覆寫。
+    /// </summary>
+    public class ButtonEditAdditionalTests
+    {
+        private static FormSchema BuildOrderSchema()
+        {
+            var schema = new FormSchema("Order", "訂單") { CategoryId = "company" };
+            var table = schema.Tables!.Add("Order", "訂單");
+            table.Fields!.Add(new FormField(SysFields.RowId, "唯一識別", FieldDbType.Guid));
+            table.Fields!.Add(new FormField(SysFields.Id, "單號", FieldDbType.String));
+
+            var customerField = new FormField("customer_rowid", "客戶", FieldDbType.Guid)
+            {
+                RelationProgId = "Customer",
+            };
+            customerField.RelationFieldMappings!.Add(SysFields.Id, "ref_customer_id");
+            customerField.RelationFieldMappings!.Add(SysFields.Name, "ref_customer_name");
+            table.Fields!.Add(customerField);
+            table.Fields!.Add(new FormField("ref_customer_id", "客戶代碼", FieldDbType.String, FieldType.RelationField));
+            table.Fields!.Add(new FormField("ref_customer_name", "客戶名稱", FieldDbType.String, FieldType.RelationField));
+            return schema;
+        }
+
+        private static DataRow BuildSelectedCustomerRow(Guid rowId, string id, string name)
+        {
+            var table = new DataTable("Customer");
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            table.Columns.Add(SysFields.Id, typeof(string));
+            table.Columns.Add(SysFields.Name, typeof(string));
+            table.Rows.Add(rowId, id, name);
+            return table.Rows[0];
+        }
+
+        private static FormDataObject BuildOrderDataObject()
+        {
+            var schema = BuildOrderSchema();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            return dataObject;
+        }
+
+        private static void InvokeOnKeyDown(ButtonEdit editor, Key key)
+        {
+            var method = typeof(ButtonEdit).GetMethod(
+                "OnKeyDown", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var args = new KeyEventArgs { Key = key };
+            method!.Invoke(editor, new object[] { args });
+        }
+
+        private static async Task InvokeOnButtonClickAsync(ButtonEdit editor)
+        {
+            var method = typeof(ButtonEdit).GetMethod(
+                "OnButtonClickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            await (Task)method!.Invoke(editor, null)!;
+        }
+
+        [Fact]
+        [DisplayName("非 lookup 欄位點擊按鈕觸發 ButtonClick 事件")]
+        public async Task OnButtonClickAsync_NonLookupField_RaisesButtonClickEvent()
+        {
+            var schema = BuildOrderSchema();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, SysFields.Id);
+            Assert.False(editor.HasLookup);
+
+            var invoked = false;
+            editor.ButtonClick += (_, _) => invoked = true;
+
+            await InvokeOnButtonClickAsync(editor);
+
+            Assert.True(invoked);
+        }
+
+        [Fact]
+        [DisplayName("Delete 鍵在 lookup 允許編輯模式下清除選取值")]
+        public void OnKeyDown_Delete_LookupModeAllowEdit_ClearsSelection()
+        {
+            var dataObject = BuildOrderDataObject();
+            var layout = BuildOrderSchema().GetFormLayout();
+            var layoutField = layout.Sections![0].Fields!.First(f => f.FieldName == "customer_rowid");
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, layoutField);
+            editor.SetControlState(SingleFormMode.Edit);
+            Assert.True(editor.HasLookup);
+
+            var field = dataObject.GetFormField("customer_rowid")!;
+            dataObject.ApplyLookupSelection(field, BuildSelectedCustomerRow(Guid.NewGuid(), "C001", "客戶甲"));
+            Assert.False(string.IsNullOrEmpty(editor.Text));
+
+            InvokeOnKeyDown(editor, Key.Delete);
+
+            Assert.Equal(string.Empty, editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("Back 鍵同樣清除 lookup 選取值")]
+        public void OnKeyDown_Back_LookupModeAllowEdit_ClearsSelection()
+        {
+            var dataObject = BuildOrderDataObject();
+            var layout = BuildOrderSchema().GetFormLayout();
+            var layoutField = layout.Sections![0].Fields!.First(f => f.FieldName == "customer_rowid");
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, layoutField);
+            editor.SetControlState(SingleFormMode.Edit);
+
+            var field = dataObject.GetFormField("customer_rowid")!;
+            dataObject.ApplyLookupSelection(field, BuildSelectedCustomerRow(Guid.NewGuid(), "C001", "客戶甲"));
+
+            InvokeOnKeyDown(editor, Key.Back);
+
+            Assert.Equal(string.Empty, editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("版面層級 DisplayFields 覆寫 schema 預設，僅顯示指定欄位")]
+        public void RefreshFromSource_WithLayoutDisplayFields_UsesLayoutOverride()
+        {
+            var schema = BuildOrderSchema();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+
+            // 版面只顯示客戶代碼，不顯示名稱
+            var layoutField = new LayoutField
+            {
+                FieldName = "customer_rowid",
+                DisplayFields = "ref_customer_id",
+            };
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, layoutField);
+            editor.SetControlState(SingleFormMode.Edit);
+            Assert.True(editor.HasLookup);
+
+            var field = dataObject.GetFormField("customer_rowid")!;
+            dataObject.ApplyLookupSelection(
+                field,
+                BuildSelectedCustomerRow(Guid.NewGuid(), "C001", "客戶甲"));
+
+            // 版面覆寫後只取 ref_customer_id，不含名稱
+            Assert.Equal("C001", editor.Text);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditAdditionalTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditAdditionalTests.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Avalonia.Input;
 using Bee.Base.Data;
 using Bee.Definition;
+using Bee.Definition.Database;
 using Bee.Definition.Forms;
 using Bee.Definition.Layouts;
 using Bee.UI.Avalonia.Controls.Editors;

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorBinderAdditionalTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorBinderAdditionalTests.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="FieldEditorBinder"/> 覆蓋率：透過 FormScope 屬性觸發
+    /// <c>OnFormModeChanged</c> 路徑（class handler 路徑，有別於直接呼叫
+    /// <c>SetControlState</c>）。
+    /// </summary>
+    public class FieldEditorBinderAdditionalTests
+    {
+        private static FormDataObject BuildDataObject()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_name", "Name", FieldDbType.String);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            return dataObject;
+        }
+
+        [Fact]
+        [DisplayName("透過 FormScope.FormModeProperty 觸發 OnFormModeChanged，View 模式套用唯讀")]
+        public void OnFormModeChanged_ViaFormScopeProperty_ViewMode_SetsReadOnly()
+        {
+            var dataObject = BuildDataObject();
+            var editor = new TextEdit();
+            editor.Bind(dataObject, "emp_name");
+            editor.SetControlState(SingleFormMode.Edit);
+            Assert.False(editor.IsReadOnly);
+
+            // class handler: FormScope.FormModeProperty.Changed.AddClassHandler<TextEdit>(
+            //   (o, e) => o._binder.OnFormModeChanged((SingleFormMode)e.NewValue!))
+            FormScope.SetFormMode(editor, SingleFormMode.View);
+
+            Assert.True(editor.IsReadOnly);
+        }
+
+        [Fact]
+        [DisplayName("透過 FormScope.FormModeProperty 切換為 Edit 模式，編輯器可編輯")]
+        public void OnFormModeChanged_ViaFormScopeProperty_EditMode_ClearsReadOnly()
+        {
+            var dataObject = BuildDataObject();
+            var editor = new TextEdit();
+            editor.Bind(dataObject, "emp_name");
+            FormScope.SetFormMode(editor, SingleFormMode.View);
+            Assert.True(editor.IsReadOnly);
+
+            FormScope.SetFormMode(editor, SingleFormMode.Edit);
+
+            Assert.False(editor.IsReadOnly);
+        }
+
+        [Fact]
+        [DisplayName("AllowEditModes=Add 時 Edit 模式透過 FormScope 觸發後仍唯讀")]
+        public void OnFormModeChanged_ViaFormScope_AllowEditModesAdd_EditModeReadOnly()
+        {
+            var dataObject = BuildDataObject();
+            var field = new LayoutField { FieldName = "emp_name", AllowEditModes = FormEditModes.Add };
+            var editor = new TextEdit();
+            editor.Bind(dataObject, field);
+
+            // Add 模式：AllowEditModes.Allows(Add) = true → 可編輯
+            FormScope.SetFormMode(editor, SingleFormMode.Add);
+            Assert.False(editor.IsReadOnly);
+
+            // Edit 模式：AllowEditModes.Allows(Edit) = false → 唯讀
+            FormScope.SetFormMode(editor, SingleFormMode.Edit);
+            Assert.True(editor.IsReadOnly);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlAdditionalTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlAdditionalTests.cs
@@ -2,7 +2,6 @@ using System.ComponentModel;
 using System.Data;
 using System.Reflection;
 using Avalonia.Controls;
-using Bee.Definition;
 using Bee.Definition.Layouts;
 using Bee.UI.Avalonia.Controls.Editors;
 

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlAdditionalTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlAdditionalTests.cs
@@ -1,0 +1,147 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Avalonia.Controls;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="GridControl"/> 覆蓋率：private static 輔助方法
+    /// ComposeDisplayText / SplitDisplayFields、BuildCellEditor null 路徑、
+    /// AddRow 在 DataTable 為 null 時的 no-op。
+    /// </summary>
+    public class GridControlAdditionalTests
+    {
+        private static readonly string[] s_idAndNameFields = { "sys_id", "sys_name" };
+        private static readonly string[] s_idField = { "sys_id" };
+
+        private static string InvokeSplitDisplayFields(string displayFields)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "SplitDisplayFields", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var result = (string[])method!.Invoke(null, new object[] { displayFields })!;
+            return string.Join(",", result);
+        }
+
+        private static string InvokeComposeDisplayText(
+            DataRowView? rowView, string[] displayFields, string displayFormat, string numberFormat)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "ComposeDisplayText", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null,
+                new object?[] { rowView, displayFields, displayFormat, numberFormat })!;
+        }
+
+        private static DataTable BuildSimpleTable()
+        {
+            var table = new DataTable("Items");
+            table.Columns.Add("sys_id", typeof(string));
+            table.Columns.Add("sys_name", typeof(string));
+            table.Rows.Add("E001", "Alice");
+            return table;
+        }
+
+        [Fact]
+        [DisplayName("SplitDisplayFields 空字串回傳空陣列")]
+        public void SplitDisplayFields_EmptyString_ReturnsEmptyArray()
+        {
+            var result = InvokeSplitDisplayFields(string.Empty);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("SplitDisplayFields 逗號分隔字串回傳修剪後的陣列")]
+        public void SplitDisplayFields_CommaSeparated_ReturnsTrimmedElements()
+        {
+            var result = InvokeSplitDisplayFields(" sys_id , sys_name ");
+
+            Assert.Equal("sys_id,sys_name", result);
+        }
+
+        [Fact]
+        [DisplayName("ComposeDisplayText 以顯示欄位組合儲存格文字")]
+        public void ComposeDisplayText_WithDisplayFields_JoinsValues()
+        {
+            var table = BuildSimpleTable();
+            var rowView = table.DefaultView[0];
+
+            var result = InvokeComposeDisplayText(rowView, s_idAndNameFields, string.Empty, string.Empty);
+
+            Assert.Equal("E001 - Alice", result);
+        }
+
+        [Fact]
+        [DisplayName("ComposeDisplayText 欄位不存在時回傳空字串")]
+        public void ComposeDisplayText_MissingField_ReturnsEmpty()
+        {
+            var table = BuildSimpleTable();
+            var rowView = table.DefaultView[0];
+
+            var result = InvokeComposeDisplayText(rowView, s_idField, string.Empty, string.Empty);
+
+            // sys_id exists → "E001"; no separator needed for single field
+            Assert.Equal("E001", result);
+        }
+
+        [Fact]
+        [DisplayName("ComposeDisplayText rowView 為 null 時回傳空字串")]
+        public void ComposeDisplayText_NullRowView_ReturnsEmpty()
+        {
+            var result = InvokeComposeDisplayText(null, s_idAndNameFields, string.Empty, string.Empty);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("BuildCellEditor 在 rowView 為 null 時回傳 TextBlock")]
+        public void BuildCellEditor_NullRowView_ReturnsTextBlock()
+        {
+            var grid = new GridControl();
+            grid.Bind(new LayoutGrid("Items", "Items"), null);
+
+            var method = typeof(GridControl).GetMethod(
+                "BuildCellEditor", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var result = method!.Invoke(grid,
+                new object?[] { null, new LayoutColumn { FieldName = "name" } });
+
+            Assert.IsType<TextBlock>(result);
+        }
+
+        [Fact]
+        [DisplayName("BuildCellEditor 在欄位不存在於 DataTable 時回傳 TextBlock")]
+        public void BuildCellEditor_FieldMissingFromTable_ReturnsTextBlock()
+        {
+            var table = BuildSimpleTable();
+            var grid = new GridControl();
+            grid.Bind(new LayoutGrid("Items", "Items"), table);
+
+            var method = typeof(GridControl).GetMethod(
+                "BuildCellEditor", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var result = method!.Invoke(grid,
+                new object?[] { table.DefaultView[0], new LayoutColumn { FieldName = "not_a_column" } });
+
+            Assert.IsType<TextBlock>(result);
+        }
+
+        [Fact]
+        [DisplayName("AddRow 在 DataTable 為 null 時為 no-op，不拋例外")]
+        public void AddRow_NullDataTable_IsNoOp()
+        {
+            var grid = new GridControl();
+
+            var exception = Record.Exception(grid.AddRow);
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewAdditionalTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewAdditionalTests.cs
@@ -1,0 +1,265 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Avalonia.Controls;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Avalonia.Controls;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls
+{
+    /// <summary>
+    /// 補強 <see cref="FormView"/> 覆蓋率：Delete 工作流程、工具列狀態、
+    /// dirty marker、OnEditClicked no-op 等路徑。
+    /// </summary>
+    public class FormViewAdditionalTests
+    {
+        private const string TestProgId = "Employee";
+
+        private static FormSchema BuildEmployeeSchema()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            schema.ListFields = "sys_id,sys_name";
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("sys_id", "Employee ID", FieldDbType.String);
+            master.Fields.Add("sys_name", "Name", FieldDbType.String);
+            return schema;
+        }
+
+        private static DataSet BuildServerDataSet(Guid rowId, string name)
+        {
+            var dataSet = new DataSet(TestProgId);
+            var master = new DataTable(TestProgId);
+            master.Columns.Add(SysFields.RowId, typeof(Guid));
+            master.Columns.Add("sys_name", typeof(string));
+            master.Rows.Add(rowId, name);
+            dataSet.Tables.Add(master);
+            dataSet.AcceptChanges();
+            return dataSet;
+        }
+
+        private static DataTable BuildEmployeeListTable(Guid rowId, string name)
+        {
+            var table = new DataTable(TestProgId);
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            table.Columns.Add("sys_id", typeof(string));
+            table.Columns.Add("sys_name", typeof(string));
+            table.Rows.Add(rowId, "E001", name);
+            return table;
+        }
+
+        private static async Task InvokePrivateAsync(FormView view, string methodName, params object[] args)
+        {
+            var method = typeof(FormView).GetMethod(
+                methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            await (Task)method!.Invoke(view, args)!;
+        }
+
+        private static void InvokeEditClicked(FormView view)
+        {
+            var method = typeof(FormView).GetMethod(
+                "OnEditClicked", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            method!.Invoke(view, null);
+        }
+
+        private static Button GetButton(FormView view, string fieldName)
+            => (Button)typeof(FormView)
+                .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(view)!;
+
+        private static TextBlock GetTextBlock(FormView view, string fieldName)
+            => (TextBlock)typeof(FormView)
+                .GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance)!
+                .GetValue(view)!;
+
+        private static void InvokeUpdateToolbarState(FormView view)
+        {
+            var method = typeof(FormView).GetMethod(
+                "UpdateToolbarState", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            method!.Invoke(view, null);
+        }
+
+        [Fact]
+        [DisplayName("Delete 成功後回到 View 模式並重載清單")]
+        public async Task OnDeleteClickedAsync_Success_ReturnsToViewAndReloadsList()
+        {
+            var rowId = Guid.NewGuid();
+            var reloadCount = 0;
+            Guid? deletedId = null;
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ =>
+                {
+                    reloadCount++;
+                    return new GetListResponse { Table = BuildEmployeeListTable(rowId, "Alice") };
+                },
+                GetDataHandler = _ => new GetDataResponse { DataSet = BuildServerDataSet(rowId, "Alice") },
+                DeleteHandler = id =>
+                {
+                    deletedId = id;
+                    return new DeleteResponse();
+                },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+
+            await InvokePrivateAsync(view, "OnDeleteClickedAsync");
+
+            Assert.Equal(rowId, deletedId);
+            Assert.Equal(SingleFormMode.View, view.FormMode);
+            Assert.Equal(2, reloadCount);
+        }
+
+        [Fact]
+        [DisplayName("Delete 失敗時 ErrorOccurred 帶出例外訊息")]
+        public async Task OnDeleteClickedAsync_Error_FiresErrorOccurred()
+        {
+            var rowId = Guid.NewGuid();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Bob") },
+                GetDataHandler = _ => new GetDataResponse { DataSet = BuildServerDataSet(rowId, "Bob") },
+                DeleteHandler = _ => throw new InvalidOperationException("delete failed"),
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+            Exception? captured = null;
+            view.ErrorOccurred += (_, ex) => captured = ex;
+
+            await InvokePrivateAsync(view, "OnDeleteClickedAsync");
+
+            Assert.NotNull(captured);
+            Assert.Equal("delete failed", captured!.Message);
+        }
+
+        [Fact]
+        [DisplayName("OnEditClicked 在無 MasterRow 時為 no-op，不變更 FormMode")]
+        public async Task OnEditClicked_WithoutMasterRow_IsNoOp()
+        {
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse
+                {
+                    Table = BuildEmployeeListTable(Guid.NewGuid(), "X"),
+                },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            Assert.Null(view.DataObject?.MasterRow);
+
+            InvokeEditClicked(view);
+
+            Assert.Equal(SingleFormMode.View, view.FormMode);
+        }
+
+        [Fact]
+        [DisplayName("View 模式有 MasterRow 時 Edit 與 Delete 按鈕啟用、Save 停用")]
+        public async Task UpdateToolbarState_ViewModeWithMasterRow_EnablesEditAndDelete()
+        {
+            var rowId = Guid.NewGuid();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Alice") },
+                GetDataHandler = _ => new GetDataResponse { DataSet = BuildServerDataSet(rowId, "Alice") },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+
+            Assert.True(GetButton(view, "_editButton").IsEnabled);
+            Assert.True(GetButton(view, "_deleteButton").IsEnabled);
+            Assert.False(GetButton(view, "_saveButton").IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("Edit 模式時 Save 啟用、Edit 與 Delete 停用")]
+        public async Task UpdateToolbarState_EditModeWithMasterRow_EnablesSaveOnly()
+        {
+            var rowId = Guid.NewGuid();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Alice") },
+                GetDataHandler = _ => new GetDataResponse { DataSet = BuildServerDataSet(rowId, "Alice") },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+            InvokeEditClicked(view);
+
+            Assert.False(GetButton(view, "_editButton").IsEnabled);
+            Assert.False(GetButton(view, "_deleteButton").IsEnabled);
+            Assert.True(GetButton(view, "_saveButton").IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("資料變更後 UpdateToolbarState 顯示 dirty marker")]
+        public async Task DirtyMarker_AfterSetField_IsVisible()
+        {
+            var rowId = Guid.NewGuid();
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = BuildEmployeeListTable(rowId, "Alice") },
+                GetDataHandler = _ => new GetDataResponse { DataSet = BuildServerDataSet(rowId, "Alice") },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            await InvokePrivateAsync(view, "OnRowSelectedAsync", rowId);
+            InvokeEditClicked(view);
+            Assert.False(GetTextBlock(view, "_dirtyMarker").IsVisible);
+
+            view.DataObject!.SetField("sys_name", "Modified");
+            InvokeUpdateToolbarState(view);
+
+            Assert.True(GetTextBlock(view, "_dirtyMarker").IsVisible);
+        }
+
+        private sealed class TestFormView : FormView
+        {
+            protected override SystemApiConnector? ResolveSystemConnector() => null;
+
+            protected override FormApiConnector ResolveFormConnector(string progId)
+                => throw new InvalidOperationException("ClientInfo fallback must not be reached in unit tests.");
+
+            protected override Guid ResolveAccessToken() => Guid.Empty;
+        }
+
+        private sealed class FakeFormApiConnector : FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), TestProgId) { }
+
+            public Func<string, GetListResponse>? GetListHandler { get; set; }
+            public Func<Guid, GetDataResponse>? GetDataHandler { get; set; }
+            public Func<GetNewDataResponse>? GetNewDataHandler { get; set; }
+            public Func<DataSet, SaveResponse>? SaveHandler { get; set; }
+            public Func<Guid, DeleteResponse>? DeleteHandler { get; set; }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                Bee.Definition.Filters.FilterNode? filter = null,
+                Bee.Definition.Sorting.SortFieldCollection? sortFields = null,
+                Bee.Definition.Paging.PagingOptions? paging = null)
+                => Task.FromResult((GetListHandler ?? (_ => new GetListResponse()))(selectFields));
+
+            public override Task<GetDataResponse> GetDataAsync(Guid rowId)
+                => Task.FromResult((GetDataHandler ?? (_ => new GetDataResponse()))(rowId));
+
+            public override Task<GetNewDataResponse> GetNewDataAsync()
+                => Task.FromResult((GetNewDataHandler ?? (() => new GetNewDataResponse()))());
+
+            public override Task<SaveResponse> SaveAsync(DataSet dataSet)
+                => Task.FromResult((SaveHandler ?? (_ => new SaveResponse()))(dataSet));
+
+            public override Task<DeleteResponse> DeleteAsync(Guid rowId)
+                => Task.FromResult((DeleteHandler ?? (_ => new DeleteResponse()))(rowId));
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewAdditionalTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewAdditionalTests.cs
@@ -7,6 +7,7 @@ using Bee.Api.Core.Messages.Form;
 using Bee.Base.Data;
 using Bee.Definition;
 using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
 using Bee.UI.Avalonia.Controls;
 
 namespace Bee.UI.Avalonia.UnitTests.Controls


### PR DESCRIPTION
## 本次修補目標

SonarCloud 偵測到以下 4 個檔案的行覆蓋率低於 90%，本 PR 補齊對應單元測試。

| 目標檔案 | 修補前覆蓋率 | 未覆蓋行數 | 對應測試檔 |
|----------|-------------|-----------|-----------|
| `Bee.UI.Avalonia/Controls/Editors/GridControl.cs` | 74.0% | 122 | `GridControlAdditionalTests.cs` |
| `Bee.UI.Avalonia/Controls/FormView.cs` | 82.6% | 36 | `FormViewAdditionalTests.cs` |
| `Bee.UI.Avalonia/Controls/Editors/ButtonEdit.cs` | 65.2% | 31 | `ButtonEditAdditionalTests.cs` |
| `Bee.UI.Avalonia/Controls/Editors/FieldEditorBinder.cs` | 81.6% | 21 | `FieldEditorBinderAdditionalTests.cs` |

> `GridControlBinder.cs`（54.3%）需要 Avalonia logical tree 才能觸發未覆蓋路徑，非單元測試可達，本次略過。

## 新增測試說明

### FormViewAdditionalTests（6 tests）
- Delete 成功 → 回 View 模式並重載清單
- Delete 失敗 → `ErrorOccurred` 帶出例外訊息
- `OnEditClicked` 無 MasterRow 時 no-op
- View 模式有 MasterRow：Edit + Delete 啟用，Save 停用
- Edit 模式：Save 啟用，Edit + Delete 停用
- 資料變更後 `UpdateToolbarState` 顯示 dirty marker

### ButtonEditAdditionalTests（4 tests）
- 非 lookup 欄 `ButtonClick` 事件觸發
- `Delete` 鍵清除 lookup 選取值
- `Back` 鍵清除 lookup 選取值
- 版面層級 `DisplayFields` 覆寫 schema 預設

### FieldEditorBinderAdditionalTests（3 tests）
- `FormScope.SetFormMode` → View 模式套用唯讀（class handler 路徑）
- `FormScope.SetFormMode` → Edit 模式清除唯讀
- `AllowEditModes=Add` 時 Edit 模式仍唯讀

### GridControlAdditionalTests（8 tests）
- `SplitDisplayFields` 空字串 / 逗號分隔
- `ComposeDisplayText` 多欄位合併 / 單欄 / null rowView
- `BuildCellEditor` null rowView → TextBlock
- `BuildCellEditor` 欄位不存在 → TextBlock
- `AddRow` DataTable 為 null → no-op

## 測試計畫

- [ ] CI 通過所有新增 `[Fact]` 測試（純單元測試，無 DB 相依）
- [ ] 無新增 analyzer 警告（IDE0005 / S2699 / CA1861）
- [ ] 僅異動 `tests/` 目錄

https://claude.ai/code/session_019d8x2LbVD6cWBkyBU9BtT2

---
_Generated by [Claude Code](https://claude.ai/code/session_019d8x2LbVD6cWBkyBU9BtT2)_