### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-06-14

### DIFF
--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditCoverageTests.cs
@@ -1,0 +1,104 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="ButtonEdit"/> 覆蓋率：lookup 無顯示欄位時 RefreshFromSource
+    /// 回傳空字串（ApplyMetadata 的 HasLookup+空 displayFields 路徑）、
+    /// OpenLookupAsync 在不允許編輯時提早回傳而不呼叫 LookupDialog。
+    /// </summary>
+    public class ButtonEditCoverageTests
+    {
+        private static FormDataObject BuildDataObjectWithLookupNoDisplayFields()
+        {
+            var schema = new FormSchema("Order", "Order");
+            var table = schema.Tables!.Add("Order", "Order");
+            table.Fields!.Add(new FormField("order_id", "Order ID", FieldDbType.String));
+            // lookup 欄無 RelationFieldMappings → GetDisplayFields() 回傳空集合
+            table.Fields!.Add(new FormField("vendor_rowid", "Vendor", FieldDbType.Guid)
+            {
+                RelationProgId = "Vendor",
+            });
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            return dataObject;
+        }
+
+        private static FormDataObject BuildOrderDataObjectWithLookup()
+        {
+            var schema = new FormSchema("Order", "Order");
+            var table = schema.Tables!.Add("Order", "Order");
+            table.Fields!.Add(new FormField("order_id", "Order ID", FieldDbType.String));
+            var customerField = new FormField("customer_rowid", "Customer", FieldDbType.Guid)
+            {
+                RelationProgId = "Customer",
+            };
+            customerField.RelationFieldMappings!.Add("sys_id", "ref_customer_id");
+            customerField.RelationFieldMappings!.Add("sys_name", "ref_customer_name");
+            table.Fields!.Add(customerField);
+            table.Fields!.Add(new FormField("ref_customer_id", "Customer Code", FieldDbType.String,
+                Bee.Definition.Database.FieldType.RelationField));
+            table.Fields!.Add(new FormField("ref_customer_name", "Customer Name", FieldDbType.String,
+                Bee.Definition.Database.FieldType.RelationField));
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            return dataObject;
+        }
+
+        private static async Task InvokeOnButtonClickAsync(ButtonEdit editor)
+        {
+            var method = typeof(ButtonEdit).GetMethod(
+                "OnButtonClickAsync", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            await (Task)method!.Invoke(editor, null)!;
+        }
+
+        [Fact]
+        [DisplayName("lookup 欄無 RelationFieldMappings 時 HasLookup 仍為 true 但 Text 顯示空字串")]
+        public void RefreshFromSource_LookupWithNoDisplayFields_SetsEmptyText()
+        {
+            var dataObject = BuildDataObjectWithLookupNoDisplayFields();
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, "vendor_rowid");
+
+            Assert.True(editor.HasLookup);
+            Assert.Equal(string.Empty, editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("lookup 欄有值但無 DisplayFields 時刷新也顯示空字串")]
+        public void RefreshFromSource_LookupValueSetNoDisplayFields_TextRemainsEmpty()
+        {
+            var dataObject = BuildDataObjectWithLookupNoDisplayFields();
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, "vendor_rowid");
+
+            // 設定 rowid 值，但因無 displayFields → Text 仍為空字串
+            dataObject.SetField("vendor_rowid", Guid.NewGuid().ToString());
+
+            Assert.Equal(string.Empty, editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("OnButtonClickAsync 在 View 模式（不允許編輯）時提早回傳，不呼叫 LookupDialog")]
+        public async Task OnButtonClickAsync_LookupInViewMode_ReturnsEarlyWithoutDialog()
+        {
+            var dataObject = BuildOrderDataObjectWithLookup();
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, "customer_rowid");
+            editor.SetControlState(SingleFormMode.View);
+            Assert.True(editor.HasLookup);
+
+            // 設定 View 模式後 _allowLookupEdit = false → OpenLookupAsync 直接回傳，不進 LookupDialog
+            var exception = await Record.ExceptionAsync(() => InvokeOnButtonClickAsync(editor));
+
+            Assert.Null(exception);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorBinderCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorBinderCoverageTests.cs
@@ -62,7 +62,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
         }
 
         [Fact]
-        [DisplayName("NotifyAttached：ambient DataObject 未設定時不綁定，Text 維持空字串")]
+        [DisplayName("NotifyAttached：ambient DataObject 未設定時不綁定，Text 維持 null")]
         public void NotifyAttached_NoAmbientDataObject_DoesNotBind()
         {
             var editor = new TextEdit();
@@ -70,7 +70,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
 
             InvokeNotifyAttached(GetBinder(editor));
 
-            Assert.Equal(string.Empty, editor.Text);
+            Assert.Null(editor.Text);
         }
 
         [Fact]

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorBinderCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/FieldEditorBinderCoverageTests.cs
@@ -1,0 +1,132 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="FieldEditorBinder"/> 的 ambient 綁定路徑覆蓋率：透過反射對
+    /// <see cref="TextEdit"/> 的私有 _binder 呼叫 NotifyAttached / NotifyDetached，
+    /// 模擬 OnAttachedToLogicalTree / OnDetachedFromLogicalTree 的觸發路徑。
+    /// 同時驗證 OnBindingContextChanged 在已附加後切換 DataObject 的重新綁定行為。
+    /// </summary>
+    public class FieldEditorBinderCoverageTests
+    {
+        private static FormDataObject BuildDataObject(string empName = "Alice")
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_name", "Name", FieldDbType.String);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            dataObject.SetField("emp_name", empName);
+            return dataObject;
+        }
+
+        private static object GetBinder(TextEdit editor)
+        {
+            var field = typeof(TextEdit).GetField("_binder", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return field!.GetValue(editor)!;
+        }
+
+        private static void InvokeNotifyAttached(object binder)
+        {
+            var method = binder.GetType().GetMethod("NotifyAttached");
+            Assert.NotNull(method);
+            method!.Invoke(binder, null);
+        }
+
+        private static void InvokeNotifyDetached(object binder)
+        {
+            var method = binder.GetType().GetMethod("NotifyDetached");
+            Assert.NotNull(method);
+            method!.Invoke(binder, null);
+        }
+
+        [Fact]
+        [DisplayName("NotifyAttached：ambient DataObject + FieldName 已設定時自動綁定編輯器並載入初值")]
+        public void NotifyAttached_WithAmbientDataObjectAndFieldName_BindsEditorAndLoadsValue()
+        {
+            var dataObject = BuildDataObject("Alice");
+            var editor = new TextEdit();
+            editor.FieldName = "emp_name";
+            FormScope.SetDataObject(editor, dataObject);
+
+            InvokeNotifyAttached(GetBinder(editor));
+
+            Assert.Equal("Alice", editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("NotifyAttached：ambient DataObject 未設定時不綁定，Text 維持空字串")]
+        public void NotifyAttached_NoAmbientDataObject_DoesNotBind()
+        {
+            var editor = new TextEdit();
+            editor.FieldName = "emp_name";
+
+            InvokeNotifyAttached(GetBinder(editor));
+
+            Assert.Equal(string.Empty, editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("NotifyDetached：ambient 綁定後呼叫 NotifyDetached，後續 SetField 不再刷新編輯器")]
+        public void NotifyDetached_AfterAmbientBind_StopsUpdates()
+        {
+            var dataObject = BuildDataObject("Alice");
+            var editor = new TextEdit();
+            editor.FieldName = "emp_name";
+            FormScope.SetDataObject(editor, dataObject);
+            var binder = GetBinder(editor);
+            InvokeNotifyAttached(binder);
+            Assert.Equal("Alice", editor.Text);
+
+            InvokeNotifyDetached(binder);
+
+            dataObject.SetField("emp_name", "Bob");
+            // 已解除綁定 → 刷新事件不再路由至編輯器
+            Assert.Equal("Alice", editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("OnBindingContextChanged：附加後切換 DataObject，編輯器重新綁定到新 DataObject")]
+        public void OnBindingContextChanged_AfterAttach_NewDataObject_Rebinds()
+        {
+            var dataObject1 = BuildDataObject("Alice");
+            var dataObject2 = BuildDataObject("Bob");
+
+            var editor = new TextEdit();
+            editor.FieldName = "emp_name";
+            FormScope.SetDataObject(editor, dataObject1);
+            InvokeNotifyAttached(GetBinder(editor));
+            Assert.Equal("Alice", editor.Text);
+
+            // 切換 DataObject → 觸發 DataObjectProperty.Changed 類別 handler → OnBindingContextChanged → 重新綁定
+            FormScope.SetDataObject(editor, dataObject2);
+
+            Assert.Equal("Bob", editor.Text);
+        }
+
+        [Fact]
+        [DisplayName("OnBindingContextChanged：相同 DataObject + 相同 FieldName，不重新綁定（短路）")]
+        public void OnBindingContextChanged_SameDataObjectAndFieldName_IsNoOp()
+        {
+            var dataObject = BuildDataObject("Carol");
+            var editor = new TextEdit();
+            editor.FieldName = "emp_name";
+            FormScope.SetDataObject(editor, dataObject);
+            InvokeNotifyAttached(GetBinder(editor));
+            Assert.Equal("Carol", editor.Text);
+
+            editor.Text = "Carol-modified";
+
+            // 再次設定相同 DataObject → short-circuit，不重新載入初值，Text 維持修改後值
+            FormScope.SetDataObject(editor, dataObject);
+            Assert.Equal("Carol-modified", editor.Text);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlBinderCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlBinderCoverageTests.cs
@@ -1,0 +1,136 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="GridControlBinder"/> 的 ambient 綁定路徑覆蓋率：透過反射對
+    /// <see cref="GridControl"/> 的私有 _binder 呼叫 NotifyAttached / NotifyDetached，
+    /// 模擬 OnAttachedToLogicalTree / OnDetachedFromLogicalTree 的觸發路徑。
+    /// 同時驗證 OnBindingContextChanged 在已附加後切換 DataObject 的重新綁定行為。
+    /// </summary>
+    public class GridControlBinderCoverageTests
+    {
+        private static FormDataObject BuildDataObjectWithDetail(string phone = "02-1234")
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_name", "Name", FieldDbType.String);
+            var detail = schema.Tables.Add("EmployeePhone", "Phones");
+            detail.Fields!.Add("phone", "Phone", FieldDbType.String);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            dataObject.DataSet.Tables["EmployeePhone"]!.Rows.Add(phone);
+            return dataObject;
+        }
+
+        private static object GetBinder(GridControl grid)
+        {
+            var field = typeof(GridControl).GetField("_binder", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return field!.GetValue(grid)!;
+        }
+
+        private static void InvokeNotifyAttached(object binder)
+        {
+            var method = binder.GetType().GetMethod("NotifyAttached");
+            Assert.NotNull(method);
+            method!.Invoke(binder, null);
+        }
+
+        private static void InvokeNotifyDetached(object binder)
+        {
+            var method = binder.GetType().GetMethod("NotifyDetached");
+            Assert.NotNull(method);
+            method!.Invoke(binder, null);
+        }
+
+        private static object? GetBinderDataObject(object binder)
+        {
+            var prop = binder.GetType().GetProperty("DataObject");
+            Assert.NotNull(prop);
+            return prop!.GetValue(binder);
+        }
+
+        [Fact]
+        [DisplayName("NotifyAttached：ambient DataObject + TableName 已設定時自動綁定網格並載入明細表")]
+        public void NotifyAttached_WithAmbientDataObjectAndTableName_BindsGridToDetailTable()
+        {
+            var dataObject = BuildDataObjectWithDetail("02-1234");
+            var grid = new GridControl();
+            grid.TableName = "EmployeePhone";
+            FormScope.SetDataObject(grid, dataObject);
+
+            InvokeNotifyAttached(GetBinder(grid));
+
+            Assert.NotNull(grid.DataTable);
+            Assert.Equal("EmployeePhone", grid.DataTable!.TableName);
+        }
+
+        [Fact]
+        [DisplayName("NotifyAttached：ambient DataObject 未設定時不綁定，DataTable 維持 null")]
+        public void NotifyAttached_NoAmbientDataObject_DoesNotBind()
+        {
+            var grid = new GridControl();
+            grid.TableName = "EmployeePhone";
+
+            InvokeNotifyAttached(GetBinder(grid));
+
+            Assert.Null(grid.DataTable);
+        }
+
+        [Fact]
+        [DisplayName("NotifyDetached：ambient 綁定後呼叫 NotifyDetached，Binder 釋放 DataObject")]
+        public void NotifyDetached_AfterAmbientBind_ClearsBinderDataObject()
+        {
+            var dataObject = BuildDataObjectWithDetail("02-1234");
+            var grid = new GridControl();
+            grid.TableName = "EmployeePhone";
+            FormScope.SetDataObject(grid, dataObject);
+            var binder = GetBinder(grid);
+            InvokeNotifyAttached(binder);
+            Assert.NotNull(grid.DataTable);
+
+            InvokeNotifyDetached(binder);
+
+            Assert.Null(GetBinderDataObject(binder));
+        }
+
+        [Fact]
+        [DisplayName("OnBindingContextChanged：附加後切換 DataObject，網格重新綁定到新 DataObject 的明細表")]
+        public void OnBindingContextChanged_AfterAttach_NewDataObject_Rebinds()
+        {
+            var dataObject1 = BuildDataObjectWithDetail("phone-1");
+            var dataObject2 = BuildDataObjectWithDetail("phone-2");
+
+            var grid = new GridControl();
+            grid.TableName = "EmployeePhone";
+            FormScope.SetDataObject(grid, dataObject1);
+            InvokeNotifyAttached(GetBinder(grid));
+            Assert.Same(dataObject1.DataSet.Tables["EmployeePhone"], grid.DataTable);
+
+            // 切換 DataObject → DataObjectProperty.Changed class handler → OnBindingContextChanged → TryAmbientBind → 重新綁定
+            FormScope.SetDataObject(grid, dataObject2);
+
+            Assert.Same(dataObject2.DataSet.Tables["EmployeePhone"], grid.DataTable);
+        }
+
+        [Fact]
+        [DisplayName("OnBindingContextChanged：未附加時（_attached=false）不觸發綁定，DataTable 維持 null")]
+        public void OnBindingContextChanged_NotAttached_IsNoOp()
+        {
+            var dataObject = BuildDataObjectWithDetail("02-1234");
+            var grid = new GridControl();
+            grid.TableName = "EmployeePhone";
+
+            // 未呼叫 NotifyAttached → _attached = false → class handler 觸發但 OnBindingContextChanged 早期回傳
+            FormScope.SetDataObject(grid, dataObject);
+
+            Assert.Null(grid.DataTable);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlCoverageTests.cs
@@ -1,0 +1,168 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Avalonia.Controls;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="GridControl"/> 覆蓋率：RefreshFromDataObject 空 DataObject 路徑、
+    /// Unbind 公開方法、RefreshRows、DeleteSelectedRow 無選取路徑、
+    /// BuildCellEditor DropDownEdit 無清單項目回退 TextBox。
+    /// </summary>
+    public class GridControlCoverageTests
+    {
+        private static FormDataObject BuildDataObjectWithDetail()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_name", "Name", FieldDbType.String);
+            var detail = schema.Tables.Add("EmployeePhone", "Phones");
+            detail.Fields!.Add("phone", "Phone", FieldDbType.String);
+            detail.Fields.Add("status", "Status", FieldDbType.String);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            return dataObject;
+        }
+
+        private static void InvokeRefreshFromDataObject(GridControl grid)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "RefreshFromDataObject", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            method!.Invoke(grid, null);
+        }
+
+        [Fact]
+        [DisplayName("RefreshFromDataObject 在無 DataObject 時為 no-op，DataTable 維持 null")]
+        public void RefreshFromDataObject_NullDataObject_IsNoOp()
+        {
+            var grid = new GridControl();
+
+            var exception = Record.Exception(() => InvokeRefreshFromDataObject(grid));
+
+            Assert.Null(exception);
+            Assert.Null(grid.DataTable);
+        }
+
+        [Fact]
+        [DisplayName("Unbind 在無綁定狀態下不拋例外")]
+        public void Unbind_WhenNotBound_DoesNotThrow()
+        {
+            var grid = new GridControl();
+
+            var exception = Record.Exception(grid.Unbind);
+
+            Assert.Null(exception);
+        }
+
+        [Fact]
+        [DisplayName("Unbind 在明細綁定後釋放，後續 DataSetReplaced 不再更新表格")]
+        public async Task Unbind_AfterExplicitBind_StopsRefreshOnDataSetReplaced()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("emp_name", "Name", FieldDbType.String);
+            var detail = schema.Tables.Add("EmployeePhone", "Phones");
+            detail.Fields!.Add("phone", "Phone", FieldDbType.String);
+
+            var refreshed = new DataSet("Employee");
+            refreshed.Tables.Add(new DataTable("Employee"));
+            var refreshedDetail = new DataTable("EmployeePhone");
+            refreshedDetail.Columns.Add("phone", typeof(string));
+            refreshedDetail.Rows.Add("new-phone");
+            refreshed.Tables.Add(refreshedDetail);
+
+            var connector = new FakeFormApiConnector
+            {
+                GetNewDataHandler = () => new Bee.Api.Core.Messages.Form.GetNewDataResponse { DataSet = refreshed },
+            };
+            var dataObject = new FormDataObject(schema, connector);
+
+            var layout = new LayoutGrid("EmployeePhone", "Phones");
+            layout.Columns!.Add(new LayoutColumn { FieldName = "phone", Caption = "Phone", Visible = true });
+
+            var grid = new GridControl();
+            grid.Bind(dataObject, layout);
+            var tableBeforeUnbind = grid.DataTable;
+
+            grid.Unbind();
+            await dataObject.NewAsync();
+
+            Assert.Same(tableBeforeUnbind, grid.DataTable);
+        }
+
+        [Fact]
+        [DisplayName("RefreshRows 在 DataTable 為 null 時清空 ItemsSource 不拋例外")]
+        public void RefreshRows_NullDataTable_ClearsItemsSourceSafely()
+        {
+            var layout = new LayoutGrid("Items", "Items");
+            layout.Columns!.Add(new LayoutColumn { FieldName = "name", Caption = "Name", Visible = true });
+            var grid = new GridControl();
+            grid.Bind(layout, null);
+
+            var exception = Record.Exception(grid.RefreshRows);
+
+            Assert.Null(exception);
+            Assert.Null(grid.InnerGrid.ItemsSource);
+        }
+
+        [Fact]
+        [DisplayName("DeleteSelectedRow 在無選取列時為 no-op，表格列數不變")]
+        public void DeleteSelectedRow_NothingSelected_IsNoOp()
+        {
+            var table = new DataTable("Items");
+            table.Columns.Add("name", typeof(string));
+            table.Rows.Add("Widget");
+            var layout = new LayoutGrid("Items", "Items");
+            layout.Columns!.Add(new LayoutColumn { FieldName = "name", Caption = "Name", Visible = true });
+
+            var grid = new GridControl();
+            grid.Bind(layout, table);
+
+            var exception = Record.Exception(grid.DeleteSelectedRow);
+
+            Assert.Null(exception);
+            Assert.Equal(1, table.Rows.Count);
+        }
+
+        [Fact]
+        [DisplayName("BuildCellEditor DropDownEdit 欄位無清單項目時回傳 TextBox")]
+        public void BuildCellEditor_DropDownEditWithoutListItems_ReturnsTextBox()
+        {
+            var dataObject = BuildDataObjectWithDetail();
+            var layout = new LayoutGrid("EmployeePhone", "Phones");
+            layout.Columns!.Add(new LayoutColumn("status", "Status", ControlType.DropDownEdit));
+
+            var grid = new GridControl();
+            grid.Bind(dataObject, layout);
+            grid.DataTable!.Rows.Add("02-1234", "active");
+            var rowView = grid.DataTable.DefaultView[0];
+
+            var method = typeof(GridControl).GetMethod(
+                "BuildCellEditor", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+
+            var result = method!.Invoke(
+                grid,
+                new object?[] { rowView, new LayoutColumn("status", "Status", ControlType.DropDownEdit) });
+
+            Assert.IsType<TextBox>(result);
+        }
+
+        private sealed class FakeFormApiConnector : Bee.Api.Client.Connectors.FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), "Employee") { }
+
+            public Func<Bee.Api.Core.Messages.Form.GetNewDataResponse>? GetNewDataHandler { get; set; }
+
+            public override Task<Bee.Api.Core.Messages.Form.GetNewDataResponse> GetNewDataAsync()
+                => Task.FromResult((GetNewDataHandler ?? (() => new Bee.Api.Core.Messages.Form.GetNewDataResponse()))());
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
@@ -1,0 +1,129 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Avalonia.Controls;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls
+{
+    /// <summary>
+    /// 補強 <see cref="FormView"/> 覆蓋率：ComputeSelectFields 的 null schema 路徑、
+    /// ListFields 組合（包含 sys_rowid 重複去重）、InitializeAsync 無輸入時的 no-op 路徑。
+    /// </summary>
+    public class FormViewCoverageTests
+    {
+        private static string InvokeComputeSelectFields(FormView view)
+        {
+            var method = typeof(FormView).GetMethod(
+                "ComputeSelectFields", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(view, null)!;
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 在 Schema 為 null 時回傳空字串")]
+        public void ComputeSelectFields_NullSchema_ReturnsEmpty()
+        {
+            var view = new TestFormView();
+
+            var result = InvokeComputeSelectFields(view);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 在 ListFields 為 null 時僅回傳 sys_rowid")]
+        public void ComputeSelectFields_NullListFields_ReturnsSysRowIdOnly()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            schema.ListFields = null;
+
+            var view = new TestFormView { Schema = schema };
+
+            var result = InvokeComputeSelectFields(view);
+
+            Assert.Equal(SysFields.RowId, result);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 在有 ListFields 時前置 sys_rowid 並包含全部欄位")]
+        public void ComputeSelectFields_WithListFields_PrependsSysRowId()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("sys_id", "ID", FieldDbType.String);
+            master.Fields.Add("sys_name", "Name", FieldDbType.String);
+            schema.ListFields = "sys_id,sys_name";
+
+            var view = new TestFormView { Schema = schema };
+
+            var result = InvokeComputeSelectFields(view);
+
+            Assert.StartsWith(SysFields.RowId, result, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("sys_id", result, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("sys_name", result, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 當 ListFields 已含 sys_rowid 時去重，不重複出現")]
+        public void ComputeSelectFields_ListFieldsContainsSysRowId_Deduplicates()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("sys_name", "Name", FieldDbType.String);
+            schema.ListFields = $"{SysFields.RowId},sys_name";
+
+            var view = new TestFormView { Schema = schema };
+
+            var result = InvokeComputeSelectFields(view);
+
+            // sys_rowid 應只出現一次
+            var fields = result.Split(',');
+            Assert.Single(fields.Where(f => string.Equals(f, SysFields.RowId, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [Fact]
+        [DisplayName("InitializeAsync 在無 ProgId 且 Schema/FormConnector 任一為 null 時為 no-op")]
+        public async Task InitializeAsync_NoProgIdAndMissingSchema_IsNoOp()
+        {
+            // Schema 為 null，FormConnector 也 null → 直接回傳
+            var view = new TestFormView();
+
+            var exception = await Record.ExceptionAsync(view.InitializeAsync);
+
+            Assert.Null(exception);
+            Assert.Null(view.DataObject);
+        }
+
+        [Fact]
+        [DisplayName("InitializeAsync 在無 ProgId 且只有 Schema 沒有 FormConnector 時為 no-op")]
+        public async Task InitializeAsync_NoProgIdSchemaSetConnectorNull_IsNoOp()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            schema.Tables!.Add("Employee", "Employee");
+            var view = new TestFormView { Schema = schema };
+            // FormConnector = null → guard: !hasProgId && (FormConnector is null) → return
+
+            var exception = await Record.ExceptionAsync(view.InitializeAsync);
+
+            Assert.Null(exception);
+            Assert.Null(view.DataObject);
+        }
+
+        private sealed class TestFormView : FormView
+        {
+            protected override SystemApiConnector? ResolveSystemConnector() => null;
+
+            protected override FormApiConnector ResolveFormConnector(string progId)
+                => throw new InvalidOperationException("Should not be reached in coverage tests.");
+
+            protected override Guid ResolveAccessToken() => Guid.Empty;
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewCoverageTests.cs
@@ -40,7 +40,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
             var schema = new FormSchema("Employee", "Employee");
             var master = schema.Tables!.Add("Employee", "Employee");
             master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
-            schema.ListFields = null;
+            schema.ListFields = null!;
 
             var view = new TestFormView { Schema = schema };
 
@@ -85,7 +85,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
 
             // sys_rowid 應只出現一次
             var fields = result.Split(',');
-            Assert.Single(fields.Where(f => string.Equals(f, SysFields.RowId, StringComparison.OrdinalIgnoreCase)));
+            Assert.Single(fields, f => string.Equals(f, SysFields.RowId, StringComparison.OrdinalIgnoreCase));
         }
 
         [Fact]


### PR DESCRIPTION
## 自動覆蓋率補強 — 5 個目標檔案

由 `bee-coverage-fix` 排程 routine 自動產生（2026-06-14）。

### 目標檔案

| # | 來源檔案 | 新增測試檔 | 補強路徑 |
|---|---------|-----------|---------|
| 1 | `src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs` | `GridControlCoverageTests.cs` | `RefreshFromDataObject` null 路徑、`Unbind`、`RefreshRows` null DataTable、`DeleteSelectedRow` 無選取、`BuildCellEditor` DropDownEdit 回退 TextBox |
| 2 | `src/Bee.UI.Avalonia/Controls/FormView.cs` | `FormViewCoverageTests.cs` | `ComputeSelectFields` null schema / null ListFields / sys_rowid 去重；`InitializeAsync` 早期回傳 |
| 3 | `src/Bee.UI.Avalonia/Controls/Editors/ButtonEdit.cs` | `ButtonEditCoverageTests.cs` | `RefreshFromSource` lookup 無 DisplayFields；`OnButtonClickAsync` View 模式提早回傳 |
| 4 | `src/Bee.UI.Avalonia/Controls/Editors/FieldEditorBinder.cs` | `FieldEditorBinderCoverageTests.cs` | `NotifyAttached` / `NotifyDetached` / `TryAmbientBind` / `BindCore(fromAmbient:true)` / `OnBindingContextChanged` |
| 5 | `src/Bee.UI.Avalonia/Controls/Editors/GridControlBinder.cs` | `GridControlBinderCoverageTests.cs` | `NotifyAttached` / `NotifyDetached` / `TryAmbientBind` / `BindCore(fromAmbient:true)` / `OnBindingContextChanged` |

### 技術說明

- `FieldEditorBinder` 與 `GridControlBinder` 均為 `internal sealed class`，測試透過反射存取 `_binder` 欄位並呼叫其 `public` 方法（`NotifyAttached` / `NotifyDetached`）
- `FormScope.SetDataObject` 觸發 class handler → `OnBindingContextChanged` 路徑
- 所有新增測試均通過 IDE0005 / S2699 / CA1861 自檢

labels: coverage-fix, auto-merge

---
_Generated by [Claude Code](https://claude.ai/code/session_012h28mSrUVsbR4bhvsse7sK)_