### PR TITLE
[AutoFix] Coverage Fix (5 files) 2026-06-14 08:30

### DIFF
--- a/tests/Bee.UI.Avalonia.UnitTests/AvaloniaRegistryWarmup.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/AvaloniaRegistryWarmup.cs
@@ -45,6 +45,11 @@ namespace Bee.UI.Avalonia.UnitTests
             _ = new CheckEdit();
             _ = new DynamicForm();
             _ = new RowEditPanel();
+            // FormView builds a StackPanel with 6 children in its constructor, exercising
+            // AvaloniaPropertyDictionaryPool.Get/Return via SetInheritanceParent on each
+            // child. Without a single-threaded warmup, parallel test classes that all
+            // construct FormView (or add children to panels) can exhaust the pool.
+            _ = new FormView();
         }
     }
 }

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditPropertyTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/ButtonEditPropertyTests.cs
@@ -1,0 +1,112 @@
+using System.ComponentModel;
+using System.Reflection;
+using Avalonia.Controls;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="ButtonEdit"/> 覆蓋率：非 lookup 欄位的 SetControlState（呼叫 base），
+    /// OnPropertyChanged 在 IsReadOnly 變更時同步按鈕啟用狀態，
+    /// 版面層級 DisplayFields 覆寫 ResolveDisplayFieldNames 路徑。
+    /// </summary>
+    public class ButtonEditPropertyTests
+    {
+        private static Button GetButton(ButtonEdit editor)
+        {
+            var field = typeof(ButtonEdit).GetField("_button", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return (Button)field!.GetValue(editor)!;
+        }
+
+        private static FormSchema BuildOrderSchema()
+        {
+            var schema = new FormSchema("Order", "Order");
+            var table = schema.Tables!.Add("Order", "Order");
+            table.Fields!.Add(new FormField("order_id", "Order ID", FieldDbType.String));
+            var customerField = new FormField("customer_rowid", "Customer", FieldDbType.Guid)
+            {
+                RelationProgId = "Customer",
+            };
+            customerField.RelationFieldMappings!.Add("sys_id", "ref_customer_id");
+            customerField.RelationFieldMappings!.Add("sys_name", "ref_customer_name");
+            table.Fields!.Add(customerField);
+            table.Fields!.Add(new FormField("ref_customer_id", "Customer Code", FieldDbType.String,
+                Bee.Definition.Database.FieldType.RelationField));
+            table.Fields!.Add(new FormField("ref_customer_name", "Customer Name", FieldDbType.String,
+                Bee.Definition.Database.FieldType.RelationField));
+            return schema;
+        }
+
+        [Fact]
+        [DisplayName("非 lookup 欄位 SetControlState Edit 模式：IsReadOnly=false，按鈕啟用")]
+        public void SetControlState_NonLookup_EditMode_IsReadOnlyFalseButtonEnabled()
+        {
+            var schema = BuildOrderSchema();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, "order_id");
+            Assert.False(editor.HasLookup);
+
+            editor.SetControlState(SingleFormMode.Edit);
+
+            Assert.False(editor.IsReadOnly);
+            Assert.True(GetButton(editor).IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("非 lookup 欄位 SetControlState View 模式：IsReadOnly=true，按鈕停用")]
+        public void SetControlState_NonLookup_ViewMode_IsReadOnlyTrueButtonDisabled()
+        {
+            var schema = BuildOrderSchema();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, "order_id");
+            editor.SetControlState(SingleFormMode.Edit);
+
+            editor.SetControlState(SingleFormMode.View);
+
+            Assert.True(editor.IsReadOnly);
+            Assert.False(GetButton(editor).IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("非 lookup 欄位直接設定 IsReadOnly 後按鈕啟用狀態同步（OnPropertyChanged 路徑）")]
+        public void IsReadOnly_SetTrue_NonLookup_ButtonBecomesDisabled()
+        {
+            var editor = new ButtonEdit();
+            editor.IsReadOnly = false;
+
+            editor.IsReadOnly = true;
+
+            Assert.False(GetButton(editor).IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("版面層級 DisplayFields 覆寫時 Text 只顯示版面指定的欄位値")]
+        public void RefreshFromSource_LayoutDisplayFieldsOverride_ShowsOnlyLayoutFields()
+        {
+            var schema = BuildOrderSchema();
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            dataObject.SetField("ref_customer_id", "C001");
+            dataObject.SetField("ref_customer_name", "Alice");
+
+            var layoutField = new LayoutField
+            {
+                FieldName = "customer_rowid",
+                DisplayFields = "ref_customer_name",
+            };
+            var editor = new ButtonEdit();
+            editor.Bind(dataObject, layoutField);
+
+            Assert.Equal("Alice", editor.Text);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DateEditCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DateEditCoverageTests.cs
@@ -1,0 +1,155 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Bee.Base.Data;
+using Bee.Definition.Forms;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+using Bee.UI.Avalonia.DataObjects;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="DateEdit"/> 覆蓋率：ParseToOffset null/無效路徑、
+    /// FieldValue setter 各型別分支、Bind(FormDataObject, LayoutFieldBase, DataRow) 明細列綁定。
+    /// </summary>
+    public class DateEditCoverageTests
+    {
+        private static DateTimeOffset? InvokeParseToOffset(string? raw)
+        {
+            var method = typeof(DateEdit).GetMethod(
+                "ParseToOffset", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (DateTimeOffset?)method!.Invoke(null, new object?[] { raw });
+        }
+
+        private static FormDataObject BuildDataObject()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            var master = schema.Tables!.Add("Employee", "Employee");
+            master.Fields!.Add("hire_date", "Hire Date", FieldDbType.Date);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            return dataObject;
+        }
+
+        private static FormDataObject BuildDataObjectWithDetail()
+        {
+            var schema = new FormSchema("Employee", "Employee");
+            schema.Tables!.Add("Employee", "Employee");
+            var detail = schema.Tables.Add("EmployeePhone", "Phones");
+            detail.Fields!.Add("call_date", "Call Date", FieldDbType.Date);
+            var dataObject = new FormDataObject(schema);
+            dataObject.InitializeNewMaster();
+            return dataObject;
+        }
+
+        [Fact]
+        [DisplayName("ParseToOffset：null 字串回傳 null")]
+        public void ParseToOffset_NullString_ReturnsNull()
+        {
+            var result = InvokeParseToOffset(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("ParseToOffset：無效日期字串回傳 null")]
+        public void ParseToOffset_InvalidDateString_ReturnsNull()
+        {
+            var result = InvokeParseToOffset("not-a-date");
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        [DisplayName("ParseToOffset：合法日期字串回傳對應 DateTimeOffset（偏移 Zero、Kind Unspecified）")]
+        public void ParseToOffset_ValidDateString_ReturnsDateTimeOffset()
+        {
+            var result = InvokeParseToOffset("2026-06-01");
+
+            Assert.NotNull(result);
+            Assert.Equal(2026, result!.Value.Year);
+            Assert.Equal(6, result.Value.Month);
+            Assert.Equal(1, result.Value.Day);
+            Assert.Equal(TimeSpan.Zero, result.Value.Offset);
+        }
+
+        [Fact]
+        [DisplayName("FieldValue setter：null 値將 SelectedDate 設為 null")]
+        public void FieldValue_SetNull_SetsSelectedDateNull()
+        {
+            var dataObject = BuildDataObject();
+            dataObject.SetField("hire_date", "2026-01-15");
+            var editor = new DateEdit();
+            editor.Bind(dataObject, "hire_date");
+            Assert.NotNull(editor.SelectedDate);
+
+            editor.FieldValue = null;
+
+            Assert.Null(editor.SelectedDate);
+        }
+
+        [Fact]
+        [DisplayName("FieldValue setter：DateTimeOffset 値直接指派給 SelectedDate")]
+        public void FieldValue_SetDateTimeOffset_SetsSelectedDate()
+        {
+            var editor = new DateEdit();
+            var dto = new DateTimeOffset(new DateTime(2026, 3, 10, 0, 0, 0, DateTimeKind.Unspecified), TimeSpan.Zero);
+
+            editor.FieldValue = dto;
+
+            Assert.Equal(dto, editor.SelectedDate);
+        }
+
+        [Fact]
+        [DisplayName("FieldValue setter：DateTime 値轉換為 Kind Unspecified 偏移 Zero 的 DateTimeOffset")]
+        public void FieldValue_SetDateTime_SetsDateOnlyWithUnspecifiedKind()
+        {
+            var editor = new DateEdit();
+            var dt = new DateTime(2026, 5, 20, 10, 30, 0, DateTimeKind.Local);
+
+            editor.FieldValue = dt;
+
+            Assert.NotNull(editor.SelectedDate);
+            Assert.Equal(2026, editor.SelectedDate!.Value.Year);
+            Assert.Equal(5, editor.SelectedDate.Value.Month);
+            Assert.Equal(20, editor.SelectedDate.Value.Day);
+            Assert.Equal(TimeSpan.Zero, editor.SelectedDate.Value.Offset);
+        }
+
+        [Fact]
+        [DisplayName("FieldValue setter：字串値透過 ParseToOffset 解析後設定 SelectedDate")]
+        public void FieldValue_SetStringDate_ParsesAndSetsSelectedDate()
+        {
+            var editor = new DateEdit();
+
+            editor.FieldValue = "2026-08-15";
+
+            Assert.NotNull(editor.SelectedDate);
+            Assert.Equal(2026, editor.SelectedDate!.Value.Year);
+            Assert.Equal(8, editor.SelectedDate.Value.Month);
+            Assert.Equal(15, editor.SelectedDate.Value.Day);
+        }
+
+        [Fact]
+        [DisplayName("Bind(FormDataObject, LayoutFieldBase, DataRow) 明細列綁定後讀取列値")]
+        public void Bind_WithDataRow_LoadsValueFromRow()
+        {
+            var dataObject = BuildDataObjectWithDetail();
+            var detailTable = dataObject.DataSet.Tables["EmployeePhone"]!;
+            var row = detailTable.NewRow();
+            row["call_date"] = "2026-04-10";
+            detailTable.Rows.Add(row);
+
+            var field = new LayoutField { FieldName = "call_date" };
+            var editor = new DateEdit();
+            editor.Bind(dataObject, field, row);
+
+            Assert.NotNull(editor.SelectedDate);
+            Assert.Equal(2026, editor.SelectedDate!.Value.Year);
+            Assert.Equal(4, editor.SelectedDate.Value.Month);
+            Assert.Equal(10, editor.SelectedDate.Value.Day);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DateEditCoverageTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/DateEditCoverageTests.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Data;
 using System.Reflection;
 using Bee.Base.Data;
 using Bee.Definition.Forms;

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlFormatTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/Editors/GridControlFormatTests.cs
@@ -1,0 +1,343 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Avalonia.Controls;
+using Bee.Definition;
+using Bee.Definition.Layouts;
+using Bee.UI.Avalonia.Controls.Editors;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls.Editors
+{
+    /// <summary>
+    /// 補強 <see cref="GridControl"/> 覆蓋率：FormatCell 各資料型別路徑、
+    /// TryConvertCellValue 成功與例外路徑、TryGetRowId 各欄位狀態、
+    /// SetControlState 依版面模式切換 AllowEdit、AddRow、
+    /// BuildCellEditor CheckEdit/DateEdit、BuildInteractiveCell 唯讀路徑。
+    /// </summary>
+    public class GridControlFormatTests
+    {
+        private static string InvokeFormatCell(
+            DataRowView? rowView, string fieldName, string displayFormat, string numberFormat)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "FormatCell", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(null,
+                new object?[] { rowView, fieldName, displayFormat, numberFormat })!;
+        }
+
+        private static bool InvokeTryConvertCellValue(string? value, DataColumn column)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "TryConvertCellValue", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var args = new object?[] { value, column, null };
+            return (bool)method!.Invoke(null, args)!;
+        }
+
+        private static bool InvokeTryGetRowId(DataRow row, out Guid rowId)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "TryGetRowId", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+            var args = new object?[] { row, Guid.Empty };
+            var result = (bool)method!.Invoke(null, args)!;
+            rowId = (Guid)args[1]!;
+            return result;
+        }
+
+        private static Control InvokeBuildCellEditor(GridControl grid, DataRowView? rowView, LayoutColumn column)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "BuildCellEditor", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (Control)method!.Invoke(grid, new object?[] { rowView, column })!;
+        }
+
+        private static Control InvokeBuildInteractiveCell(GridControl grid, DataRowView? rowView, LayoutColumn column)
+        {
+            var method = typeof(GridControl).GetMethod(
+                "BuildInteractiveCell", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (Control)method!.Invoke(grid, new object?[] { rowView, column })!;
+        }
+
+        private static (GridControl grid, DataTable table) BindSimpleGrid(string colName, Type colType)
+        {
+            var table = new DataTable("T");
+            table.Columns.Add(colName, colType);
+            var layout = new LayoutGrid("T", "T");
+            layout.Columns!.Add(new LayoutColumn { FieldName = colName, Caption = colName, Visible = true });
+            var grid = new GridControl();
+            grid.Bind(layout, table);
+            return (grid, table);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell：rowView 為 null 時回傳空字串")]
+        public void FormatCell_NullRowView_ReturnsEmptyString()
+        {
+            var result = InvokeFormatCell(null, "col", string.Empty, string.Empty);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell：欄位不存在時回傳空字串")]
+        public void FormatCell_MissingColumn_ReturnsEmptyString()
+        {
+            var table = new DataTable("T");
+            table.Columns.Add("name", typeof(string));
+            table.Rows.Add("Alice");
+
+            var result = InvokeFormatCell(table.DefaultView[0], "nonexistent", string.Empty, string.Empty);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell：值為 DBNull 時回傳空字串")]
+        public void FormatCell_DBNullValue_ReturnsEmptyString()
+        {
+            var table = new DataTable("T");
+            table.Columns.Add("col", typeof(string));
+            table.Rows.Add(DBNull.Value);
+
+            var result = InvokeFormatCell(table.DefaultView[0], "col", string.Empty, string.Empty);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell：DateTime 含時間部分時格式化為 yyyy-MM-dd HH:mm:ss")]
+        public void FormatCell_DateTimeWithTime_FormatsWithTimePart()
+        {
+            var dt = new DateTime(2026, 1, 15, 14, 30, 0, DateTimeKind.Unspecified);
+            var table = new DataTable("T");
+            table.Columns.Add("ts", typeof(DateTime));
+            table.Rows.Add(dt);
+
+            var result = InvokeFormatCell(table.DefaultView[0], "ts", string.Empty, string.Empty);
+
+            Assert.Equal("2026-01-15 14:30:00", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell：DateTime 無時間部分時格式化為 yyyy-MM-dd")]
+        public void FormatCell_DateTimeWithNoTime_FormatsDateOnly()
+        {
+            var dt = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Unspecified);
+            var table = new DataTable("T");
+            table.Columns.Add("d", typeof(DateTime));
+            table.Rows.Add(dt);
+
+            var result = InvokeFormatCell(table.DefaultView[0], "d", string.Empty, string.Empty);
+
+            Assert.Equal("2026-06-01", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell：指定 displayFormat 時套用顯示格式")]
+        public void FormatCell_WithDisplayFormat_AppliesDisplayFormat()
+        {
+            var table = new DataTable("T");
+            table.Columns.Add("amount", typeof(decimal));
+            table.Rows.Add(100.5m);
+
+            var result = InvokeFormatCell(table.DefaultView[0], "amount", "F2", string.Empty);
+
+            Assert.Equal("100.50", result);
+        }
+
+        [Fact]
+        [DisplayName("FormatCell：指定 numberFormat 時套用數字格式")]
+        public void FormatCell_WithNumberFormat_AppliesNumberFormat()
+        {
+            var table = new DataTable("T");
+            table.Columns.Add("qty", typeof(int));
+            table.Rows.Add(42);
+
+            var result = InvokeFormatCell(table.DefaultView[0], "qty", string.Empty, "D5");
+
+            Assert.Equal("00042", result);
+        }
+
+        [Fact]
+        [DisplayName("TryConvertCellValue：合法整數字串轉換成功回傳 true")]
+        public void TryConvertCellValue_ValidIntString_ReturnsTrue()
+        {
+            var column = new DataColumn("qty", typeof(int));
+
+            var ok = InvokeTryConvertCellValue("5", column);
+
+            Assert.True(ok);
+        }
+
+        [Fact]
+        [DisplayName("TryConvertCellValue：無法解析字串時回傳 false，不拋例外")]
+        public void TryConvertCellValue_InvalidString_ReturnsFalse()
+        {
+            var column = new DataColumn("qty", typeof(int));
+
+            var ok = InvokeTryConvertCellValue("not-a-number", column);
+
+            Assert.False(ok);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId：無 sys_rowid 欄位時回傳 false")]
+        public void TryGetRowId_NoRowIdColumn_ReturnsFalse()
+        {
+            var table = new DataTable("T");
+            table.Columns.Add("name", typeof(string));
+            table.Rows.Add("Alice");
+
+            var result = InvokeTryGetRowId(table.Rows[0], out _);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId：sys_rowid 為 DBNull 時回傳 false")]
+        public void TryGetRowId_DBNullValue_ReturnsFalse()
+        {
+            var table = new DataTable("T");
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            table.Rows.Add(DBNull.Value);
+
+            var result = InvokeTryGetRowId(table.Rows[0], out _);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId：sys_rowid 為 Guid 類型時回傳 true 並輸出該 Guid")]
+        public void TryGetRowId_GuidValue_ReturnsTrueWithCorrectGuid()
+        {
+            var expected = Guid.NewGuid();
+            var table = new DataTable("T");
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            table.Rows.Add(expected);
+
+            var result = InvokeTryGetRowId(table.Rows[0], out var rowId);
+
+            Assert.True(result);
+            Assert.Equal(expected, rowId);
+        }
+
+        [Fact]
+        [DisplayName("TryGetRowId：sys_rowid 為可解析字串時回傳 true 並輸出對應 Guid")]
+        public void TryGetRowId_StringGuidValue_ReturnsTrueWithCorrectGuid()
+        {
+            var expected = Guid.NewGuid();
+            var table = new DataTable("T");
+            table.Columns.Add(SysFields.RowId, typeof(string));
+            table.Rows.Add(expected.ToString());
+
+            var result = InvokeTryGetRowId(table.Rows[0], out var rowId);
+
+            Assert.True(result);
+            Assert.Equal(expected, rowId);
+        }
+
+        [Fact]
+        [DisplayName("SetControlState View 模式：AllowEdit 設為 false")]
+        public void SetControlState_ViewMode_SetsAllowEditFalse()
+        {
+            var layout = new LayoutGrid("T", "T");
+            layout.AllowEditModes = FormEditModes.All;
+            layout.Columns!.Add(new LayoutColumn { FieldName = "name", Caption = "Name", Visible = true });
+            var grid = new GridControl();
+            grid.Bind(layout, null);
+            grid.AllowEdit = true;
+
+            grid.SetControlState(SingleFormMode.View);
+
+            Assert.False(grid.AllowEdit);
+        }
+
+        [Fact]
+        [DisplayName("SetControlState Edit 模式且版面允許 All 編輯模式：AllowEdit 設為 true")]
+        public void SetControlState_EditModeWithAllowingLayout_SetsAllowEditTrue()
+        {
+            var layout = new LayoutGrid("T", "T");
+            layout.AllowEditModes = FormEditModes.All;
+            layout.Columns!.Add(new LayoutColumn { FieldName = "name", Caption = "Name", Visible = true });
+            var grid = new GridControl();
+            grid.Bind(layout, null);
+
+            grid.SetControlState(SingleFormMode.Edit);
+
+            Assert.True(grid.AllowEdit);
+        }
+
+        [Fact]
+        [DisplayName("AddRow 有 DataTable 時新增一筆列")]
+        public void AddRow_WithNonNullableColumn_AddsRow()
+        {
+            var (grid, table) = BindSimpleGrid("name", typeof(string));
+            table.Columns["name"]!.AllowDBNull = false;
+
+            grid.AddRow();
+
+            Assert.Equal(1, table.Rows.Count);
+        }
+
+        [Fact]
+        [DisplayName("BuildCellEditor CheckEdit 欄位回傳 CheckBox")]
+        public void BuildCellEditor_CheckEdit_ReturnsCheckBox()
+        {
+            var (grid, table) = BindSimpleGrid("active", typeof(bool));
+            table.Rows.Add(true);
+            var rowView = table.DefaultView[0];
+
+            var result = InvokeBuildCellEditor(grid, rowView,
+                new LayoutColumn("active", "Active", ControlType.CheckEdit));
+
+            Assert.IsType<CheckBox>(result);
+        }
+
+        [Fact]
+        [DisplayName("BuildCellEditor DateEdit 欄位回傳 DatePicker")]
+        public void BuildCellEditor_DateEdit_ReturnsDatePicker()
+        {
+            var (grid, table) = BindSimpleGrid("hire_date", typeof(DateTime));
+            table.Rows.Add(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Unspecified));
+            var rowView = table.DefaultView[0];
+
+            var result = InvokeBuildCellEditor(grid, rowView,
+                new LayoutColumn("hire_date", "Date", ControlType.DateEdit));
+
+            Assert.IsType<DatePicker>(result);
+        }
+
+        [Fact]
+        [DisplayName("BuildInteractiveCell CheckEdit 唯讀時回傳已停用的 CheckBox")]
+        public void BuildInteractiveCell_CheckEditReadOnly_ReturnsDisabledCheckBox()
+        {
+            var (grid, table) = BindSimpleGrid("active", typeof(bool));
+            table.Rows.Add(false);
+            var rowView = table.DefaultView[0];
+
+            var result = InvokeBuildInteractiveCell(grid, rowView,
+                new LayoutColumn("active", "Active", ControlType.CheckEdit));
+
+            var checkBox = Assert.IsType<CheckBox>(result);
+            Assert.False(checkBox.IsEnabled);
+        }
+
+        [Fact]
+        [DisplayName("BuildInteractiveCell 非 CheckEdit 唯讀時回傳 TextBlock")]
+        public void BuildInteractiveCell_DateEditReadOnly_ReturnsTextBlock()
+        {
+            var (grid, table) = BindSimpleGrid("hire_date", typeof(DateTime));
+            table.Rows.Add(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Unspecified));
+            var rowView = table.DefaultView[0];
+
+            var result = InvokeBuildInteractiveCell(grid, rowView,
+                new LayoutColumn("hire_date", "Date", ControlType.DateEdit));
+
+            Assert.IsType<TextBlock>(result);
+        }
+    }
+}

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewErrorTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewErrorTests.cs
@@ -56,9 +56,10 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
             {
                 GetListHandler = _ => throw new InvalidOperationException("list load failed"),
             };
-            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            var view = new TestFormView { Schema = BuildEmployeeSchema() };
             Exception? captured = null;
             view.ErrorOccurred += (_, ex) => captured = ex;
+            view.FormConnector = connector;
 
             var exception = await Record.ExceptionAsync(view.InitializeAsync);
 

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewErrorTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewErrorTests.cs
@@ -49,7 +49,7 @@ namespace Bee.UI.Avalonia.UnitTests.Controls
         }
 
         [Fact]
-        [DisplayName("補強 <see cref=\"FormView\"/> 覆蓋率：ReloadListAsync 失敗路徑、第二次 InitializeAsync 為 no-op、_emptyListLabel 可見性。")]
+        [DisplayName("ReloadListAsync 拋例外時觸發 ErrorOccurred 並不崩潰")]
         public async Task ReloadListAsync_GetListThrows_FiresErrorOccurred()
         {
             var connector = new FakeFormApiConnector

--- a/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewErrorTests.cs
+++ b/tests/Bee.UI.Avalonia.UnitTests/Controls/FormViewErrorTests.cs
@@ -1,0 +1,149 @@
+using System.ComponentModel;
+using System.Data;
+using System.Reflection;
+using Avalonia.Controls;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Avalonia.Controls;
+
+namespace Bee.UI.Avalonia.UnitTests.Controls
+{
+    /// <summary>
+    /// 補強 <see cref="FormView"/> 覆蓋率：ReloadListAsync 失敗路徑、
+    /// 第二次 InitializeAsync 為 no-op、_emptyListLabel 可見性。
+    /// </summary>
+    public class FormViewErrorTests
+    {
+        private const string TestProgId = "Employee";
+
+        private static FormSchema BuildEmployeeSchema()
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("sys_id", "ID", FieldDbType.String);
+            master.Fields.Add("sys_name", "Name", FieldDbType.String);
+            schema.ListFields = "sys_id,sys_name";
+            return schema;
+        }
+
+        private static DataTable BuildEmployeeListTable(Guid rowId, string name)
+        {
+            var table = new DataTable(TestProgId);
+            table.Columns.Add(SysFields.RowId, typeof(Guid));
+            table.Columns.Add("sys_id", typeof(string));
+            table.Columns.Add("sys_name", typeof(string));
+            table.Rows.Add(rowId, "E001", name);
+            return table;
+        }
+
+        private static TextBlock GetEmptyListLabel(FormView view)
+        {
+            var field = typeof(FormView).GetField(
+                "_emptyListLabel", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            return (TextBlock)field!.GetValue(view)!;
+        }
+
+        [Fact]
+        [DisplayName("補強 <see cref=\"FormView\"/> 覆蓋率：ReloadListAsync 失敗路徑、第二次 InitializeAsync 為 no-op、_emptyListLabel 可見性。")]
+        public async Task ReloadListAsync_GetListThrows_FiresErrorOccurred()
+        {
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => throw new InvalidOperationException("list load failed"),
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            Exception? captured = null;
+            view.ErrorOccurred += (_, ex) => captured = ex;
+
+            var exception = await Record.ExceptionAsync(view.InitializeAsync);
+
+            Assert.Null(exception);
+            Assert.NotNull(captured);
+            Assert.Equal("list load failed", captured!.Message);
+        }
+
+        [Fact]
+        [DisplayName("第二次呼叫 InitializeAsync 不重新建立 DataObject（no-op）")]
+        public async Task InitializeAsync_AlreadyInitialized_IsNoOp()
+        {
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse
+                {
+                    Table = BuildEmployeeListTable(Guid.NewGuid(), "Alice"),
+                },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+            var firstDataObject = view.DataObject;
+            Assert.NotNull(firstDataObject);
+
+            await view.InitializeAsync();
+
+            Assert.Same(firstDataObject, view.DataObject);
+        }
+
+        [Fact]
+        [DisplayName("列表為空時 _emptyListLabel 顯示、_grid 隱藏")]
+        public async Task ReloadListAsync_EmptyTable_ShowsEmptyLabel()
+        {
+            var emptyTable = new DataTable(TestProgId);
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse { Table = emptyTable },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+
+            var emptyLabel = GetEmptyListLabel(view);
+            Assert.True(emptyLabel.IsVisible);
+        }
+
+        [Fact]
+        [DisplayName("列表有資料時 _emptyListLabel 隱藏")]
+        public async Task ReloadListAsync_NonEmptyTable_HidesEmptyLabel()
+        {
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = _ => new GetListResponse
+                {
+                    Table = BuildEmployeeListTable(Guid.NewGuid(), "Bob"),
+                },
+            };
+            var view = new TestFormView { Schema = BuildEmployeeSchema(), FormConnector = connector };
+            await view.InitializeAsync();
+
+            var emptyLabel = GetEmptyListLabel(view);
+            Assert.False(emptyLabel.IsVisible);
+        }
+
+        private sealed class TestFormView : FormView
+        {
+            protected override SystemApiConnector? ResolveSystemConnector() => null;
+
+            protected override FormApiConnector ResolveFormConnector(string progId)
+                => throw new InvalidOperationException("ClientInfo fallback must not be reached.");
+
+            protected override Guid ResolveAccessToken() => Guid.Empty;
+        }
+
+        private sealed class FakeFormApiConnector : FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), TestProgId) { }
+
+            public Func<string, GetListResponse>? GetListHandler { get; set; }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                Bee.Definition.Filters.FilterNode? filter = null,
+                Bee.Definition.Sorting.SortFieldCollection? sortFields = null,
+                Bee.Definition.Paging.PagingOptions? paging = null)
+                => Task.FromResult((GetListHandler ?? (_ => new GetListResponse()))(selectFields));
+        }
+    }
+}

--- a/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
@@ -93,13 +93,10 @@ namespace Bee.UI.Maui.UnitTests.Controls
             {
                 GetListHandler = () => throw new InvalidOperationException("list load failed"),
             };
-            var page = new FormPage
-            {
-                Schema = BuildEmployeeSchema("sys_id"),
-                FormConnector = connector,
-            };
+            var page = new FormPage { Schema = BuildEmployeeSchema("sys_id") };
             Exception? captured = null;
             page.ErrorOccurred += (_, ex) => captured = ex;
+            page.FormConnector = connector;
 
             var exception = await Record.ExceptionAsync(page.InitializeAsync);
 

--- a/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
+++ b/tests/Bee.UI.Maui.UnitTests/Controls/FormPageCoverageTests.cs
@@ -1,0 +1,147 @@
+using System.ComponentModel;
+using System.Reflection;
+using Bee.Api.Client.Connectors;
+using Bee.Api.Core.Messages.Form;
+using Bee.Base.Data;
+using Bee.Definition;
+using Bee.Definition.Forms;
+using Bee.UI.Maui.Controls;
+
+namespace Bee.UI.Maui.UnitTests.Controls
+{
+    /// <summary>
+    /// 補強 <see cref="FormPage"/> 覆蓋率：ComputeSelectFields 各路徑、
+    /// ReloadListAsync 失敗觸發 ErrorOccurred、第二次 InitializeAsync 為 no-op。
+    /// </summary>
+    [Collection("ClientInfo")]
+    public class FormPageCoverageTests
+    {
+        private const string TestProgId = "Employee";
+
+        private static FormSchema BuildEmployeeSchema(string? listFields = null)
+        {
+            var schema = new FormSchema(TestProgId, TestProgId);
+            var master = schema.Tables!.Add(TestProgId, TestProgId);
+            master.Fields!.Add(SysFields.RowId, "Row Id", FieldDbType.Guid);
+            master.Fields.Add("sys_id", "Employee ID", FieldDbType.String);
+            master.Fields.Add("sys_name", "Name", FieldDbType.String);
+            schema.ListFields = listFields!;
+            return schema;
+        }
+
+        private static string InvokeComputeSelectFields(FormPage page)
+        {
+            var method = typeof(FormPage).GetMethod(
+                "ComputeSelectFields", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            return (string)method!.Invoke(page, null)!;
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 在 Schema 為 null 時回傳空字串")]
+        public void ComputeSelectFields_NullSchema_ReturnsEmpty()
+        {
+            var page = new FormPage();
+
+            var result = InvokeComputeSelectFields(page);
+
+            Assert.Equal(string.Empty, result);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 在 ListFields 為 null 時僅回傳 sys_rowid")]
+        public void ComputeSelectFields_NullListFields_ReturnsSysRowIdOnly()
+        {
+            var schema = BuildEmployeeSchema(null);
+            var page = new FormPage { Schema = schema };
+
+            var result = InvokeComputeSelectFields(page);
+
+            Assert.Equal(SysFields.RowId, result);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 有 ListFields 時前置 sys_rowid 並包含全部欄位")]
+        public void ComputeSelectFields_WithListFields_PrependsSysRowId()
+        {
+            var schema = BuildEmployeeSchema("sys_id,sys_name");
+            var page = new FormPage { Schema = schema };
+
+            var result = InvokeComputeSelectFields(page);
+
+            Assert.Equal("sys_rowid,sys_id,sys_name", result);
+        }
+
+        [Fact]
+        [DisplayName("ComputeSelectFields 當 ListFields 已含 sys_rowid 時去重，不重複出現")]
+        public void ComputeSelectFields_ListFieldsContainsSysRowId_Deduplicates()
+        {
+            var schema = BuildEmployeeSchema($"{SysFields.RowId},sys_name");
+            var page = new FormPage { Schema = schema };
+
+            var result = InvokeComputeSelectFields(page);
+
+            var fields = result.Split(',');
+            Assert.Single(fields, f => string.Equals(f, SysFields.RowId, StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        [DisplayName("ReloadListAsync 拋例外時觸發 ErrorOccurred 且不崩潰")]
+        public async Task ReloadListAsync_GetListThrows_FiresErrorOccurred()
+        {
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = () => throw new InvalidOperationException("list load failed"),
+            };
+            var page = new FormPage
+            {
+                Schema = BuildEmployeeSchema("sys_id"),
+                FormConnector = connector,
+            };
+            Exception? captured = null;
+            page.ErrorOccurred += (_, ex) => captured = ex;
+
+            var exception = await Record.ExceptionAsync(page.InitializeAsync);
+
+            Assert.Null(exception);
+            Assert.NotNull(captured);
+            Assert.Equal("list load failed", captured!.Message);
+        }
+
+        [Fact]
+        [DisplayName("第二次呼叫 InitializeAsync 不重新建立 DataObject（no-op）")]
+        public async Task InitializeAsync_AlreadyInitialized_IsNoOp()
+        {
+            var connector = new FakeFormApiConnector
+            {
+                GetListHandler = () => new GetListResponse(),
+            };
+            var page = new FormPage
+            {
+                Schema = BuildEmployeeSchema("sys_id"),
+                FormConnector = connector,
+            };
+            await page.InitializeAsync();
+            var firstDataObject = page.DataObject;
+            Assert.NotNull(firstDataObject);
+
+            await page.InitializeAsync();
+
+            Assert.Same(firstDataObject, page.DataObject);
+        }
+
+        private sealed class FakeFormApiConnector : FormApiConnector
+        {
+            public FakeFormApiConnector() : base(Guid.NewGuid(), TestProgId) { }
+
+            public Func<GetListResponse>? GetListHandler { get; set; }
+
+            public override Task<GetListResponse> GetListAsync(
+                string selectFields = "",
+                Bee.Definition.Filters.FilterNode? filter = null,
+                Bee.Definition.Sorting.SortFieldCollection? sortFields = null,
+                Bee.Definition.Paging.PagingOptions? paging = null)
+                => Task.FromResult((GetListHandler ?? (() => new GetListResponse()))());
+        }
+    }
+}


### PR DESCRIPTION
## 覆蓋率補強摘要

本 PR 由 `bee-coverage-fix` 自動產生，補強 SonarCloud 回報覆蓋率不足的 5 個檔案。

## 目標檔案（依未覆蓋行數降序）

| 檔案 | 未覆蓋行數 | 新增測試檔 | 測試數 |
|------|-----------|-----------|--------|
| `src/Bee.UI.Avalonia/Controls/Editors/GridControl.cs` | 114 | `GridControlFormatTests.cs` | 18 |
| `src/Bee.UI.Avalonia/Controls/FormView.cs` | 28 | `FormViewErrorTests.cs` | 4 |
| `src/Bee.UI.Avalonia/Controls/Editors/DateEdit.cs` | 20 | `DateEditCoverageTests.cs` | 7 |
| `src/Bee.UI.Avalonia/Controls/Editors/ButtonEdit.cs` | 18 | `ButtonEditPropertyTests.cs` | 4 |
| `src/Bee.UI.Maui/Controls/FormPage.cs` | 18 | `FormPageCoverageTests.cs` | 6 |

**合計新增測試：39 個**

## 覆蓋路徑說明

### GridControl（18 tests）
- `FormatCell`：null rowView、欄位不存在、DBNull、DateTime（有/無時間）、displayFormat、numberFormat
- `TryConvertCellValue`：合法整數字串 → true、無法解析 → false
- `TryGetRowId`：無欄位 → false、DBNull → false、Guid → true、字串 Guid → true
- `SetControlState`：View 模式 → AllowEdit=false；Edit + AllowEditModes.All → AllowEdit=true
- `AddRow`：含非 nullable 欄位時新增一列
- `BuildCellEditor`：CheckEdit → CheckBox、DateEdit → DatePicker
- `BuildInteractiveCell`：CheckEdit 唯讀 → 停用 CheckBox、DateEdit 唯讀 → TextBlock

### FormView（4 tests）
- `ReloadListAsync` 拋例外 → ErrorOccurred 觸發、不崩潰
- 第二次 `InitializeAsync` → same DataObject（no-op）
- 空 table → `_emptyListLabel.IsVisible=true`
- 非空 table → `_emptyListLabel.IsVisible=false`

### DateEdit（7 tests）
- `ParseToOffset`：null → null、無效字串 → null、合法字串 → DateTimeOffset
- `FieldValue` setter：null、DateTimeOffset、DateTime（Local→Unspecified offset Zero）、字串
- `Bind(FormDataObject, LayoutFieldBase, DataRow)`：明細列綁定後讀取值

### ButtonEdit（4 tests）
- 非 lookup 欄位 `SetControlState` Edit → IsReadOnly=false + 按鈕啟用
- 非 lookup 欄位 `SetControlState` View → IsReadOnly=true + 按鈕停用
- 直接設定 `IsReadOnly=true` → 按鈕停用（OnPropertyChanged 路徑）
- 版面層級 `DisplayFields` 覆寫 → Text 只顯示指定欄位值

### FormPage（6 tests）
- `ComputeSelectFields`：null schema → ""、null ListFields → "sys_rowid"、有 ListFields → 前置 sys_rowid、去重
- `ReloadListAsync` 拋例外 → ErrorOccurred 觸發
- 第二次 `InitializeAsync` → same DataObject（no-op）

## 變更範圍

- 僅異動 `tests/` 目錄
- `src/`、`samples/`、`docs/`、`.github/`、`.claude/` 均未異動

---
_Generated by [Claude Code](https://claude.ai/code/session_015CBQdnyVjoW1pPFuNHBjEJ)_